### PR TITLE
fix: playing sound when sound slider released

### DIFF
--- a/plugins/dde-dock/common/slidercontainer.cpp
+++ b/plugins/dde-dock/common/slidercontainer.cpp
@@ -69,6 +69,9 @@ SliderContainer::SliderContainer(QWidget *parent)
     installEventFilter(this);
 
     connect(m_slider, &QSlider::valueChanged, this, &SliderContainer::sliderValueChanged);
+    connect(m_slider, &QSlider::sliderReleased, this, [this] {
+        Q_EMIT sliderReleased(m_slider->value());
+    });
 
     connect(DGuiApplicationHelper::instance(), &DGuiApplicationHelper::themeTypeChanged, this, [this]{
         QColor tipColor;
@@ -97,6 +100,9 @@ void SliderContainer::setSlider(QSlider *slider)
     m_slider->installEventFilter(this);
 
     connect(m_slider, &QSlider::valueChanged, this, &SliderContainer::sliderValueChanged);
+    connect(m_slider, &QSlider::sliderReleased, this, [this] {
+        Q_EMIT sliderReleased(m_slider->value());
+    });
 }
 
 void SliderContainer::setSlider(Dtk::Widget::DSlider *slider)
@@ -107,6 +113,9 @@ void SliderContainer::setSlider(Dtk::Widget::DSlider *slider)
     slider->installEventFilter(this);
 
     connect(m_slider, &QSlider::valueChanged, this, &SliderContainer::sliderValueChanged);
+    connect(m_slider, &QSlider::sliderReleased, this, [this] {
+        Q_EMIT sliderReleased(m_slider->value());
+    });
 }
 
 void SliderContainer::setTip(const QString &text, TitlePosition pos)

--- a/plugins/dde-dock/common/slidercontainer.h
+++ b/plugins/dde-dock/common/slidercontainer.h
@@ -71,6 +71,7 @@ Q_SIGNALS:
     void iconClicked(IconPosition pos);
     void sliderValueChanged(int value);
     void panelClicked();
+    void sliderReleased(int value);
 
 public slots:
     void updateSliderValue(int value);

--- a/plugins/dde-dock/sound/soundapplet.cpp
+++ b/plugins/dde-dock/sound/soundapplet.cpp
@@ -122,7 +122,7 @@ void SoundApplet::initConnections()
     connect(DGuiApplicationHelper::instance(), &DGuiApplicationHelper::themeTypeChanged, this, &SoundApplet::refreshIcon);
     connect(qApp, &DApplication::iconThemeChanged, this, &SoundApplet::refreshIcon);
 
-    connect(m_volumeSlider, &DockSlider::valueChanged, this, &SoundApplet::volumeSliderValueChanged);
+    connect(m_volumeSlider, &DockSlider::sliderReleased, this, &SoundApplet::volumeSliderValueChanged);
     connect(m_sliderContainer, &SliderContainer::iconClicked, this, [this](SliderContainer::IconPosition icon) {
         if (icon == SliderContainer::LeftIcon && SoundController::ref().existActiveOutputDevice() && m_defSinkInter) {
             m_defSinkInter->SetMuteQueued(!m_defSinkInter->mute());

--- a/plugins/dde-dock/sound/soundquickpanel.cpp
+++ b/plugins/dde-dock/sound/soundquickpanel.cpp
@@ -75,7 +75,7 @@ void SoundQuickPanel::initConnection()
         refreshWidget();
     });
 
-    connect(m_sliderContainer, &SliderContainer::sliderValueChanged, this, [this](int value) {
+    connect(m_sliderContainer, &SliderContainer::sliderReleased, this, [this](int value) {
         SoundController::ref().SetVolume(value * 0.01, true);
     });
     connect(&SoundModel::ref(), &SoundModel::activePortChanged, this, &SoundQuickPanel::refreshWidget);


### PR DESCRIPTION
as title

Log: as title
Pms: BUG-280645

## Summary by Sourcery

Modify sound slider behavior to emit a signal when the slider is released, enabling more precise volume control interactions

Bug Fixes:
- Fix volume control interaction by emitting a signal specifically when the sound slider is released, instead of on every value change

Enhancements:
- Improve sound slider interaction by adding a dedicated 'sliderReleased' signal to the SliderContainer class