### PR TITLE
fix: dnd-mode and airplane mode plugin icon missing under dark theme

### DIFF
--- a/plugins/dde-dock/common/commoniconbutton.cpp
+++ b/plugins/dde-dock/common/commoniconbutton.cpp
@@ -135,6 +135,10 @@ void CommonIconButton::setIcon(const QString &icon, const QString &fallback, con
         addDarkMark(tmpFallback);
     }
     m_icon = QIcon::fromTheme(tmp, QIcon::fromTheme(tmpFallback));
+    if (m_icon.isNull()) {
+        QString defaultIcon = m_fileMapping[State::Default].first;
+        m_icon = QIcon::fromTheme(defaultIcon);
+    }
     update();
 }
 


### PR DESCRIPTION
Unknown load error on plugin items. Use temporary fallback icon instead.

pms: BUG-293455
Log: fix: dnd-mode and airplane mode plugin icon missing under dark theme