### PR TITLE
fix: dde-dock plugins crash on RISC-V platform

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-tray-loader (1.0.7) unstable; urgency=medium
+
+  * fix: dde-dock plugins crash on RISC-V platform
+
+ -- Yutao Meng <mengyutao@deepin.org>  Thu, 28 Nov 2024 10:40:52 +0800
+
 dde-tray-loader (1.0.6) unstable; urgency=medium
 
   * fix: Avoid showing XEMBED and SNI plugins together

--- a/plugins/dde-dock/bluetooth/componments/bluetoothadapteritem.cpp
+++ b/plugins/dde-dock/bluetooth/componments/bluetoothadapteritem.cpp
@@ -25,7 +25,7 @@ BluetoothDeviceItem::BluetoothDeviceItem(QStyle *style, const Device *device, Pl
     : m_style(style)
     , m_device(device)
 {
-    m_standardItem = new PluginItem();
+    m_standardItem = new PluginStandardItem();
 
     m_standardItem->updateIcon(m_device->deviceType().isEmpty() ? QIcon::fromTheme("bluetooth_other")
                                                                 : QIcon::fromTheme(QString("bluetooth_%1").arg(m_device->deviceType())));
@@ -42,7 +42,7 @@ BluetoothDeviceItem::~BluetoothDeviceItem()
 void BluetoothDeviceItem::initConnect()
 {
     connect(m_device, &Device::stateChanged, this, &BluetoothDeviceItem::updateDeviceState);
-    connect(m_standardItem, &PluginItem::connectBtnClicked, this, &BluetoothDeviceItem::disconnectDevice);
+    connect(m_standardItem, &PluginStandardItem::connectBtnClicked, this, &BluetoothDeviceItem::disconnectDevice);
 }
 
 void BluetoothDeviceItem::updateDeviceState(Device::State state)
@@ -97,7 +97,7 @@ void BluetoothAdapterItem::onConnectDevice(const QModelIndex &index)
     const QStandardItemModel *deviceModel = dynamic_cast<const QStandardItemModel *>(index.model());
     if (!deviceModel)
         return;
-    PluginItem *deviceitem = dynamic_cast<PluginItem *>(deviceModel->item(index.row()));
+    PluginStandardItem *deviceitem = dynamic_cast<PluginStandardItem *>(deviceModel->item(index.row()));
 
     foreach (const auto item, m_deviceItems) {
         // 只有非连接状态才发送connectDevice信号（connectDevice信号连接的槽为取反操作，而非仅仅连接）
@@ -110,14 +110,14 @@ void BluetoothAdapterItem::onConnectDevice(const QModelIndex &index)
     }
 }
 
-void BluetoothAdapterItem::onTopDeviceItem(PluginItem *item)
+void BluetoothAdapterItem::onTopDeviceItem(PluginStandardItem *item)
 {
     if (!item || item->row() == -1 || item->row() == 0)
         return;
 
     int row = item->row();
     // 先获取，再移除，后插入
-    PluginItem *sItem = dynamic_cast<PluginItem *>(m_myDeviceModel->takeItem(row, 0));
+    PluginStandardItem *sItem = dynamic_cast<PluginStandardItem *>(m_myDeviceModel->takeItem(row, 0));
     if (sItem) {
         m_myDeviceModel->removeRow(row);
         m_myDeviceModel->insertRow(0, sItem);
@@ -197,11 +197,11 @@ void BluetoothAdapterItem::onDeviceAdded(const Device *device)
         Q_EMIT deviceStateChanged(device);
         if (!(device->state() == Device::StateUnavailable))
             return;
-        PluginItem *item = deviceItem->standardItem();
+        PluginStandardItem *item = deviceItem->standardItem();
         if (item && deviceItem->device()->paired()) {
             QModelIndex myDeviceIndex = m_myDeviceModel->indexFromItem(item);
             if(myDeviceIndex.isValid()) {
-                PluginItem *sItem = dynamic_cast<PluginItem *>(m_myDeviceModel->takeItem(myDeviceIndex.row(), 0));
+                PluginStandardItem *sItem = dynamic_cast<PluginStandardItem *>(m_myDeviceModel->takeItem(myDeviceIndex.row(), 0));
                 if (sItem) {
                     QMap<const Device *, BluetoothDeviceItem *>::iterator i;
                     // 计算已连接蓝牙设备数
@@ -228,12 +228,12 @@ void BluetoothAdapterItem::onDeviceAdded(const Device *device)
     });
     connect(device, &Device::pairedChanged, this, [this, deviceItem](const bool paired) {
         if (deviceItem && deviceItem->device()) {
-            PluginItem *item = deviceItem->standardItem();
+            PluginStandardItem *item = deviceItem->standardItem();
             if (item) {
                 if (paired) {
                     QModelIndex otherDeviceIndex = m_otherDeviceModel->indexFromItem(item);
                     if(otherDeviceIndex.isValid()) {
-                        PluginItem *sItem = dynamic_cast<PluginItem *>(m_otherDeviceModel->takeItem(otherDeviceIndex.row(), 0));
+                        PluginStandardItem *sItem = dynamic_cast<PluginStandardItem *>(m_otherDeviceModel->takeItem(otherDeviceIndex.row(), 0));
                         if (sItem) {
                             m_otherDeviceModel->removeRow(otherDeviceIndex.row());
                             m_myDeviceModel->appendRow(sItem);
@@ -242,7 +242,7 @@ void BluetoothAdapterItem::onDeviceAdded(const Device *device)
                 } else {
                     QModelIndex myDeviceIndex = m_myDeviceModel->indexFromItem(item);
                     if (myDeviceIndex.isValid()) {
-                        PluginItem *sItem = dynamic_cast<PluginItem *>(m_myDeviceModel->takeItem(myDeviceIndex.row(), 0));
+                        PluginStandardItem *sItem = dynamic_cast<PluginStandardItem *>(m_myDeviceModel->takeItem(myDeviceIndex.row(), 0));
                         if (sItem) {
                             m_myDeviceModel->removeRow(myDeviceIndex.row());
                             m_otherDeviceModel->appendRow(sItem);
@@ -298,7 +298,7 @@ void BluetoothAdapterItem::onDeviceRemoved(const Device *device)
     QStandardItemModel *sourceModel = m_deviceItems.value(device)->standardItem()->model();
     for (int rowIndex = 0; rowIndex < sourceModel->rowCount(); ++rowIndex) {
         QModelIndex index = sourceModel->index(rowIndex, 0);
-        auto item = dynamic_cast<PluginItem *>(sourceModel->itemFromIndex(index));
+        auto item = dynamic_cast<PluginStandardItem *>(sourceModel->itemFromIndex(index));
         if (item == m_deviceItems.value(device)->standardItem()) {
             sourceModel->removeRow(rowIndex);
             break;
@@ -483,7 +483,7 @@ void BluetoothAdapterItem::setUnnamedDevicesVisible(bool isShow)
             BluetoothDeviceItem *deviceItem = i.value();
 
             if (deviceItem && deviceItem->device() && deviceItem->device()->name().isEmpty()) {
-                PluginItem *dListItem = deviceItem->standardItem();
+                PluginStandardItem *dListItem = deviceItem->standardItem();
                 QStandardItemModel *model = i.value()->standardItem()->model();
                 QModelIndex index = model->indexFromItem(dListItem);
                 if (!index.isValid()) {
@@ -501,7 +501,7 @@ void BluetoothAdapterItem::setUnnamedDevicesVisible(bool isShow)
         // 将名称为空的蓝牙设备过滤,如果蓝牙正在连接或者已连接不过滤
         if (deviceItem && deviceItem->device() && deviceItem->device()->name().isEmpty()
                 && (Device::StateConnected != deviceItem->device()->state() || !deviceItem->device()->connecting())) {
-            PluginItem *dListItem = deviceItem->standardItem();
+            PluginStandardItem *dListItem = deviceItem->standardItem();
             QStandardItemModel *model = i.value()->standardItem()->model();
             QModelIndex index = model->indexFromItem(dListItem);
             if (index.isValid()) {

--- a/plugins/dde-dock/bluetooth/componments/bluetoothadapteritem.h
+++ b/plugins/dde-dock/bluetooth/componments/bluetoothadapteritem.h
@@ -41,7 +41,7 @@ public:
     explicit BluetoothDeviceItem(QStyle *style = nullptr, const Device *device = nullptr, PluginListView *parent = nullptr);
     virtual ~BluetoothDeviceItem();
 
-    PluginItem *standardItem() { return m_standardItem; }
+    PluginStandardItem *standardItem() { return m_standardItem; }
     const Device *device() { return m_device; }
 
 public slots:
@@ -49,7 +49,7 @@ public slots:
     void updateDeviceState(Device::State state);
 
 signals:
-    void requestTopDeviceItem(PluginItem *item);
+    void requestTopDeviceItem(PluginStandardItem *item);
     void deviceStateChanged(const Device *device);
     void disconnectDevice();
 
@@ -59,7 +59,7 @@ private:
     DStyleHelper m_style;
 
     const Device *m_device;
-    PluginItem *m_standardItem;
+    PluginStandardItem *m_standardItem;
 };
 
 class DeviceControlWidget : public QPushButton
@@ -158,7 +158,7 @@ public slots:
     // 连接蓝牙设备
     void onConnectDevice(const QModelIndex &index);
     // 将已连接的蓝牙设备放到列表第一个
-    void onTopDeviceItem(PluginItem *item);
+    void onTopDeviceItem(PluginStandardItem *item);
     // 设置蓝牙适配器名称
     void onAdapterNameChanged(const QString name);
 

--- a/plugins/dde-dock/common/pluginitemdelegate.cpp
+++ b/plugins/dde-dock/common/pluginitemdelegate.cpp
@@ -83,7 +83,7 @@ QWidget *PluginItemDelegate::createEditor(QWidget *parent, const QStyleOptionVie
     QStandardItem* item = qobject_cast<QStandardItemModel*>(m_view->model())->itemFromIndex(index);
     PluginItemWidget *widget = nullptr;
     if (item) {
-        widget = new PluginItemWidget(dynamic_cast<PluginItem *>(item), parent);
+        widget = new PluginItemWidget(dynamic_cast<PluginStandardItem *>(item), parent);
     }
     return widget;
 }
@@ -134,7 +134,7 @@ ItemSpacing PluginItemDelegate::getItemSpacing(const QModelIndex &index) const
     return spacing;
 }
 
-PluginItem::PluginItem(const QIcon &icon, const QString &name, const PluginItemState state)
+PluginStandardItem::PluginStandardItem(const QIcon &icon, const QString &name, const PluginItemState state)
     : QStandardItem()
     , m_icon(icon)
     , m_name(name)
@@ -142,7 +142,7 @@ PluginItem::PluginItem(const QIcon &icon, const QString &name, const PluginItemS
 {
 }
 
-PluginItem::PluginItem()
+PluginStandardItem::PluginStandardItem()
     : QStandardItem()
     , m_icon(QIcon())
     , m_name(QString())
@@ -150,11 +150,11 @@ PluginItem::PluginItem()
 {
 }
 
-PluginItem::~PluginItem()
+PluginStandardItem::~PluginStandardItem()
 {
 }
 
-void PluginItem::updateIcon(const QIcon &icon)
+void PluginStandardItem::updateIcon(const QIcon &icon)
 {
     if (m_icon.cacheKey() != icon.cacheKey()) {
         m_icon = icon;
@@ -162,7 +162,7 @@ void PluginItem::updateIcon(const QIcon &icon)
     }
 }
 
-void PluginItem::updateName(const QString &name)
+void PluginStandardItem::updateName(const QString &name)
 {
     if (m_name != name) {
         m_name = name;
@@ -170,7 +170,7 @@ void PluginItem::updateName(const QString &name)
     }
 }
 
-void PluginItem::updateState(const PluginItemState state)
+void PluginStandardItem::updateState(const PluginItemState state)
 {
     if (m_state != state) {
         m_state = state;
@@ -178,7 +178,7 @@ void PluginItem::updateState(const PluginItemState state)
     }
 }
 
-PluginItemWidget::PluginItemWidget(PluginItem *item, QWidget *parent)
+PluginItemWidget::PluginItemWidget(PluginStandardItem *item, QWidget *parent)
     : QWidget(parent)
     , m_item(item)
     , m_mainLayout(new QHBoxLayout(this))
@@ -233,11 +233,11 @@ PluginItemWidget::PluginItemWidget(PluginItem *item, QWidget *parent)
     if (parent)
         setForegroundRole(parent->foregroundRole());
 
-    connect(m_item, &PluginItem::iconChanged, this, &PluginItemWidget::updateIcon);
-    connect(m_item, &PluginItem::nameChanged, this, &PluginItemWidget::updateName);
-    connect(m_item, &PluginItem::stateChanged, this, &PluginItemWidget::updateState);
+    connect(m_item, &PluginStandardItem::iconChanged, this, &PluginItemWidget::updateIcon);
+    connect(m_item, &PluginStandardItem::nameChanged, this, &PluginItemWidget::updateName);
+    connect(m_item, &PluginStandardItem::stateChanged, this, &PluginItemWidget::updateState);
 
-    connect(m_connBtn, &CommonIconButton::clicked, m_item, &PluginItem::connectBtnClicked);
+    connect(m_connBtn, &CommonIconButton::clicked, m_item, &PluginStandardItem::connectBtnClicked);
 }
 
 PluginItemWidget::~PluginItemWidget()

--- a/plugins/dde-dock/common/pluginitemdelegate.h
+++ b/plugins/dde-dock/common/pluginitemdelegate.h
@@ -33,7 +33,7 @@ struct ItemSpacing
     QStyleOptionViewItem::ViewItemPosition viewItemPosition;
 };
 
-class PluginItem;
+class PluginStandardItem;
 class PluginItemWidget;
 class PluginItemDelegate : public QStyledItemDelegate
 {
@@ -72,14 +72,14 @@ private:
     QStyleOptionViewItem::ViewItemPosition m_endItemStyle;
 };
 
-class PluginItem : public QObject, public QStandardItem
+class PluginStandardItem : public QObject, public QStandardItem
 {
     Q_OBJECT
 
 public:
-    explicit PluginItem(const QIcon &icon, const QString &name, const PluginItemState state = PluginItemState::NoState);
-    explicit PluginItem();
-    ~PluginItem() override;
+    explicit PluginStandardItem(const QIcon &icon, const QString &name, const PluginItemState state = PluginItemState::NoState);
+    explicit PluginStandardItem();
+    ~PluginStandardItem() override;
 
     void updateIcon(const QIcon &icon);
     QIcon icon() const { return m_icon; }
@@ -106,7 +106,7 @@ class PluginItemWidget : public QWidget
 {
     Q_OBJECT
 public:
-    explicit PluginItemWidget(PluginItem *item, QWidget *parent = nullptr);
+    explicit PluginItemWidget(PluginStandardItem *item, QWidget *parent = nullptr);
     ~PluginItemWidget() override;
 
 public Q_SLOTS:
@@ -118,7 +118,7 @@ protected:
     bool event(QEvent *e) override;
 
 private:
-    PluginItem *m_item;
+    PluginStandardItem *m_item;
 
     QHBoxLayout *m_mainLayout;
     CommonIconButton *m_iconBtn;

--- a/plugins/dde-dock/eye-comfort-mode/eyecomfortmodeapplet.cpp
+++ b/plugins/dde-dock/eye-comfort-mode/eyecomfortmodeapplet.cpp
@@ -23,9 +23,9 @@ EyeComfortmodeApplet::EyeComfortmodeApplet(QWidget *parent)
     , m_settingButton(new JumpSettingButton(this))
     , m_themeView(new PluginListView(this))
     , m_themeItemModel(new QStandardItemModel(m_themeView))
-    , m_lightTheme(new PluginItem(QIcon::fromTheme("theme-light"), tr("Light")))
-    , m_darkTheme(new PluginItem(QIcon::fromTheme("theme-dark"), tr("Dark")))
-    , m_autoTheme(new PluginItem(QIcon::fromTheme("theme-auto"), tr("Auto")))
+    , m_lightTheme(new PluginStandardItem(QIcon::fromTheme("theme-light"), tr("Light")))
+    , m_darkTheme(new PluginStandardItem(QIcon::fromTheme("theme-dark"), tr("Dark")))
+    , m_autoTheme(new PluginStandardItem(QIcon::fromTheme("theme-auto"), tr("Auto")))
 {
     initUi();
     initConnect();

--- a/plugins/dde-dock/eye-comfort-mode/eyecomfortmodeapplet.h
+++ b/plugins/dde-dock/eye-comfort-mode/eyecomfortmodeapplet.h
@@ -53,9 +53,9 @@ private:
     JumpSettingButton *m_settingButton;
     PluginListView *m_themeView;
     QStandardItemModel *m_themeItemModel;
-    PluginItem *m_lightTheme;
-    PluginItem *m_darkTheme;
-    PluginItem *m_autoTheme;
+    PluginStandardItem *m_lightTheme;
+    PluginStandardItem *m_darkTheme;
+    PluginStandardItem *m_autoTheme;
     QString m_themeTypeName;
 };
 

--- a/plugins/dde-dock/power/powerapplet.cpp
+++ b/plugins/dde-dock/power/powerapplet.cpp
@@ -134,7 +134,7 @@ void PowerApplet::initData()
         } else if (pair.first == BALANCEPERFORMANCE) {
             icon = QIcon::fromTheme("status-performance-mode");
         }
-        PluginItem *item = new PluginItem(icon, pair.second);
+        PluginStandardItem *item = new PluginStandardItem(icon, pair.second);
         item->setData(pair.first, MODE_DATA_ROLE);
         m_model->appendRow(item);
     }
@@ -179,7 +179,7 @@ void PowerApplet::onCurPowerModeChanged(const QString &curPowerMode)
 {
     int row_count = m_model->rowCount();
     for (int i = 0; i < row_count; ++i) {
-        auto item = dynamic_cast<PluginItem *>(m_model->item(i, 0));
+        auto item = dynamic_cast<PluginStandardItem *>(m_model->item(i, 0));
         if (!item) {
             continue;
         }
@@ -220,7 +220,7 @@ void PowerApplet::onHighPerformanceSupportChanged(const bool isSupport)
             QList<QPair<QString, QString>> modeList = PerformanceModeController::ref().modeList();
             for (const auto &pair : modeList) {
                 if (pair.first == PERFORMANCE) {
-                    PluginItem *item = new PluginItem(QIcon::fromTheme("performance"), pair.second);
+                    PluginStandardItem *item = new PluginStandardItem(QIcon::fromTheme("performance"), pair.second);
                     item->setData(PERFORMANCE, MODE_DATA_ROLE);
                     m_model->insertRow(0, item);
                     break;

--- a/plugins/dde-dock/sound/soundapplet.cpp
+++ b/plugins/dde-dock/sound/soundapplet.cpp
@@ -219,26 +219,26 @@ void SoundApplet::refreshIcon()
     m_sliderContainer->setIcon(SliderContainer::RightIcon, "audio-volume-high-symbolic", 0);
 }
 
-PluginItem* SoundApplet::findItem(const QString &uniqueKey) const
+PluginStandardItem* SoundApplet::findItem(const QString &uniqueKey) const
 {
     for (int i = 0; i < m_itemModel->rowCount(); i++) {
         auto item = m_itemModel->item(i);
         if (uniqueKey == item->data(Qt::WhatsThisPropertyRole).value<QString>()) {
-            return dynamic_cast<PluginItem*>(item);
+            return dynamic_cast<PluginStandardItem*>(item);
         }
     }
 
     return nullptr;
 }
 
-void SoundApplet::selectItem(PluginItem *targetItem)
+void SoundApplet::selectItem(PluginStandardItem *targetItem)
 {
     if (!targetItem) {
         return;
     }
 
     for (int i = 0; i < m_itemModel->rowCount(); ++i) {
-        auto item = dynamic_cast<PluginItem *>(m_itemModel->item(i, 0));
+        auto item = dynamic_cast<PluginStandardItem *>(m_itemModel->item(i, 0));
         if (!item) {
             continue;
         }
@@ -251,7 +251,7 @@ void SoundApplet::addPort(const SoundCardPort* port)
     if (!port->isEnabled())
         return;
 
-    PluginItem* pi = new PluginItem(QIcon::fromTheme(SoundCardPort::icon(port->portType())), 
+    PluginStandardItem* pi = new PluginStandardItem(QIcon::fromTheme(SoundCardPort::icon(port->portType())), 
                                     port->description() + "(" + port->cardName() + ")");
     pi->setData(port->uniqueKey(), Qt::WhatsThisPropertyRole);
 

--- a/plugins/dde-dock/sound/soundapplet.h
+++ b/plugins/dde-dock/sound/soundapplet.h
@@ -66,8 +66,8 @@ private:
     void removeDisabledDevice(QString portId, unsigned int cardId);
     void updateVolumeSliderStatus(const QString& status);
     void resizeApplet();
-    PluginItem* findItem(const QString &uniqueKey) const;
-    void selectItem(PluginItem *targetItem);
+    PluginStandardItem* findItem(const QString &uniqueKey) const;
+    void selectItem(PluginStandardItem *targetItem);
 
 protected:
     bool eventFilter(QObject *watcher, QEvent *event);


### PR DESCRIPTION
dde-dock PluginItem is confused with the same name class from src/loader. And this caused unknown behavior of inheritting QWidget as well.

pms: BUG-277621
Log: dde-dock plugins crash on RISC-V platform