### PR TITLE
fix: Popup position cannot be refreshed with dock

### DIFF
--- a/src/loader/pluginitem.cpp
+++ b/src/loader/pluginitem.cpp
@@ -158,6 +158,19 @@ void PluginItem::enterEvent(QEvent *event)
     QWidget::enterEvent(event);
 }
 
+void PluginItem::moveEvent(QMoveEvent* e)
+{
+    if (auto popup = m_pluginsItemInterface->itemPopupApplet(m_itemKey); popup && popup->isVisible()) {
+        if (auto pluginPopup = Plugin::PluginPopup::get(popup->windowHandle())) {
+            auto geometry = windowHandle()->geometry();
+            const auto offset = QPoint(0, 0);
+            pluginPopup->setX(geometry.x() + offset.x());
+            pluginPopup->setY(geometry.y() + offset.y());
+        }
+    }
+    QWidget::moveEvent(e);
+}
+
 void PluginItem::leaveEvent(QEvent *event)
 {
     closeToolTip();

--- a/src/loader/pluginitem.h
+++ b/src/loader/pluginitem.h
@@ -38,6 +38,7 @@ protected:
     void mouseReleaseEvent(QMouseEvent *e) override;
     void enterEvent(QEvent *event) override;
     void leaveEvent(QEvent *event) override;
+    void moveEvent(QMoveEvent *e) override;
 
     virtual QWidget *centralWidget();
     virtual QMenu *pluginContextMenu();


### PR DESCRIPTION
use moveEvent to Refresh Position

Issue: https://github.com/linuxdeepin/developer-center/issu es/10096