### PR TITLE
fix: plugin right-click menu content displays incorrectly

### DIFF
--- a/src/loader/pluginitem.cpp
+++ b/src/loader/pluginitem.cpp
@@ -83,9 +83,11 @@ QWidget *PluginItem::itemPopupApplet()
 
 QMenu *PluginItem::pluginContextMenu()
 {
-    if (m_menu->actions().isEmpty()) {
-        initPluginMenu();
+    if (!m_menu->actions().isEmpty()) {
+        m_menu->clear();
     }
+
+    initPluginMenu();
 
     qDebug() << "mouseRightButtonClicked:" << m_itemKey << m_menu->actions().size();
     m_menu->setAttribute(Qt::WA_TranslucentBackground, true);


### PR DESCRIPTION
menu not update.

Log: as title
Issue: https://github.com/linuxdeepin/developer-center/issues/9761
Influence: menu content display