### PR TITLE
fix: Hide Airplane mode settings in popup applet

### DIFF
--- a/plugins/dde-dock/airplane-mode/airplanemodeitem.cpp
+++ b/plugins/dde-dock/airplane-mode/airplanemodeitem.cpp
@@ -35,6 +35,7 @@ AirplaneModeItem::AirplaneModeItem(QWidget* parent)
     m_applet->setDccPage("network", "Airplane Mode");
     m_applet->setDescription(tr("Airplane mode settings"));
     m_applet->setIcon(QIcon::fromTheme("open-arrow"));
+    m_applet->hideSettingButton();
 
     auto vLayout = new QVBoxLayout(this);
     vLayout->setSpacing(0);

--- a/plugins/dde-dock/common/commonapplet.cpp
+++ b/plugins/dde-dock/common/commonapplet.cpp
@@ -77,3 +77,8 @@ void CommonApplet::setDccPage(const QString &module, const QString &page)
 {
     m_settingButton->setDccPage(module, page);
 }
+
+void CommonApplet::hideSettingButton()
+{
+    m_settingButton->setVisible(false);
+}

--- a/plugins/dde-dock/common/commonapplet.h
+++ b/plugins/dde-dock/common/commonapplet.h
@@ -23,6 +23,7 @@ public:
     void setIcon(const QIcon &icon);
     void setDescription(const QString &description);
     void setDccPage(const QString &first, const QString &second);
+    void hideSettingButton();
 
 signals:
     void enableChanged(bool enable);


### PR DESCRIPTION
Also, add hideSettingButton method for CommonApplet class

Issue: https://github.com/linuxdeepin/developer-center/issues/9884 Log: