### PR TITLE
fix: network vpn setting cannot jump to dcc's vpn module

### DIFF
--- a/plugins/dde-network-core/net-view/operation/netmanager.cpp
+++ b/plugins/dde-network-core/net-view/operation/netmanager.cpp
@@ -229,7 +229,7 @@ NetManagerPrivate::NetManagerPrivate(NetManager *manager, bool tipsLinkEnabled)
     if (!m_isGreeterMode) {
         NetVPNControlItem *vpnControlItem = new NetVPNControlItem("NetVPNControlItem");
         addItem(vpnControlItem);
-        addItem(new NetVPNTipsItem("NetVPNTipsItem", "VPN", tipsLinkEnabled), vpnControlItem);
+        addItem(new NetVPNTipsItem("NetVPNTipsItem", "networkVpn", tipsLinkEnabled), vpnControlItem);
         addItem(new NetSystemProxyControlItem("NetSystemProxyControlItem"), m_root);
     }
     for (int i = 0; i < DeviceItemCount; ++i) {


### PR DESCRIPTION
as title

Log: as title
Issue: https://github.com/linuxdeepin/developer-center/issues/9946
Influence: network vpn setting can jump to dcc's vpn module