### PR TITLE
fix: tooltip margin and tooltip disappears abnormally

### DIFF
--- a/src/loader/pluginitem.cpp
+++ b/src/loader/pluginitem.cpp
@@ -300,8 +300,13 @@ QWidget * PluginItem::itemTooltip(const QString &itemKey)
         m_tipsWidget = new QWidget();
         QVBoxLayout *layout = new QVBoxLayout(m_tipsWidget);
         layout->setMargin(0);
+        // add content margin, tooltip popup do not need to set padding
+        layout->setContentsMargins(8, 4, 8, 4);
         layout->addWidget(toolTip);
-        layout->setSizeConstraint(QLayout::SetFixedSize);
+        // fixme: 这个设置会导致widget resize, 当任务栏在右的时候，窗口变化会会遮住鼠标导致leaveEvent触发，tooltip消失
+        if (itemKey.contains("network")) {
+            layout->setSizeConstraint(QLayout::SetFixedSize);
+        }
         toolTip->setVisible(true);
     } else {
         // can update tooltip content


### PR DESCRIPTION
1.When the dock is on the right, the margins is not 10. 2.tooltip widget resize, 当任务栏在右的时候，窗口变化会会遮住鼠标导致leaveEvent触发，tooltip消失

Log: as title
Issue: https://github.com/linuxdeepin/developer-center/issues/10478