### PR TITLE
fix: crash when removing the usb drive

### DIFF
--- a/src/loader/widgetplugin.cpp
+++ b/src/loader/widgetplugin.cpp
@@ -139,7 +139,7 @@ void WidgetPlugin::itemRemoved(PluginsItemInterface * const itemInter, const QSt
     }
 
     auto popupWidget = m_pluginsItemInterface->itemPopupApplet(itemKey);
-    if(popupWidget) popupWidget->windowHandle()->hide();
+    if(popupWidget && popupWidget->windowHandle()) popupWidget->windowHandle()->hide();
 
     auto tipsWidget = m_pluginsItemInterface->itemTipsWidget(itemKey);
     if(tipsWidget && tipsWidget->windowHandle()) tipsWidget->windowHandle()->hide();


### PR DESCRIPTION
return nullptr when popupWidget->windowHandle() is called

Issue: