### PR TITLE
fix: Menu display incomplete

### DIFF
--- a/plugins/application-tray/sniprotocolhandler.cpp
+++ b/plugins/application-tray/sniprotocolhandler.cpp
@@ -200,8 +200,7 @@ bool SniTrayProtocolHandler::eventFilter(QObject *watched, QEvent *event)
                 const auto offset = mouseEvent->pos();
                 pluginPopup->setX(geometry.x() + offset.x());
                 pluginPopup->setY(geometry.y() + offset.y());
-                // FIXME: show() will not get inputfocus while exec() case a ui issue
-                menu->exec();
+                menu->show();
             }
         }
     }


### PR DESCRIPTION
Menu grab mouse in server, so it always gets inputforcus.

Issue: https://github.com/linuxdeepin/developer-center/issues/9721
Issue: https://github.com/linuxdeepin/developer-center/issues/9729
