### PR TITLE
fix: right-click menu icon adapts to dark theme

### DIFF
--- a/plugins/application-tray/sniprotocolhandler.cpp
+++ b/plugins/application-tray/sniprotocolhandler.cpp
@@ -14,6 +14,10 @@
 #include <QMouseEvent>
 #include <QWindow>
 
+#include <DGuiApplicationHelper>
+
+DGUI_USE_NAMESPACE
+
 // Q_LOGGING_CATEGORY(sniTrayLod, "dde.shell.tray.sni")
 
 namespace tray {
@@ -36,6 +40,16 @@ public:
             menu->setFixedSize(menu->sizeHint());
         });
         return menu;
+    }
+
+    virtual QIcon iconForName(const QString &name) override
+    {
+        if (DGuiApplicationHelper::instance()->themeType() == DGuiApplicationHelper::LightType) {
+            QIcon darkIcon = QIcon::fromTheme(name + "-dark");
+            if (!darkIcon.isNull())
+                return darkIcon;
+        }
+        return QIcon::fromTheme(name);
     }
 };
 
@@ -105,6 +119,9 @@ SniTrayProtocolHandler::SniTrayProtocolHandler(const QString &sniServicePath, QO
     connect(m_sniInter, &StatusNotifierItem::NewTitle, this, &SniTrayProtocolHandler::titleChanged);
     connect(m_sniInter, &StatusNotifierItem::NewStatus, this, &SniTrayProtocolHandler::statusChanged);
     connect(m_sniInter, &StatusNotifierItem::NewToolTip, this, &SniTrayProtocolHandler::tooltiChanged);
+    connect(DGuiApplicationHelper::instance(), &DGuiApplicationHelper::themeTypeChanged, [this](DGuiApplicationHelper::ColorType themeType) {
+        m_dbusMenuImporter->updateMenu(true);
+    });
 }
 
 SniTrayProtocolHandler::~SniTrayProtocolHandler()

--- a/plugins/libdbusmenuqt/dbusmenuimporter.cpp
+++ b/plugins/libdbusmenuqt/dbusmenuimporter.cpp
@@ -80,6 +80,7 @@ public:
 
     QSet<int> m_idsRefreshedByAboutToShow;
     QSet<int> m_pendingLayoutUpdates;
+    bool m_forceRefresh = false;
 
     QDBusPendingCallWatcher *refresh(int id)
     {
@@ -154,6 +155,7 @@ public:
         for (const QString &key : requestedProperties) {
             updateActionProperty(action, key, map.value(key));
         }
+        m_forceRefresh = false;
     }
 
     void updateActionProperty(QAction *action, const QString &key, const QVariant &value)
@@ -199,7 +201,7 @@ public:
     {
         const QString iconName = value.toString();
         const QString previous = action->property(DBUSMENU_PROPERTY_ICON_NAME).toString();
-        if (previous == iconName) {
+        if (!m_forceRefresh && previous == iconName) {
             return;
         }
         action->setProperty(DBUSMENU_PROPERTY_ICON_NAME, iconName);
@@ -458,8 +460,9 @@ void DBusMenuImporter::sendClickedEvent(int id)
     d->sendEvent(id, QStringLiteral("clicked"));
 }
 
-void DBusMenuImporter::updateMenu()
+void DBusMenuImporter::updateMenu(bool force)
 {
+    d->m_forceRefresh = force;
     updateMenu(DBusMenuImporter::menu());
 }
 

--- a/plugins/libdbusmenuqt/dbusmenuimporter.h
+++ b/plugins/libdbusmenuqt/dbusmenuimporter.h
@@ -45,7 +45,7 @@ public Q_SLOTS:
      * Will Q_EMIT menuUpdated() when complete.
      * This should be done before showing a menu
      */
-    void updateMenu();
+    void updateMenu(bool force = false);
 
     void updateMenu(QMenu *menu);
 


### PR DESCRIPTION
The right-click menu icon of the Sni protocol plugin adapts to the dark theme

pms: Bug-288619