### PR TITLE
fix: Modifying proxy icon does not display issue

### DIFF
--- a/plugins/dde-network-core/net-view/window/netstatus.cpp
+++ b/plugins/dde-network-core/net-view/window/netstatus.cpp
@@ -61,7 +61,7 @@ NetStatus::NetStatus(NetManager *manager, QObject *parent)
     , m_vpnAndProxyBut(nullptr)
     , m_tipsLabel(nullptr)
     , m_dockIconWidgetlayout(nullptr)
-    , m_vpnAndProxyIconVisibel(false)
+    , m_vpnAndProxyIconVisibel(true)
 {
     NetItem *root = m_manager->root();
     connect(root, &NetItem::childRemoved, this, &NetStatus::onChildRemoved);
@@ -491,10 +491,10 @@ void NetStatus::updateVpnAndProxyStatus()
         const bool visible = m_vpnItem.Connected || m_proxyItem.Enabled;
         if (m_vpnAndProxyIconVisibel != visible) {
             m_vpnAndProxyIconVisibel = visible;
+            m_vpnAndProxyBut->setVisible(m_vpnAndProxyIconVisibel);
             updateItemWidgetSize();
             Q_EMIT vpnAndProxyIconVisibelChanged(m_vpnAndProxyIconVisibel);
         }
-        m_vpnAndProxyBut->setVisible(m_vpnAndProxyIconVisibel);
         m_vpnAndProxyBut->setIcon(m_vpnAndProxyIcon);
     }
     if (m_vpnAndProxyTips != tips) {

--- a/src/loader/pluginitem.cpp
+++ b/src/loader/pluginitem.cpp
@@ -233,6 +233,7 @@ void PluginItem::init()
     hLayout->addWidget(centralWidget());
     hLayout->setMargin(0);
     hLayout->setSpacing(0);
+    hLayout->setSizeConstraint(QLayout::SetFixedSize);
 
     setLayout(hLayout);
 }


### PR DESCRIPTION
After the icon size changed, the parent window size did not change in a timely manner

Issue: https://github.com/linuxdeepin/developer-center/issues/9888