### PR TITLE
fix: right-click menu icon adapts to dark theme

### DIFF
--- a/plugins/application-tray/sniprotocolhandler.cpp
+++ b/plugins/application-tray/sniprotocolhandler.cpp
@@ -14,6 +14,10 @@
 #include <QMouseEvent>
 #include <QWindow>
 
+#include <DGuiApplicationHelper>
+
+DGUI_USE_NAMESPACE
+
 // Q_LOGGING_CATEGORY(sniTrayLod, "dde.shell.tray.sni")
 
 namespace tray {
@@ -36,6 +40,16 @@ public:
             menu->setFixedSize(menu->sizeHint());
         });
         return menu;
+    }
+
+    virtual QIcon iconForName(const QString &name) override
+    {
+        if (DGuiApplicationHelper::instance()->themeType() == DGuiApplicationHelper::LightType) {
+            QIcon darkIcon = QIcon::fromTheme(name + "-dark");
+            if (!darkIcon.isNull())
+                return darkIcon;
+        }
+        return QIcon::fromTheme(name);
     }
 };
 
@@ -105,6 +119,7 @@ SniTrayProtocolHandler::SniTrayProtocolHandler(const QString &sniServicePath, QO
     connect(m_sniInter, &StatusNotifierItem::NewTitle, this, &SniTrayProtocolHandler::titleChanged);
     connect(m_sniInter, &StatusNotifierItem::NewStatus, this, &SniTrayProtocolHandler::statusChanged);
     connect(m_sniInter, &StatusNotifierItem::NewToolTip, this, &SniTrayProtocolHandler::tooltiChanged);
+    connect(DGuiApplicationHelper::instance(), &DGuiApplicationHelper::themeTypeChanged, m_dbusMenuImporter, &DBusMenu::updateMenu);
 }
 
 SniTrayProtocolHandler::~SniTrayProtocolHandler()


### PR DESCRIPTION
The right-click menu icon of the Sni protocol plugin adapts to the dark theme

Log: right-click menu icon adapts to dark theme
Bug: https://pms.uniontech.com/bug-view-270985.html