### PR TITLE
fix: Fixed the issue that setting custom time format in taskbar does …

### DIFF
--- a/plugins/dde-dock/datetime/datetimeplugin.h
+++ b/plugins/dde-dock/datetime/datetimeplugin.h
@@ -9,6 +9,7 @@
 #include "datetimewidget.h"
 #include "sidebarcalendarwidget.h"
 #include "tipswidget.h"
+#include "regionFormat.h"
 
 #include <QTimer>
 #include <QLabel>
@@ -69,6 +70,9 @@ private:
     QString m_currentTimeString;
     QDBusInterface *m_interface;
     bool m_pluginLoaded;
+
+    RegionFormat* m_RegionFormatModel;
+
 };
 
 

--- a/plugins/dde-dock/datetime/datetimewidget.h
+++ b/plugins/dde-dock/datetime/datetimewidget.h
@@ -9,6 +9,8 @@
 
 #include <QWidget>
 
+#include "regionFormat.h"
+
 using Timedate = com::deepin::daemon::Timedate;
 
 class DatetimeWidget : public QWidget
@@ -16,13 +18,15 @@ class DatetimeWidget : public QWidget
     Q_OBJECT
 
 public:
-    explicit DatetimeWidget(QWidget *parent = nullptr);
+    explicit DatetimeWidget(RegionFormat *regionFormat, QWidget *parent = nullptr) ;
 
     QSize sizeHint() const;
     inline bool is24HourFormat() const { return m_24HourFormat; }
     inline QString getDateTime() { return m_dateTime; }
     void setDockPanelSize(const QSize &dockSize);
     void dockPositionChanged();
+
+    void setRegionFormat(RegionFormat *newRegionFormat);
 
 protected:
     void resizeEvent(QResizeEvent *event);
@@ -35,33 +39,29 @@ signals:
 public slots:
     void set24HourFormat(const bool value);
     void updateDateTimeString();
+    void updateDateTime();
 
 private Q_SLOTS:
     void setShortDateFormat(int type);
-    void setShortTimeFormat(int type);
-    void setLongDateFormat(int type);
+
     void setWeekdayFormat(int type);
-    void setLongTimeFormat(int type);
 
 private:
     QSize curTimeSize() const;
     void updateWeekdayFormat();
-    void updateLongTimeFormat();
 
 private:
     bool m_24HourFormat;
-    int m_longDateFormatType;
-    int m_longTimeFormatType;
     int m_weekdayFormatType;
     mutable QFont m_timeFont;
     mutable QFont m_dateFont;
     Timedate *m_timedateInter;
     QString m_shortDateFormat;
-    QString m_shortTimeFormat;
     QString m_dateTime;
     QString m_weekFormat;
-    QString m_longTimeFormat;
     QSize m_dockSize;
+
+    RegionFormat *m_regionFormat;
 };
 
 #endif // DATETIMEWIDGET_H

--- a/plugins/dde-dock/datetime/regionFormat.cpp
+++ b/plugins/dde-dock/datetime/regionFormat.cpp
@@ -1,0 +1,165 @@
+// SPDX-FileCopyrightText: 2011 - 2022 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include "regionFormat.h"
+
+#include <qguiapplication.h>
+#include <QLocale>
+
+RegionFormat::RegionFormat(QObject *parent)
+    : QObject(parent)
+    , shortDateFormat("")
+    , longDateFormat("")
+    , shortTimeFormat("")
+    , longTimeFormat("")
+    , m_config(DTK_CORE_NAMESPACE::DConfig::createGeneric("org.deepin.region-format", QString(), this))
+{
+    initData();
+    initConnect();
+}
+
+void RegionFormat::initConnect()
+{
+    connect(m_config, &DTK_CORE_NAMESPACE::DConfig::valueChanged, this, [this] (const QString &key) {
+    if (key == shortDateFormat_key) {
+        setShortDateFormat(m_config->value(key).toString());
+    } else if (key == longDateFormat_key) {
+        setLongDateFormat(m_config->value(key).toString());
+    } else if (key == shortTimeFormat_key) {
+        setShortTimeFormat(m_config->value(key).toString());
+    } else if (key == longTimeFormat_key) {
+        setLongTimeFormat(m_config->value(key).toString());
+    }
+});
+}
+
+void RegionFormat::initData()
+{
+    if (!m_config->isValid())
+        return;
+
+    if (m_config->isDefaultValue(localeName_key)) {
+        setLocaleName(QLocale::system().name());
+    } else {
+        setLocaleName(m_config->value(localeName_key).toString());
+    }
+    if (m_config->isDefaultValue(shortDateFormat_key)) {
+        QLocale locale(QLocale::system().name());
+        setShortDateFormat(locale.dateFormat(QLocale::ShortFormat));
+    } else {
+        setShortDateFormat(m_config->value(shortDateFormat_key).toString());
+    }
+    if (m_config->isDefaultValue(longDateFormat_key)) {
+        QLocale locale(QLocale::system().name());
+        setLongDateFormat(locale.dateFormat(QLocale::LongFormat));
+    } else {
+        setLongDateFormat(m_config->value(longDateFormat_key).toString());
+    }
+    if (m_config->isDefaultValue(shortTimeFormat_key)) {
+        QLocale locale(QLocale::system().name());
+        setShortTimeFormat(locale.timeFormat(QLocale::ShortFormat));
+    } else {
+        setShortTimeFormat(m_config->value(shortTimeFormat_key).toString());
+    }
+    if (m_config->isDefaultValue(longTimeFormat_key)) {
+        QLocale locale(QLocale::system().name());
+        setLongTimeFormat(locale.timeFormat(QLocale::LongFormat));
+    } else {
+        setLongTimeFormat(m_config->value(longTimeFormat_key).toString());
+    }
+
+}
+
+QString RegionFormat::getShortDateFormat() const
+{
+    return shortDateFormat;
+}
+
+void RegionFormat::setShortDateFormat(const QString &newShortDateFormat)
+{
+
+    QString format = newShortDateFormat;
+    const Dock::Position position = qApp->property(PROP_POSITION).value<Dock::Position>();
+    // 任务栏在左/右的时候不显示年份
+    const bool removeY = (position == Dock::Top || position == Dock::Bottom) ? false : true;
+    if (removeY) {
+        format.remove('y');
+        format.remove('Y');
+    }
+
+    if (!format.at(0).isLetter()) {
+        format.remove(0, 1);
+    }
+
+    if (!format.at(format.length() -1).isLetter()) {
+        format.chop(1);
+    }
+
+    if (shortDateFormat == format)
+        return;
+    shortDateFormat = format;
+    emit shortDateFormatChanged();
+}
+
+QString RegionFormat::getLongDateFormat() const
+{
+    return longDateFormat;
+}
+
+void RegionFormat::setLongDateFormat(const QString &newLongDateFormat)
+{
+    if (longDateFormat == newLongDateFormat)
+        return;
+    longDateFormat = newLongDateFormat;
+    emit longDateFormatChanged();
+}
+
+QString RegionFormat::getShortTimeFormat() const
+{
+    return shortTimeFormat;
+}
+
+void RegionFormat::setShortTimeFormat(const QString &newShortTimeFormat)
+{
+    if (shortTimeFormat == newShortTimeFormat)
+        return;
+    shortTimeFormat = newShortTimeFormat;
+    emit shortTimeFormatChanged();
+}
+
+QString RegionFormat::getLongTimeFormat() const
+{
+    return longTimeFormat;
+}
+
+void RegionFormat::setLongTimeFormat(const QString &newLongTimeFormat)
+{
+    if (longTimeFormat == newLongTimeFormat)
+        return;
+    longTimeFormat = newLongTimeFormat;
+    emit longTimeFormatChanged();
+}
+
+QString RegionFormat::getLocaleName() const
+{
+    return localeName;
+}
+
+void RegionFormat::setLocaleName(const QString &newLocaleName)
+{
+    if (localeName == newLocaleName)
+        return;
+    localeName = newLocaleName;
+    emit localeNameChanged(localeName);
+}
+
+void RegionFormat::onDockPositionChanged(const Dock::Position position)
+{
+    if (m_config->isDefaultValue(shortDateFormat_key)) {
+        QLocale locale(QLocale::system().name());
+        setShortDateFormat(locale.dateFormat(QLocale::ShortFormat));
+    } else {
+        setShortDateFormat(m_config->value(shortDateFormat_key).toString());
+    }
+}

--- a/plugins/dde-dock/datetime/regionFormat.h
+++ b/plugins/dde-dock/datetime/regionFormat.h
@@ -1,0 +1,70 @@
+// SPDX-FileCopyrightText: 2011 - 2022 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#ifndef REGIONFORMAT_H
+#define REGIONFORMAT_H
+
+#include <QObject>
+
+#include <DConfig>
+
+#include "constants.h"
+
+const QString localeName_key = "localeName";
+const QString country_key = "country";
+const QString languageRegion_key = "languageRegion";
+const QString firstDayOfWeek_key = "firstDayOfWeek";
+const QString shortDateFormat_key = "shortDateFormat";
+const QString longDateFormat_key = "longDateFormat";
+const QString shortTimeFormat_key = "shortTimeFormat";
+const QString longTimeFormat_key = "longTimeFormat";
+const QString currencyFormat_key = "currencyFormat";
+const QString numberFormat_key = "numberFormat";
+const QString paperFormat_key = "paperFormat";
+
+class RegionFormat : public QObject
+{
+    Q_OBJECT
+
+public:
+    explicit RegionFormat(QObject *parent = 0);
+
+    void initConnect();
+    void initData();
+
+    QString getShortDateFormat() const;
+    void setShortDateFormat(const QString &newShortDateFormat);
+    QString getLongDateFormat() const;
+    void setLongDateFormat(const QString &newLongDateFormat);
+    QString getShortTimeFormat() const;
+    void setShortTimeFormat(const QString &newShortTimeFormat);
+    QString getLongTimeFormat() const;
+    void setLongTimeFormat(const QString &newLongTimeFormat);
+
+    QString getLocaleName() const;
+    void setLocaleName(const QString &newLocaleName);
+
+signals:
+    void shortDateFormatChanged() const;
+    void longDateFormatChanged() const;
+    void shortTimeFormatChanged() const;
+    void longTimeFormatChanged() const;
+    void localeNameChanged(const QString &localeName);
+
+public slots:
+    void onDockPositionChanged(const Dock::Position position);
+
+private:
+    QString shortDateFormat;
+    QString longDateFormat;
+    QString shortTimeFormat;
+    QString longTimeFormat;
+
+    QString localeName;
+    DTK_CORE_NAMESPACE::DConfig *m_config;
+};
+
+
+
+#endif //REGIONFORMAT_H


### PR DESCRIPTION
…not take effect

The time format of the taskbar time plugin v20 uses the backend dbus method, but now it is changed to get data from dconfig

Issue: https://github.com/linuxdeepin/developer-center/issues/9724