### PR TITLE
fix: clicking some plugins setting btn cannot jump to dcc's module

### DIFF
--- a/plugins/dde-dock/dnd-mode/dndmodeitem.cpp
+++ b/plugins/dde-dock/dnd-mode/dndmodeitem.cpp
@@ -36,7 +36,7 @@ void DndModeItem::init()
     m_tipsLabel->setVisible(false);
 
     m_applet->setVisible(false);
-    m_applet->setDccPage("notification", "System Notification");
+    m_applet->setDccPage("notification", "SystemNotify");
     m_applet->setTitle(tr("DND Mode"));
     m_applet->setDescription(tr("DND mode settings"));
     m_applet->setIcon(QIcon::fromTheme("open-arrow"));

--- a/plugins/dde-dock/power/powerstatuswidget.cpp
+++ b/plugins/dde-dock/power/powerstatuswidget.cpp
@@ -23,7 +23,7 @@ PowerStatusWidget::PowerStatusWidget(QWidget *parent)
     m_iconWidget->setFixedSize(Dock::DOCK_PLUGIN_ITEM_FIXED_SIZE);
 
     m_applet->setVisible(false);
-    m_applet->setDccPage("power", "General");
+    m_applet->setDccPage("power", "general");
     m_applet->setDescription(tr("Power settings"));
     m_applet->setIcon(QIcon::fromTheme("open-arrow"));
 

--- a/plugins/dde-dock/sound/soundapplet.cpp
+++ b/plugins/dde-dock/sound/soundapplet.cpp
@@ -88,7 +88,7 @@ void SoundApplet::initUi()
 
     // sound setting button
     m_settingButton->setAutoShowPage(true);
-    m_settingButton->setDccPage("sound", "Speaker");
+    m_settingButton->setDccPage("sound", "output");
     m_settingButton->setIcon(QIcon::fromTheme("open-arrow"));
     m_settingButton->setDescription(tr("Sound settings"));
 


### PR DESCRIPTION
dbus param error

Log: as title
Issue: https://github.com/linuxdeepin/developer-center/issues/9719
Influence: jump dcc module