### PR TITLE
feat: Power module uses DConfig instead of QGSettings

### DIFF
--- a/plugins/dde-dock/configs/org.deepin.dde.dock.plugin.power.json
+++ b/plugins/dde-dock/configs/org.deepin.dde.dock.plugin.power.json
@@ -12,6 +12,17 @@
             "description":"",
             "permissions":"readwrite",
             "visibility":"private"
+        },
+        "showTimeToFull":{
+            "value": true,
+            "serial": 0,
+            "flags": [],
+            "name": "showTimeToFull",
+            "name[zh_CN]": "显示完整时间",
+            "description[zh_CN]": "是否显示电池使用时间/剩余充电时间",
+            "description":"",
+            "permissions":"readwrite",
+            "visibility":"public"
         }
     }
 }

--- a/plugins/dde-dock/power/powerplugin.h
+++ b/plugins/dde-dock/power/powerplugin.h
@@ -16,6 +16,9 @@
 
 using SystemPowerInter = com::deepin::system::Power;
 
+DCORE_BEGIN_NAMESPACE
+class DConfig;
+DCORE_END_NAMESPACE
 
 class PowerPlugin : public QObject, PluginsItemInterfaceV2
 {
@@ -48,7 +51,7 @@ private:
     void updateBatteryVisible();
     void loadPlugin();
     void refreshPluginItemsVisible();
-    void onGSettingsChanged(const QString &key);
+    void onDConfigValueChanged(const QString &key);
     void refreshTipsData();
     void batteryTimeToDisplayData(const qulonglong &time, uint &hour, uint &minute);
     void notifySupportFlagChanged(bool supportFlag);
@@ -64,6 +67,8 @@ private:
     DBusPower *m_powerInter;
     QTimer *m_batteryStateChangedTimer;
     MessageCallbackFunc m_messageCallback;
+
+    Dtk::Core::DConfig *m_config = nullptr;
 };
 
 #endif // POWERPLUGIN_H

--- a/src/loader/configs/com.deepin.dde.dock.module.gschema.xml
+++ b/src/loader/configs/com.deepin.dde.dock.module.gschema.xml
@@ -232,13 +232,6 @@
           Control Module Enable
       </description>
     </key>
-    <key type="b" name="showtimetofull">
-      <default>true</default>
-      <summary>Show TimeToFull</summary>
-      <description>
-          Show TimeToFull
-      </description>
-    </key>
     <key type="b" name="menu-enable">
       <default>true</default>
       <summary>Menu Enable</summary>


### PR DESCRIPTION
As title, to adapt to the dde-control-center of deepin 25

Log: