### PR TITLE
fix: Disable jumping to dcc's airplane module

### DIFF
--- a/plugins/dde-network-core/net-view/operation/netitem.cpp
+++ b/plugins/dde-network-core/net-view/operation/netitem.cpp
@@ -392,7 +392,9 @@ NetItemType NetAirplaneModeTipsItem::itemType() const
 
 void NetAirplaneModeTipsItem::retranslateUi()
 {
-    updateName(tr("Disable <a style=\"text-decoration: none;\" href=\"Airplane Mode\">Airplane Mode</a> first if you want to connect to a wireless network"));
+    //updateName(tr("Disable <a style=\"text-decoration: none;\" href=\"Airplane Mode\">Airplane Mode</a> first if you want to connect to a wireless network"));
+    // v23控制中心无“飞行模式”模块，因此不能跳转到控制中心模块
+    updateName(tr("Disable Airplane Mode first if you want to connect to a wireless network"));
 }
 
 // 有线禁用项


### PR DESCRIPTION
dcc has no airplane module.

Log: as title
Issue: https://github.com/linuxdeepin/developer-center/issues/9674
Influence: not jump dcc's airplane module