### PR TITLE
fix: removing jump to dcc's airplane mode

### DIFF
--- a/plugins/dde-dock/bluetooth/componments/bluetoothapplet.cpp
+++ b/plugins/dde-dock/bluetooth/componments/bluetoothapplet.cpp
@@ -247,7 +247,7 @@ void BluetoothApplet::initUi()
     airplaneLayout->setContentsMargins(20, 0, 10, 0);
     airplaneLayout->setSpacing(0);
     m_airplaneModeLabel->setAlignment(Qt::AlignLeft | Qt::AlignTop);
-    m_airplaneModeLabel->setText(tr("Disable <a style=\"text-decoration: none;\" href=\"Airplane Mode\">Airplane Mode</a> first if you want to connect to a Bluetooth"));
+    m_airplaneModeLabel->setText(tr("Disable Airplane Mode first if you want to connect to a Bluetooth"));
     m_airplaneModeLabel->setWordWrap(true);
     DFontSizeManager::instance()->bind(m_airplaneModeLabel, DFontSizeManager::T8);
     airplaneLayout->addWidget(m_airplaneModeLabel, 0, Qt::AlignTop);


### PR DESCRIPTION
as title

Log: as title
Issue: https://github.com/linuxdeepin/developer-center/issues/9990
Influence: bluetooth can not jump to dcc's airplane mode