### PR TITLE
fix: Fixed dnd-mode settings cannot jump to the Control Center

### DIFF
--- a/plugins/dde-dock/dnd-mode/dndmodeitem.cpp
+++ b/plugins/dde-dock/dnd-mode/dndmodeitem.cpp
@@ -116,7 +116,7 @@ void DndModeItem::invokeMenuItem(const QString menuId, const bool checked)
             .path("/com/deepin/dde/ControlCenter")
             .method(QString("ShowPage"))
             .arg(QString("notification"))
-            .arg(QString("System Notification"))
+            .arg(QString("SystemNotify"))
             .call();
 
         Q_EMIT requestHideApplet();


### PR DESCRIPTION
Issue: https://github.com/linuxdeepin/developer-center/issues/9988