### PR TITLE
fix: applicatin-tray coredump while open wechat and wework

### DIFF
--- a/plugins/application-tray/sniprotocolhandler.cpp
+++ b/plugins/application-tray/sniprotocolhandler.cpp
@@ -86,7 +86,7 @@ uint32_t SniTrayProtocolHandler::windowId() const
 
 QString SniTrayProtocolHandler::id() const
 {
-    return sniPfrefix + UTIL->getProcExe(QDBusConnection::sessionBus().interface()->servicePid(m_sniInter->service()));
+    return sniPfrefix + UTIL->getProcExe(QDBusConnection::sessionBus().interface()->servicePid(m_sniInter->service())) + QString("-%1").arg(windowId());
 }
     
 QString SniTrayProtocolHandler::title() const

--- a/plugins/application-tray/xembedprotocolhandler.cpp
+++ b/plugins/application-tray/xembedprotocolhandler.cpp
@@ -106,7 +106,7 @@ uint32_t XembedProtocolHandler::windowId() const
 
 QString XembedProtocolHandler::id() const
 {
-    return sniPfrefix + UTIL->getProcExe(UTIL->getWindowPid(m_windowId));
+    return sniPfrefix + UTIL->getProcExe(UTIL->getWindowPid(m_windowId))  + QString("-%1").arg(windowId());
 }
     
 QString XembedProtocolHandler::title() const


### PR DESCRIPTION
wechat and wework has same proc/exe which make them have same id. It will be considered as a registered plugin and call show directly while the plugin does not have a corresponding window actiually.

So appned winId after exe as new id which will distinguishing between different instances of the same programe

log: as title
issue: https://github.com/linuxdeepin/developer-center/issues/9918