### PR TITLE
fix: missing release event for pluginitem

### DIFF
--- a/plugins/dde-dock/bluetooth/quickpanelwidget.cpp
+++ b/plugins/dde-dock/bluetooth/quickpanelwidget.cpp
@@ -116,6 +116,7 @@ void QuickPanelWidget::mouseReleaseEvent(QMouseEvent *event)
         break;
     }
     m_clickPoint = QPoint();
+    return QWidget::mouseReleaseEvent(event);
 }
 
 void QuickPanelWidget::initUi()

--- a/plugins/dde-dock/common/singlequickpanel.cpp
+++ b/plugins/dde-dock/common/singlequickpanel.cpp
@@ -75,6 +75,7 @@ void SignalQuickPanel::mouseReleaseEvent(QMouseEvent *event)
     if (underMouse()) {
         Q_EMIT clicked();
     }
+    return QWidget::mouseReleaseEvent(event);
 }
 
 void SignalQuickPanel::refreshBg()

--- a/plugins/dde-dock/media/quickpanelwidget.cpp
+++ b/plugins/dde-dock/media/quickpanelwidget.cpp
@@ -124,6 +124,7 @@ void QuickPanelWidget::mouseReleaseEvent(QMouseEvent *event)
     if (underMouse()) {
         Q_EMIT clicked();
     }
+    return QWidget::mouseReleaseEvent(event);
 }
 
 QuickPanelWidget::~QuickPanelWidget()

--- a/plugins/dde-network-core/dock-tray-network-plugin/quickpanelwidget.cpp
+++ b/plugins/dde-network-core/dock-tray-network-plugin/quickpanelwidget.cpp
@@ -118,6 +118,7 @@ void QuickPanelWidget::mouseReleaseEvent(QMouseEvent *event)
         break;
     }
     m_clickPoint = QPoint();
+    return QWidget::mouseReleaseEvent(event);
 }
 
 void QuickPanelWidget::initUi()

--- a/plugins/dde-network-display-ui/plugins/dock-wirelesscasting-plugin/src/quickpanelwidget.cpp
+++ b/plugins/dde-network-display-ui/plugins/dock-wirelesscasting-plugin/src/quickpanelwidget.cpp
@@ -111,6 +111,7 @@ void QuickPanelWidget::mouseReleaseEvent(QMouseEvent *event)
         break;
     }
     m_clickPoint = QPoint();
+    return QWidget::mouseReleaseEvent(event);
 }
 
 void QuickPanelWidget::initUi()


### PR DESCRIPTION
MouseEvent should be propagated to parent widget if not accept.