### PR TITLE
chore: adjust cmake base version to 1.99.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@
 CMAKE_MINIMUM_REQUIRED(VERSION 3.16)
 
 cmake_policy(SET CMP0160 OLD)
-set(DTL_VERSION "0.0.1" CACHE STRING "Define project version")
+set(DTL_VERSION "1.99.0" CACHE STRING "Define project version")
 set(DOCK_VERSION "6.0.37" CACHE STRING "Dock compatible version")
 
 project(dde-tray-loader


### PR DESCRIPTION
as title

Log: as title

## Summary by Sourcery

Update the project version from 0.0.1 to 1.99.0 in the CMakeLists.txt file

Build:
- Modify CMakeLists.txt to update the DTL_VERSION from 0.0.1 to 1.99.0

Chores:
- Bump the project version number to prepare for an upcoming release