### PR TITLE
fix: click application tray border has no response

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-tray-loader (1.0.8) unstable; urgency=medium
+
+  * fix: unable to click application tray border
+
+ -- tsic404 <liuheng@depein.org>  Mon, 09 Dec 2024 13:26:27 +0800
+
 dde-tray-loader (1.0.7) unstable; urgency=medium
 
   * fix: dde-dock plugins crash on RISC-V platform

--- a/plugins/application-tray/abstracttrayprotocol.h
+++ b/plugins/application-tray/abstracttrayprotocol.h
@@ -8,8 +8,7 @@
 #include <QWidget>
 #include <QObject>
 #include <QHash>
-#include <cstddef>
-#include <qwidget.h>
+#include <QWidget>
 
 class TrayWidget;
 namespace tray {
@@ -72,6 +71,8 @@ public:
     virtual QWidget *tooltip() const {return nullptr;}
 
     virtual bool enabled() const {return false;}
+    void setWindow(QWidget *window) {m_window = window;}
+    QWidget *window() const {return m_window;}
 
 protected:
     virtual bool eventFilter(QObject *watched, QEvent *event) {return false;};
@@ -87,5 +88,8 @@ Q_SIGNALS:
     void attentionIconChanged();
 
     void enabledChanged();
+
+private:
+    QWidget* m_window;
 };
 }

--- a/plugins/application-tray/sniprotocolhandler.cpp
+++ b/plugins/application-tray/sniprotocolhandler.cpp
@@ -226,7 +226,7 @@ bool SniTrayProtocolHandler::enabled() const
 
 bool SniTrayProtocolHandler::eventFilter(QObject *watched, QEvent *event)
 {
-    if (watched == parent()) {
+    if (watched == window()) {
         if (event->type() == QEvent::MouseButtonRelease) {
             QMouseEvent* mouseEvent = static_cast<QMouseEvent*>(event);
             if (mouseEvent->button() == Qt::LeftButton) {

--- a/plugins/application-tray/traywidget.cpp
+++ b/plugins/application-tray/traywidget.cpp
@@ -29,7 +29,6 @@ TrayWidget::TrayWidget(QPointer<AbstractTrayProtocolHandler> handler)
     setFixedSize(trayIconSize, trayIconSize);
 
     m_handler->setParent(this);
-    installEventFilter(m_handler);
     setMouseTracking(true);
 
     connect(m_handler, &AbstractTrayProtocolHandler::iconChanged, this, [this](){update();});
@@ -44,6 +43,12 @@ TrayWidget::TrayWidget(QPointer<AbstractTrayProtocolHandler> handler)
 
 TrayWidget::~TrayWidget()
 {
+}
+
+void TrayWidget::showEvent(QShowEvent* event)
+{
+    m_handler->setWindow(window());
+    window()->installEventFilter(m_handler);
 }
 
 void TrayWidget::paintEvent(QPaintEvent* event)

--- a/plugins/application-tray/traywidget.h
+++ b/plugins/application-tray/traywidget.h
@@ -21,6 +21,7 @@ public:
 
 protected:
     void paintEvent(QPaintEvent* event) override;
+    void showEvent(QShowEvent* event) override;
 
 private:
     QPointer<AbstractTrayProtocolHandler> m_handler;

--- a/plugins/application-tray/xembedprotocolhandler.cpp
+++ b/plugins/application-tray/xembedprotocolhandler.cpp
@@ -187,7 +187,7 @@ void XembedProtocolHandler::xembedTrayIconChanged(uint32_t windowId)
 
 bool XembedProtocolHandler::eventFilter(QObject *watched, QEvent *event)
 {
-    if (watched == parent()) {
+    if (watched == window()) {
         // 有透明通道时，可以做到container一直透明隐藏，就走Enter触发
         // 没有透明通道时，走旧dock的方式 QEvent::Move防止在 dock/container 之前一直切换
         if ((event->type() == QEvent::Enter)) {


### PR DESCRIPTION
Listen to the external Widget size instead of just the TrayWidget part

log: as title
pms: BUG-290519