### PR TITLE
fix: network plugin display error When the system network proxy is al…

### DIFF
--- a/plugins/dde-network-core/net-view/window/netstatus.cpp
+++ b/plugins/dde-network-core/net-view/window/netstatus.cpp
@@ -489,6 +489,9 @@ void NetStatus::updateVpnAndProxyStatus()
         const bool visible = m_vpnItem.Connected || m_proxyItem.Enabled;
         if (m_vpnAndProxyIconVisibel != visible) {
             m_vpnAndProxyIconVisibel = visible;
+            if (m_dockIconWidgetlayout->parentWidget()) {
+                m_dockIconWidgetlayout->parentWidget()->setFixedSize(visible ? QSize(42, 16) : QSize(16, 16));
+            }
             Q_EMIT vpnAndProxyIconVisibelChanged(m_vpnAndProxyIconVisibel);
         }
         m_vpnAndProxyBut->setVisible(m_vpnAndProxyIconVisibel);


### PR DESCRIPTION
…ready enabled

item size has error.

Log: as title
Issue: https://github.com/linuxdeepin/developer-center/issues/9700
Influence: network plugin display