### PR TITLE
fix: plugin panel display error

### DIFF
--- a/src/loader/pluginitem.h
+++ b/src/loader/pluginitem.h
@@ -49,6 +49,7 @@ protected:
 
 private:
     QWidget *itemPopupApplet();
+    bool panelPopupExisted() const;
 
 private:
     void updatePopupSize(const QRect &rect);
@@ -63,7 +64,6 @@ private:
     PluginsItemInterfaceV2 *m_pluginsItemInterfacev2;
 
     int m_pluginFlags = 0;
-    bool m_isPanelPopupShow = false;
 };
 
 #endif // PLUGINSITEM_H

--- a/src/loader/widgetplugin.cpp
+++ b/src/loader/widgetplugin.cpp
@@ -207,6 +207,8 @@ void WidgetPlugin::requestRefreshWindowVisible(PluginsItemInterface * const item
 
 void WidgetPlugin::requestSetAppletVisible(PluginsItemInterface * const itemInter, const QString &itemKey, const bool visible)
 {
+    if (!visible) return;
+
     auto setPluginMsg = [itemInter]  {
         auto pluginsItemInterfaceV2 = dynamic_cast<PluginsItemInterfaceV2 *>(itemInter);
         if (!pluginsItemInterfaceV2)

--- a/src/tray-wayland-integration/plugin.cpp
+++ b/src/tray-wayland-integration/plugin.cpp
@@ -319,6 +319,13 @@ PluginPopup* PluginPopup::get(QWindow* window)
         QObject::connect(popup, &PluginPopup::destroyed, window, [window] () {
             s_popupMap.remove(window);
         });
+
+        QObject::connect(window, &QWindow::visibleChanged, popup, [window, popup] (bool visible) {
+            if (!visible) {
+                popup->deleteLater();
+                s_popupMap.remove(window);
+            }
+        });
     }
 
     return popup;


### PR DESCRIPTION
1.plugin panel title disappears after clicking the jumpSetting button 2.first click jumpSetting btn, panel popup does not show when clicking plugin item again

Log: as title
Influence: plugin panel display