### PR TITLE
fix: pinned to dock only works once

### DIFF
--- a/src/loader/pluginitem.cpp
+++ b/src/loader/pluginitem.cpp
@@ -26,8 +26,7 @@ PluginItem::PluginItem(PluginsItemInterface *pluginItemInterface, const QString 
     connect(m_menu, &QMenu::triggered, this, [this](QAction *action){
         QString actionStr = action->data().toString();
         if (actionStr == Dock::dockMenuItemId || actionStr == Dock::unDockMenuItemId) {
-            setPluginVisible(actionStr == Dock::dockMenuItemId);
-            m_dbusProxy->setItemOnDock(DockQuickPlugins, pluginId() + "::" + m_itemKey, actionStr == Dock::dockMenuItemId);
+            m_dbusProxy->setItemOnDock(DockQuickPlugins, m_itemKey, actionStr == Dock::dockMenuItemId);
         } else {
             m_pluginsItemInterface->invokedMenuItem(m_itemKey, action->data().toString(), action->isCheckable() ? action->isChecked() : true);
         }
@@ -310,18 +309,6 @@ bool PluginItem::executeCommand()
         return true;
     }
     return false;
-}
-
-void PluginItem::setPluginVisible(bool isVisible)
-{
-    auto widget = m_pluginsItemInterface->itemWidget(m_itemKey);
-    if (widget && widget->window() && widget->window()->windowHandle()) {
-        if (isVisible) {
-            widget->window()->windowHandle()->show();
-        } else {
-            widget->window()->windowHandle()->hide();
-        }
-    }
 }
 
 bool PluginItem::panelPopupExisted() const

--- a/src/loader/pluginitem.h
+++ b/src/loader/pluginitem.h
@@ -45,7 +45,6 @@ protected:
     void initPluginMenu();
     QWidget *itemTooltip(const QString &itemKey);
     bool executeCommand();
-    void setPluginVisible(bool isvisible);
 
 private:
     QWidget *itemPopupApplet();

--- a/src/loader/quickpluginitem.cpp
+++ b/src/loader/quickpluginitem.cpp
@@ -73,7 +73,6 @@ QuickPluginItem::QuickPluginItem(PluginsItemInterface *pluginInterface, const QS
     if (m_dbusProxy.isNull())
         m_dbusProxy.reset(new DockDBusProxy);
     qApp->installEventFilter(new EventFilter(this));
-    connect(m_dbusProxy.data(), &DockDBusProxy::pluginVisibleChanged, this, &QuickPluginItem::onPluginVisibleChanged);
 }
 
 QWidget *QuickPluginItem::centralWidget()
@@ -148,13 +147,6 @@ QWidget *QuickPluginItem::pluginTooltip()
 QString QuickPluginItem::itemKey() const
 {
     return Dock::QUICK_ITEM_KEY;
-}
-
-void QuickPluginItem::onPluginVisibleChanged(const QString &itemKey, bool visible)
-{
-    if (itemKey == m_itemKey) {
-        setPluginVisible(visible);
-    }
 }
 
 bool QuickPluginItem::pluginIsVisible()

--- a/src/loader/quickpluginitem.h
+++ b/src/loader/quickpluginitem.h
@@ -22,9 +22,6 @@ protected:
     virtual QWidget *pluginTooltip() override;
     virtual QString itemKey() const override;
 
-public Q_SLOTS:
-    void onPluginVisibleChanged(const QString &itemKey, bool visible);
-
 private:
     bool pluginIsVisible();
 


### PR DESCRIPTION
Calling dock's dbus to dock or undock, instead of hide or show it's
window.
