### PR TITLE
fix: missing tooltip in quickpanel

### DIFF
--- a/src/loader/pluginitem.h
+++ b/src/loader/pluginitem.h
@@ -24,6 +24,9 @@ public:
     void setPluginFlags(int flags);
     void init();
 
+    QString pluginId() const { return m_pluginsItemInterface->pluginName(); }
+    virtual QString itemKey() const { return m_itemKey; }
+
 signals:
     void recvMouseEvent(int type);
 

--- a/src/loader/quickpluginitem.cpp
+++ b/src/loader/quickpluginitem.cpp
@@ -134,9 +134,10 @@ QMenu *QuickPluginItem::pluginContextMenu()
 
 QWidget *QuickPluginItem::pluginTooltip()
 {
-    auto popup = pluginsItemInterface()->itemPopupApplet(m_itemKey);
-    if (popup && popup->isVisible())
-        popup->windowHandle()->hide();
+    return nullptr;
+}
 
-    return itemTooltip(Dock::QUICK_ITEM_KEY);
+QString QuickPluginItem::itemKey() const
+{
+    return Dock::QUICK_ITEM_KEY;
 }

--- a/src/loader/quickpluginitem.h
+++ b/src/loader/quickpluginitem.h
@@ -20,6 +20,7 @@ protected:
     virtual void mouseReleaseEvent(QMouseEvent *e) override;
     virtual QMenu *pluginContextMenu() override;
     virtual QWidget *pluginTooltip() override;
+    virtual QString itemKey() const override;
 
 private:
     QAction *m_onDockAction;

--- a/src/protocol/plugin-manager-v1.xml
+++ b/src/protocol/plugin-manager-v1.xml
@@ -92,6 +92,10 @@
       <arg name="width" type="int"/>
       <arg name="height" type="int"/>
     </event>
+    <request name="set_position" >
+        <arg name="x" type="int"/>
+        <arg name="y" type="int"/>
+    </request>
   </interface>
 
   <interface name="plugin" version="1">

--- a/src/tray-wayland-integration/plugin.cpp
+++ b/src/tray-wayland-integration/plugin.cpp
@@ -128,12 +128,21 @@ void EmbedPlugin::setPluginSizePolicy(int sizePolicy)
 }
 
 static QMap<QWindow*, EmbedPlugin*> s_map;
+EmbedPlugin *EmbedPlugin::getWithoutCreating(QWindow *window)
+{
+    if (contains(window))
+        return get(window);
+    return nullptr;
+}
 EmbedPlugin* EmbedPlugin::get(QWindow* window)
 {
     auto plugin = s_map.value(window);
     if (!plugin) {
         plugin = new EmbedPlugin(window);
         s_map.insert(window, plugin);
+        QObject::connect(plugin, &EmbedPlugin::destroyed, window, [window] () {
+            s_map.remove(window);
+        });
     }
 
     return plugin;
@@ -280,12 +289,21 @@ void PluginPopup::setY(const int& y)
 }
 
 static QMap<QWindow*, PluginPopup*> s_popupMap;
+PluginPopup* PluginPopup::getWithoutCreating(QWindow* window)
+{
+    if (contains(window))
+        return get(window);
+    return nullptr;
+}
 PluginPopup* PluginPopup::get(QWindow* window)
 {
     auto popup = s_popupMap.value(window);
     if (!popup) {
         popup = new PluginPopup(window);
         s_popupMap.insert(window, popup);
+        QObject::connect(popup, &PluginPopup::destroyed, window, [window] () {
+            s_popupMap.remove(window);
+        });
     }
 
     return popup;

--- a/src/tray-wayland-integration/plugin.h
+++ b/src/tray-wayland-integration/plugin.h
@@ -52,6 +52,7 @@ public:
     QPoint rawGlobalPos() const;
     void setRawGlobalPos(const QPoint& pos);
 
+    static EmbedPlugin *getWithoutCreating(QWindow *window);
     static EmbedPlugin* get(QWindow* window);
     static bool contains(QWindow* window);
     static bool contains(const QString &pluginId, int type, const QString &itemKey = QString());
@@ -118,6 +119,7 @@ public:
     int y() const;
     void setY(const int& y);
 
+    static PluginPopup *getWithoutCreating(QWindow *window);
     static PluginPopup* get(QWindow* window);
     static bool contains(QWindow* window);
 

--- a/src/tray-wayland-integration/pluginmanager_p.h
+++ b/src/tray-wayland-integration/pluginmanager_p.h
@@ -36,6 +36,9 @@ protected:
     virtual void plugin_manager_v1_event_message(const QString &msg);
 
 private:
+    bool tryCreatePopupForSubWindow(QWindow *window);
+
+private:
     uint32_t m_dockPosition;
     uint32_t m_dockColorType;
 };

--- a/src/tray-wayland-integration/pluginsurface_p.h
+++ b/src/tray-wayland-integration/pluginsurface_p.h
@@ -43,8 +43,12 @@ protected:
     virtual void plugin_popup_geometry(int32_t x, int32_t y, int32_t width, int32_t height) override;
 
 private:
+    void dirtyPosition();
+
+private:
     PluginPopup* m_popup;
     QWindow* m_window;
+    QTimer *m_dirtyTimer = nullptr;
 };
 
 }


### PR DESCRIPTION
create surface for global ToolTipWindow, and it's extent property
is from it's transientParent,
and then update it's position in next event loop.
