### PR TITLE
fix: bluetooth devices list width

### DIFF
--- a/plugins/dde-dock/bluetooth/componments/bluetoothapplet.cpp
+++ b/plugins/dde-dock/bluetooth/componments/bluetoothapplet.cpp
@@ -367,7 +367,7 @@ void BluetoothApplet::updateSize()
     // top and bottom margin
     height += hMargins;
 
-    resize(ItemWidth, height);
+    setFixedSize(ItemWidth, height);
 }
 
 void BluetoothApplet::updateMinHeight(int minHeight)


### PR DESCRIPTION
fixed width 330.

Log: fix bluetooth list width bug
Issue: https://github.com/linuxdeepin/developer-center/issues/9981
Influence: bluetooth devices list display