### PR TITLE
fix: menu maybe invalid for app tray

### DIFF
--- a/src/loader/pluginitem.cpp
+++ b/src/loader/pluginitem.cpp
@@ -89,6 +89,10 @@ QMenu *PluginItem::pluginContextMenu()
     initPluginMenu();
 
     qDebug() << "mouseRightButtonClicked:" << m_itemKey << m_menu->actions().size();
+
+    if (m_menu->isEmpty())
+        return nullptr;
+
     m_menu->setAttribute(Qt::WA_TranslucentBackground, true);
     // FIXME: qt5integration drawMenuItemBackground will draw a background event is's transparent
     auto pa = this->palette();

--- a/src/tray-wayland-integration/plugin.cpp
+++ b/src/tray-wayland-integration/plugin.cpp
@@ -329,8 +329,8 @@ PluginPopup* PluginPopup::get(QWindow* window)
 
         QObject::connect(window, &QWindow::visibleChanged, popup, [window, popup] (bool visible) {
             if (!visible) {
-                popup->deleteLater();
                 s_popupMap.remove(window);
+                popup->deleteLater();
             }
         });
     }


### PR DESCRIPTION
Application tray is using custom widget instead of PluginItem's
menu, so we shouldn't show PluginItem's menu, otherwise it maybe
show an empty menu.
