### PR TITLE
chore: bump version to 1.99.20

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+dde-tray-loader (1.99.20) UNRELEASED; urgency=medium
+  
+  * [skip CI] Translate dde-dock.ts in tr
+  * fix: missing null pointer judgment
+  * chore: remove wireless casting module
+
+ -- YeShanShan <yeshanshan@deepin.org>  Fri, 14 Mar 2025 13:18:20 +0800
+
 dde-tray-loader (1.99.19) UNRELEASED; urgency=medium
 
   * fix: power popup icon size is too small


### PR DESCRIPTION
bump version to 1.99.20

## Summary by Sourcery

Chores:
- Update Debian changelog to reflect the new version number