### PR TITLE
fix: DndMode state doesn't follow change with dde-control-center

### DIFF
--- a/plugins/dde-dock/notification/notification.h
+++ b/plugins/dde-dock/notification/notification.h
@@ -11,6 +11,10 @@
 #include <QDBusVariant>
 #include <QDBusInterface>
 
+DCORE_BEGIN_NAMESPACE
+class DConfig;
+DCORE_END_NAMESPACE
+
 class Notification : public QWidget
 {
     Q_OBJECT
@@ -40,9 +44,9 @@ public Q_SLOTS:
     void refreshIcon();
 
 private Q_SLOTS:
-    void onSystemInfoChanged(quint32 info, QDBusVariant value);
     void setNotificationCount(uint count);
     void onNotificationStateChanged(qint64 id, int processedType);
+    void updateDndModeState();
 
 protected:
     void paintEvent(QPaintEvent *e) override;
@@ -52,6 +56,7 @@ private:
     uint m_notificationCount;
     QScopedPointer<QDBusInterface> m_dbus;
     bool m_dndMode;
+    Dtk::Core::DConfig *m_dndModeConfig = nullptr;
     bool m_hasNewNotification = false;
 };
 


### PR DESCRIPTION
SystemInfoChanged has remove in dde-shell when refacting dde-osd.

pms: BUG-310895

## Summary by Sourcery

Migrate DndMode state management from DBus to DConfig in the notification plugin

Bug Fixes:
- Fix the DndMode state synchronization by using DConfig instead of relying on DBus SystemInfoChanged signal

Enhancements:
- Replace direct DBus method call with a more robust configuration management approach using DConfig