### PR TITLE
fix: PluginItem can't resize automatically

### DIFF
--- a/src/loader/pluginitem.cpp
+++ b/src/loader/pluginitem.cpp
@@ -283,8 +283,8 @@ QWidget * PluginItem::itemTooltip(const QString &itemKey)
     pluginPopup->setPluginId(m_pluginsItemInterface->pluginName());
     pluginPopup->setItemKey(itemKey);
     pluginPopup->setPopupType(Plugin::PluginPopup::PopupTypeTooltip);
-    if (toolTip->sizeHint().width() > 0 && toolTip->sizeHint().height() > 0) {
-        toolTip->setFixedSize(toolTip->sizeHint());
+    if (!toolTip->sizeHint().isEmpty()) {
+        toolTip->resize(toolTip->sizeHint());
     }
     return toolTip;
 }

--- a/src/loader/pluginitem.cpp
+++ b/src/loader/pluginitem.cpp
@@ -177,18 +177,10 @@ void PluginItem::leaveEvent(QEvent *event)
 
 QWidget* PluginItem::centralWidget()
 {
-    const int trayItemWidth = 16;
-    const int trayItemHeight = 16;
-
     auto trayItemWidget = m_pluginsItemInterface->itemWidget(m_itemKey);
     auto policy = m_pluginsItemInterface->pluginSizePolicy();
     if (policy == PluginsItemInterface::System) {
-        trayItemWidget->setFixedSize(trayItemWidth, trayItemHeight);
-    } else {
-        auto size = trayItemWidget->sizeHint();
-        if (size.width() > 0 && size.height() > 0) {
-            trayItemWidget->setFixedSize(trayItemWidget->sizeHint());
-        }
+        trayItemWidget->setFixedSize(Dock::DOCK_PLUGIN_ITEM_FIXED_SIZE);
     }
 
     return trayItemWidget;


### PR DESCRIPTION
in PluginItem::centralWidget(), trayItemWidget is setFixedSize to its sizeHint(),
which makes it unable to resize automatically when sizeHint() changed,
especially for those PluginSizePolicy::Custom ones

Log: delete setFixedSize operation in PluginItem::centralWidget() when PluginSizePolicy is Custom