### PR TITLE
fix: loss unread status for notification

### DIFF
--- a/plugins/dde-dock/configs/org.deepin.dde.dock.plugin.notification.json
+++ b/plugins/dde-dock/configs/org.deepin.dde.dock.plugin.notification.json
@@ -1,0 +1,17 @@
+{
+    "magic":"dsg.config.meta",
+    "version":"1.0",
+    "contents":{
+        "hasUnreadNotification": {
+          "value": false,
+          "serial": 0,
+          "flags": [],
+          "name": "has unread notifications",
+          "name[zh_CN]": "是否有未读通知",
+          "description": "has unread notifications for notification-center",
+          "description[zh_CN]": "是否有未读通知",
+          "permissions": "readwrite",
+          "visibility": "private"
+        }
+    }
+}

--- a/plugins/dde-dock/notification/CMakeLists.txt
+++ b/plugins/dde-dock/notification/CMakeLists.txt
@@ -32,3 +32,5 @@ target_link_libraries(${PLUGIN_NAME} PRIVATE
 
 install(TARGETS ${PLUGIN_NAME} LIBRARY DESTINATION lib/dde-dock/plugins)
 install(FILES "icons/dcc-notification.dci" DESTINATION share/dde-dock/icons/dcc-setting)
+
+dtk_add_config_meta_files(APPID org.deepin.dde.tray-loader FILES ../configs/org.deepin.dde.dock.plugin.notification.json)

--- a/plugins/dde-dock/notification/notification.h
+++ b/plugins/dde-dock/notification/notification.h
@@ -48,6 +48,7 @@ private Q_SLOTS:
     void onNotificationStateChanged(qint64 id, int processedType);
     void updateDndModeState();
     void onNotificationCenterVisibleChanged(bool visible);
+    void updateUnreadNotificationState();
 
 protected:
     void paintEvent(QPaintEvent *e) override;

--- a/src/loader/main.cpp
+++ b/src/loader/main.cpp
@@ -93,7 +93,7 @@ int main(int argc, char *argv[], char *envp[])
     oldEnvs["QT_WAYLAND_SHELL_INTEGRATION"] = qgetenv("QT_WAYLAND_SHELL_INTEGRATION");
     oldEnvs["QT_WAYLAND_RECONNECT"] = qgetenv("QT_WAYLAND_RECONNECT");
 
-    qputenv("DSG_APP_ID", "org.deepin.dde-tray-loader");
+    qputenv("DSG_APP_ID", "org.deepin.dde.tray-loader");
     qputenv("WAYLAND_DISPLAY", "dockplugin");
     qputenv("QT_WAYLAND_SHELL_INTEGRATION", "plugin-shell");
     qputenv("QT_WAYLAND_RECONNECT", "1");
@@ -109,7 +109,7 @@ int main(int argc, char *argv[], char *envp[])
 
     LoaderApplication app(argc, argv);
     app.setOrganizationName("deepin");
-    app.setApplicationName("org.deepin.dde-tray-loader");
+    app.setApplicationName("org.deepin.dde.tray-loader");
     app.setQuitOnLastWindowClosed(false);
 
     QList<QString> translateDirs;


### PR DESCRIPTION
Add DConfig to save the status.

pms: BUG-304965

## Summary by Sourcery

Implement persistent storage for notification unread status using DConfig

Bug Fixes:
- Preserve notification unread status across application restarts by using DConfig for storage

Enhancements:
- Add method to save and retrieve unread notification state
- Update application and loader identifiers to use more consistent naming