### PR TITLE
fix: Repair time plug-in display is incomplete

### DIFF
--- a/plugins/dde-dock/datetime/datetimeplugin.cpp
+++ b/plugins/dde-dock/datetime/datetimeplugin.cpp
@@ -97,7 +97,10 @@ void DatetimePlugin::loadPlugin()
 
     m_centralWidget.reset(new DatetimeWidget(m_RegionFormatModel));
 
-    connect(m_centralWidget.data(), &DatetimeWidget::requestUpdateGeometry, this, [this] { m_proxyInter->itemUpdate(this, pluginName()); });
+    connect(m_centralWidget.data(), &DatetimeWidget::requestUpdateGeometry, this, [this] {
+        m_centralWidget.data()->setFixedSize(m_centralWidget.data()->sizeHint());
+        m_proxyInter->itemUpdate(this, pluginName());
+    });
     connect(m_refershTimer, &QTimer::timeout, this, &DatetimePlugin::updateCurrentTimeString);
     connect(m_calendarPopup.data(), &SidebarCalendarWidget::jumpButtonClicked, this, [this]() {
         m_proxyInter->requestSetAppletVisible(this, DATETIME_KEY, false);

--- a/plugins/dde-dock/datetime/datetimewidget.cpp
+++ b/plugins/dde-dock/datetime/datetimewidget.cpp
@@ -263,12 +263,12 @@ QSize DatetimeWidget::curTimeSize() const
     } else {
         // 有效宽度，控件与任务栏要至少保持2px的间距（左/右），hover样式美观
         int vaildWidth = widgetSize.width() > (m_dockSize.width() - 4) ? m_dockSize.width() - 4 : widgetSize.width();
-        widgetSize.setWidth(vaildWidth);
 
         // 更新有效宽度下的字体大小
         // 任务栏宽度固定，控件宽度固定，如果要使文本不贴边显示，只能再将文本矩形宽度缩小6px，模拟出内左/右间距3px的效果
         int textWidth = vaildWidth;
-        while (std::max(timeSize.width(), dateSize.width()) > vaildWidth - 6 && m_timeFont.pixelSize() > 1) {
+        while (std::max(timeSize.width(), dateSize.width()) > vaildWidth - 18 && m_timeFont.pixelSize() > 1) {
+
             m_timeFont.setPixelSize(m_timeFont.pixelSize() - 1);
             if (m_24HourFormat) {
                 timeSize.setHeight(QFontMetrics(m_timeFont).boundingRect(timeString).size().height());
@@ -290,6 +290,7 @@ QSize DatetimeWidget::curTimeSize() const
             }
         }
 
+        widgetSize.setWidth(timeSize.width());
         // 新字体大小更新控件的size
         widgetSize.setHeight(timeSize.height() + dateSize.height());
     }
@@ -429,7 +430,23 @@ void DatetimeWidget::paintEvent(QPaintEvent *e)
     }
 
     painter.setFont(m_timeFont);
-    painter.drawText(timeTextRect, Qt::AlignCenter, timeStr);
+
+    if (timeStr.contains("\n")) {
+        QStringList SL = timeStr.split("\n");
+        int height = QFontMetrics(m_timeFont).boundingRect(timeStr).height();
+        for (int index = 0; index < SL.count(); index++) {
+            QRect rect;
+            rect.setX(timeTextRect.x());
+            rect.setY(timeTextRect.y() + height * index);
+            rect.setWidth(timeTextRect.width());
+            rect.setHeight(height);
+            painter.drawText(rect, Qt::AlignCenter, SL.at(index));
+        }
+
+    } else {
+        painter.drawText(timeTextRect, Qt::AlignCenter, timeStr);
+    }
+
 
     painter.setFont(m_dateFont);
     painter.drawText(dateTextRect, Qt::AlignCenter, dateStr);

--- a/plugins/dde-dock/datetime/regionFormat.cpp
+++ b/plugins/dde-dock/datetime/regionFormat.cpp
@@ -173,5 +173,5 @@ void RegionFormat::sync24HourFormatConfig(bool is24HourFormat)
 
 bool RegionFormat::is24HourFormat() const
 {
-    return !getShortTimeFormat().contains("AP");
+    return !getShortTimeFormat().contains("AP", Qt::CaseInsensitive);
 }


### PR DESCRIPTION
The time plug-in needs to update the page size and redraw in real time after the time format changes.

Issue: https://github.com/linuxdeepin/developer-center/issues/9914