### PR TITLE
fix: ToolTip is positioned to the left

### DIFF
--- a/src/loader/pluginitem.cpp
+++ b/src/loader/pluginitem.cpp
@@ -155,7 +155,7 @@ void PluginItem::enterEvent(QEvent *event)
         if (auto pluginPopup = Plugin::PluginPopup::get(toolTip->windowHandle())) {
             auto geometry = windowHandle()->geometry();
             auto e = dynamic_cast<QEnterEvent *>(event);
-            const auto offset = QPoint(0, 0);
+            const auto offset = QPoint(width() / 2, height() / 2);
             pluginPopup->setX(geometry.x() + offset.x());
             pluginPopup->setY(geometry.y() + offset.y());
 


### PR DESCRIPTION
Position offset of half the width and height of itemWIdge

Issue: https://github.com/linuxdeepin/developer-center/issues/9953