### PR TITLE
chore: add fallback icon for applicaiton-tray

### DIFF
--- a/plugins/application-tray/traywidget.cpp
+++ b/plugins/application-tray/traywidget.cpp
@@ -60,8 +60,12 @@ void TrayWidget::paintEvent(QPaintEvent* event)
     if(m_attentionTimer->isActive()) {
         m_handler->attentionIcon().paint(&painter, QRect(0, 0, trayIconSize, trayIconSize));
     } else {
-        m_handler->icon().paint(&painter, QRect(0, 0, trayIconSize, trayIconSize));
-
+        QIcon icon = m_handler->icon();
+        if (icon.isNull()) {
+            static const QIcon defaultIcon = QIcon::fromTheme("application-x-desktop");
+            icon = defaultIcon;
+        }
+        icon.paint(&painter, QRect(0, 0, trayIconSize, trayIconSize));
     }
 }
 }


### PR DESCRIPTION
avoid displaying empty area due to not obtaining icons.
