### PR TITLE
prevent submenu item hover event propagation from main menu

### DIFF
--- a/plugins/application-tray/sniprotocolhandler.cpp
+++ b/plugins/application-tray/sniprotocolhandler.cpp
@@ -28,6 +28,9 @@ public:
     DBusMenu(const QString &service, const QString &path, QObject *parent = 0)
         : DBusMenuImporter(service, path, parent)
     {
+        QObject::connect(this, &DBusMenuImporter::menuUpdated, this, [this] (QMenu *menu) {
+            menu->setFixedSize(menu->sizeHint());
+        }, Qt::QueuedConnection);
     }
     virtual QMenu *createMenu(QWidget *parent) override
     {
@@ -36,9 +39,6 @@ public:
         auto pa = menu->palette();
         pa.setColor(QPalette::ColorRole::Window, Qt::transparent);
         menu->setPalette(pa);
-        QObject::connect(menu, &QMenu::aboutToShow, menu, [this, menu] () {
-            menu->setFixedSize(menu->sizeHint());
-        });
         return menu;
     }
 

--- a/src/tray-wayland-integration/pluginmanagerintegration.cpp
+++ b/src/tray-wayland-integration/pluginmanagerintegration.cpp
@@ -109,6 +109,8 @@ bool PluginManagerIntegration::tryCreatePopupForSubWindow(QWindow *window)
         pluginPopup->setPopupType(Plugin::PluginPopup::PopupTypeSubPopup);
         pluginPopup->setPluginId(plugin->pluginId());
         pluginPopup->setItemKey(plugin->itemKey());
+        // TODO submenu window's x is changed to zero from parent menu's with when it repeated open.
+        window->setX(parentWindow->width());
         auto parentPos = plugin->pluginPos();
         // TODO move to parentWindow's right position.
         pluginPopup->setX(parentPos.x() + parentWindow->width());


### PR DESCRIPTION
- fix: submenu can't display
- fix: prevent submenu item hover event propagation from main menu

## Summary by Sourcery

Fix submenu display and interaction issues in application tray plugin

Bug Fixes:
- Resolve submenu display problem by setting fixed size at the right time
- Prevent submenu positioning issues when repeatedly opening submenus

Enhancements:
- Improve menu update handling by connecting size adjustment to menu updated signal
- Adjust submenu window positioning to maintain correct horizontal placement