### PR TITLE
fix: Modify the issue of unresponsive clicks on the network panel

### DIFF
--- a/plugins/dde-network-core/net-view/window/netview.cpp
+++ b/plugins/dde-network-core/net-view/window/netview.cpp
@@ -80,11 +80,6 @@ NetView::NetView(NetManager *manager)
 
     connect(this, &NetView::clicked, this, &NetView::activated);
     connect(this, &NetView::activated, this, &NetView::onActivated);
-
-    // 支持在触摸屏上滚动
-    QScroller::grabGesture(viewport(), QScroller::LeftMouseButtonGesture);
-    QScrollerProperties sp;
-    sp.setScrollMetric(QScrollerProperties::VerticalOvershootPolicy, QScrollerProperties::OvershootAlwaysOff);
 }
 
 NetView::~NetView() = default;


### PR DESCRIPTION
The grabGesture function caused the mouse press event to not be sent to the child control

Issue: https://github.com/linuxdeepin/developer-center/issues/9722