### PR TITLE
chore: 解决显示时间tips的date和time贴在一起的问题

### DIFF
--- a/plugins/dde-dock/datetime/datetimewidget.cpp
+++ b/plugins/dde-dock/datetime/datetimewidget.cpp
@@ -186,7 +186,7 @@ void DatetimeWidget::setRegionFormat(RegionFormat *newRegionFormat)
 void DatetimeWidget::updateDateTimeString()
 {
     QLocale locale(m_regionFormat->getLocaleName());
-    m_dateTime = locale.toString(QDate::currentDate(), m_regionFormat->getLongDateFormat()) + QDateTime::currentDateTime().toString(m_regionFormat->getLongTimeFormat());
+    m_dateTime = locale.toString(QDate::currentDate(), m_regionFormat->getLongDateFormat()) + " " + QDateTime::currentDateTime().toString(m_regionFormat->getLongTimeFormat());
 
     QDateTime current = QDateTime::currentDateTime();
 


### PR DESCRIPTION
release 解决显示时间tips的date和time贴在一起的问题
Issue: https://github.com/linuxdeepin/developer-center/issues/10339