### PR TITLE
fix: datetime plugin in DCC dosn't have icon

### DIFF
--- a/src/loader/widgetplugin.cpp
+++ b/src/loader/widgetplugin.cpp
@@ -155,6 +155,10 @@ void WidgetPlugin::itemAdded(PluginsItemInterface * const itemInter, const QStri
             plugin->setItemKey(itemKey);
             plugin->setPluginType(Plugin::EmbedPlugin::Fixed);
             plugin->setPluginSizePolicy(itemInter->pluginSizePolicy());
+            if (flag & Dock::Attribute_CanSetting) {
+                const QString path = DCCIconPath + itemInter->pluginName() + ".svg";
+                plugin->setDccIcon(path);
+            }
             item->windowHandle()->hide();
             item->show();
         }


### PR DESCRIPTION
Issues: linuxdeepin/developer-center#9820