### PR TITLE
fix: Click on clipboard quick item will trigger screenshot plugins too

### DIFF
--- a/src/loader/widgetplugin.cpp
+++ b/src/loader/widgetplugin.cpp
@@ -382,7 +382,10 @@ QString WidgetPlugin::messageCallback(PluginsItemInterfaceV2 *pluginItem, const 
         }
     } else {
         foreach (auto plugin, Plugin::EmbedPlugin::all()) {
-            Q_EMIT plugin->requestMessage(msg);
+            if (plugin->pluginId() == pluginItem->pluginName()) {
+                Q_EMIT plugin->requestMessage(msg);
+                break;
+            }
         }
     }
 


### PR DESCRIPTION
The message events were emitted on all the plugins. By typo maybe?

pms: BUG-295927
Log: Click on clipboard quick item will trigger screenshot plugins too