### PR TITLE
chore: bump version to 1.99.3

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-tray-loader (1.99.3) UNRELEASED; urgency=medium
+
+  * fix: normalize the naming of the deb package
+
+ -- xionglinlin <xionglinlin@uniontech.com>  Fri, 08 Nov 2024 15:47:41 +0800
+
 dde-tray-loader (1.99.2) UNRELEASED; urgency=medium
 
   * bump version to 1.99.2


### PR DESCRIPTION
release 1.99.3

Log: bump version to 1.99.3