### PR TITLE
fix: no "Open Calendar" button in non-Chinese environments

### DIFF
--- a/plugins/dde-dock/datetime/calendar/sidebarcalendarwidget.cpp
+++ b/plugins/dde-dock/datetime/calendar/sidebarcalendarwidget.cpp
@@ -385,7 +385,7 @@ void SidebarCalendarWidget::setLunarVisible(bool visible)
     const bool isChinese = QLocale::system().language() == QLocale::Language::Chinese;
     m_lunarLabel->setVisible(isChinese && visible);
     m_lunarDetailLabel->setVisible(isChinese && visible);
-    m_jumpCalendarButton->setVisible(isChinese && visible);
+    m_jumpCalendarButton->setVisible(visible);
 }
 
 void SidebarCalendarWidget::checkService()


### PR DESCRIPTION
Button hiding does not depend on the locale language

Log: no "Open Calendar" button in non-Chinese environments
Bug: https://pms.uniontech.com/bug-view-277117.html