### PR TITLE
fix: plugin popup/tooltip pos not correct

### DIFF
--- a/plugins/application-tray/sniprotocolhandler.cpp
+++ b/plugins/application-tray/sniprotocolhandler.cpp
@@ -217,7 +217,8 @@ bool SniTrayProtocolHandler::eventFilter(QObject *watched, QEvent *event)
                 menu->winId();
 
                 auto widget = static_cast<QWidget*>(parent());
-                auto geometry = widget->window()->windowHandle()->geometry();
+                auto plugin = Plugin::EmbedPlugin::get(widget->window()->windowHandle());
+                auto geometry = plugin->pluginPos();
                 auto pluginPopup = Plugin::PluginPopup::get(menu->windowHandle());
                 pluginPopup->setPluginId("application-tray");
                 pluginPopup->setItemKey(id());

--- a/src/loader/pluginitem.cpp
+++ b/src/loader/pluginitem.cpp
@@ -102,7 +102,6 @@ QMenu *PluginItem::pluginContextMenu()
     m_menu->setPalette(pa);
     m_menu->winId();
 
-    auto geometry = windowHandle()->geometry();
     auto pluginPopup = Plugin::PluginPopup::get(m_menu->windowHandle());
     pluginPopup->setPluginId(m_pluginsItemInterface->pluginName());
     pluginPopup->setItemKey(m_itemKey);
@@ -125,7 +124,8 @@ void PluginItem::mouseReleaseEvent(QMouseEvent *e)
 
         if (auto popup = itemPopupApplet()) {
             if (auto pluginPopup = Plugin::PluginPopup::get(popup->windowHandle())) {
-                auto geometry = windowHandle()->geometry();
+                auto plugin = Plugin::EmbedPlugin::get(window()->windowHandle());
+                auto geometry = plugin->pluginPos();
                 const auto offset = QPoint(0, 0);
                 pluginPopup->setX(geometry.x() + offset.x());
                 pluginPopup->setY(geometry.y() + offset.y());
@@ -135,7 +135,8 @@ void PluginItem::mouseReleaseEvent(QMouseEvent *e)
     } else if (e->button() == Qt::RightButton) {
         if (auto menu = pluginContextMenu()) {
             if (auto pluginPopup = Plugin::PluginPopup::get(menu->windowHandle())) {
-                auto geometry = windowHandle()->geometry();
+                auto plugin = Plugin::EmbedPlugin::get(windowHandle());
+                auto geometry = plugin->pluginPos();
                 const auto offset = e->pos();
                 pluginPopup->setX(geometry.x() + offset.x());
                 pluginPopup->setY(geometry.y() + offset.y());
@@ -155,7 +156,8 @@ void PluginItem::enterEvent(QEvent *event)
 
     if (auto toolTip = pluginTooltip()) {
         if (auto pluginPopup = Plugin::PluginPopup::get(toolTip->windowHandle())) {
-            auto geometry = windowHandle()->geometry();
+            auto plugin = Plugin::EmbedPlugin::get(windowHandle());
+            auto geometry = plugin->pluginPos();
             auto e = dynamic_cast<QEnterEvent *>(event);
             const auto offset = QPoint(width() / 2, height() / 2);
             pluginPopup->setX(geometry.x() + offset.x());
@@ -176,7 +178,8 @@ void PluginItem::moveEvent(QMoveEvent *e)
 {
     if (auto popup = m_pluginsItemInterface->itemPopupApplet(m_itemKey); popup && popup->isVisible()) {
         if (auto pluginPopup = Plugin::PluginPopup::get(popup->windowHandle())) {
-            auto geometry = windowHandle()->geometry();
+            auto plugin = Plugin::EmbedPlugin::get(windowHandle());
+            auto geometry = plugin->pluginPos();
             const auto offset = QPoint(0, 0);
             pluginPopup->setX(geometry.x() + offset.x());
             pluginPopup->setY(geometry.y() + offset.y());
@@ -317,7 +320,6 @@ QWidget * PluginItem::itemTooltip(const QString &itemKey)
     m_tipsWidget->setAttribute(Qt::WA_TranslucentBackground);
     m_tipsWidget->winId();
 
-    auto geometry = windowHandle()->geometry();
     auto pluginPopup = Plugin::PluginPopup::get(m_tipsWidget->windowHandle());
     pluginPopup->setPluginId(m_pluginsItemInterface->pluginName());
     pluginPopup->setItemKey(itemKey);

--- a/src/loader/quickpluginitem.cpp
+++ b/src/loader/quickpluginitem.cpp
@@ -128,7 +128,8 @@ void QuickPluginItem::mouseReleaseEvent(QMouseEvent *e)
      if (e->button() == Qt::RightButton) {
         if (auto menu = pluginContextMenu()) {
             if (auto pluginPopup = Plugin::PluginPopup::get(menu->windowHandle())) {
-                auto geometry = windowHandle()->geometry();
+                auto plugin = Plugin::EmbedPlugin::get(windowHandle());
+                auto geometry = plugin->pluginPos();
                 const auto offset = e->pos();
                 pluginPopup->setX(geometry.x() + offset.x());
                 pluginPopup->setY(geometry.y() + offset.y());
@@ -169,7 +170,6 @@ QMenu *QuickPluginItem::pluginContextMenu()
     m_menu->setPalette(pa);
     m_menu->winId();
 
-    auto geometry = windowHandle()->geometry();
     auto pluginPopup = Plugin::PluginPopup::get(m_menu->windowHandle());
     pluginPopup->setPluginId(pluginsItemInterface()->pluginName());
     pluginPopup->setItemKey(Dock::QUICK_ITEM_KEY);

--- a/src/tray-wayland-integration/plugin.cpp
+++ b/src/tray-wayland-integration/plugin.cpp
@@ -23,6 +23,7 @@ public:
     int pluginType;
     int sizePolicy;
     QPoint globalPos;
+    QPoint pluginPos;
     QString dccIcon;
 };
 
@@ -207,6 +208,20 @@ void EmbedPlugin::setDccIcon(const QString &dccIcon)
     Q_EMIT dccIconChanged(d->dccIcon);
 }
 
+QPoint EmbedPlugin::pluginPos()
+{
+    return d->pluginPos;
+}
+
+void EmbedPlugin::setPluginPos(const QPoint &pos)
+{
+    if (d->pluginPos == pos) {
+        return;
+    }
+    d->pluginPos = pos;
+    Q_EMIT pluginPosChanged(d->pluginPos);
+}
+
 class PluginPopupPrivate
 {
 public:
@@ -221,6 +236,7 @@ public:
     int popupType;
     int x = 0;
     int y = 0;
+    QPoint plugPos;
 };
 
 PluginPopup::PluginPopup(QWindow* window)
@@ -308,6 +324,20 @@ void PluginPopup::setY(const int& y)
 
     d->y = y;
     Q_EMIT yChanged();
+}
+
+QPoint PluginPopup::pluginPos()
+{
+    return d->plugPos;
+}
+
+void PluginPopup::setPluginPos(const QPoint &pos)
+{
+    if (d->plugPos == pos) {
+        return;
+    }
+    d->plugPos = pos;
+    Q_EMIT pluginPosChanged(d->plugPos);
 }
 
 static QMap<QWindow*, PluginPopup*> s_popupMap;

--- a/src/tray-wayland-integration/plugin.h
+++ b/src/tray-wayland-integration/plugin.h
@@ -56,6 +56,9 @@ public:
     QString dccIcon() const;
     void setDccIcon(const QString &dccIcon);
 
+    QPoint pluginPos();
+    void setPluginPos(const QPoint &pos);
+
     static EmbedPlugin *getWithoutCreating(QWindow *window);
     static EmbedPlugin* get(QWindow* window);
     static bool contains(QWindow* window);
@@ -70,6 +73,7 @@ Q_SIGNALS:
     void dockColorThemeChanged(uint32_t colorType);
     void pluginSupportFlagChanged(bool);
     void dccIconChanged(const QString &dccIcon);
+    void pluginPosChanged(const QPoint &point);
 
 Q_SIGNALS:
     void itemKeyChanged();
@@ -126,6 +130,9 @@ public:
     int y() const;
     void setY(const int& y);
 
+    QPoint pluginPos();
+    void setPluginPos(const QPoint &pos);
+
     static PluginPopup *getWithoutCreating(QWindow *window);
     static PluginPopup* get(QWindow* window);
     static void remove(QWindow *window);
@@ -141,6 +148,7 @@ Q_SIGNALS:
 
     void xChanged();
     void yChanged();
+    void pluginPosChanged(const QPoint &point);
 
 private:
     explicit PluginPopup(QWindow* window);

--- a/src/tray-wayland-integration/pluginsurface.cpp
+++ b/src/tray-wayland-integration/pluginsurface.cpp
@@ -51,7 +51,7 @@ void PluginSurface::plugin_geometry(int32_t x, int32_t y, int32_t width, int32_t
     if (height <= 0)
         rect.setHeight(m_window->height());
 
-    m_window->setGeometry(rect);
+    m_plugin->setPluginPos(QPoint(x, y));
     Q_EMIT m_plugin->eventGeometry(rect);
 }
 
@@ -107,7 +107,7 @@ void PluginPopupSurface::plugin_popup_geometry(int32_t x, int32_t y, int32_t wid
     if (rect.height() <= 0)
         rect.setHeight(m_window->height());
 
-    m_window->setGeometry(rect);
+    m_popup->setPluginPos(QPoint(x, y));
     if (plugin) {
         Q_EMIT plugin->eventGeometry(rect);
     }


### PR DESCRIPTION
QWindow cannot set window position on wayland, and will always return (0,0) So we store plugin pos at EmbedPlugin not in QWindow anymore.

log: as title