### PR TITLE
fix: Modify network non automatic reconnection issue

### DIFF
--- a/plugins/dde-network-core/src/impl/networkmanager/devicemanagerrealize.cpp
+++ b/plugins/dde-network-core/src/impl/networkmanager/devicemanagerrealize.cpp
@@ -302,6 +302,9 @@ void DeviceManagerRealize::setEnabled(bool enabled)
     QDBusInterface dbusInter(SYS_NETWORK_INTER, SYS_NETWORK_PATH, SYS_NETWORK_INTER, QDBusConnection::systemBus());
     QDBusReply<QDBusObjectPath> reply = dbusInter.call("EnableDevice", m_device->uni(), enabled);
     deviceEnabledAction(reply, enabled);
+    if (enabled) {
+        m_device->setAutoconnect(true);
+    }
 }
 
 void DeviceManagerRealize::disconnectNetwork()


### PR DESCRIPTION
When enabling the network, it is necessary to synchronously turn on Autoconnect

Issue: https://github.com/linuxdeepin/developer-center/issues/10184