### PR TITLE
fix: remove dependency of deepin-network-display to migrate qt6

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -67,7 +67,6 @@ Description: deepin desktop-environment - tray plugins module development files
 
 Package: dde-wirelesscasting-plugin
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends},
- deepin-network-displays (>=0.90.6-deepin2)
+Depends: ${shlibs:Depends}, ${misc:Depends}
 Description: deepin desktop-environment - wireless casting plugin for dde-dock
  wireless casting plugin module


### PR DESCRIPTION
deepin-network-display depends libzbar, but which depends qt5.

## Summary by Sourcery

Remove Qt5 dependency to prepare for Qt6 migration in deepin-network-display

Bug Fixes:
- Resolve dependency conflict between deepin-network-display and libzbar that was blocking Qt6 migration

Chores:
- Update project dependencies to support future Qt6 transition