### PR TITLE
fix: Modify the issue of dock plugin crashing when double clicking

### DIFF
--- a/src/tray-wayland-integration/pluginsurface.cpp
+++ b/src/tray-wayland-integration/pluginsurface.cpp
@@ -34,6 +34,7 @@ PluginSurface::PluginSurface(PluginManager *manager, QtWaylandClient::QWaylandWi
 
 PluginSurface::~PluginSurface()
 {
+    plugin_destroy(this->object());
 }
 
 void PluginSurface::plugin_close()
@@ -87,6 +88,7 @@ PluginPopupSurface::PluginPopupSurface(PluginManager *manager, QtWaylandClient::
 
 PluginPopupSurface::~PluginPopupSurface()
 {
+    plugin_popup_destroy(this->object());
 }
 
 void PluginPopupSurface::plugin_popup_close()


### PR DESCRIPTION
After the PluginPopupSurface object is released, the static function is called to plugin_popuc_lose

Issue: https://github.com/linuxdeepin/developer-center/issues/10118
Issue: https://github.com/linuxdeepin/developer-center/issues/10067