### PR TITLE
fix: close applet popup after bluetooth adaptor was removed

### DIFF
--- a/plugins/dde-dock/bluetooth/bluetoothplugin.cpp
+++ b/plugins/dde-dock/bluetooth/bluetoothplugin.cpp
@@ -160,9 +160,13 @@ void BluetoothPlugin::refreshPluginItemsVisible()
     if(!m_proxyInter)
         return;
 
-    if (pluginIsDisable() || !m_enableState)
+    if (pluginIsDisable() || !m_enableState) {
         m_proxyInter->itemRemoved(this, BLUETOOTH_KEY);
-    else
+        auto popupWidget = m_bluetoothItem->popupApplet();
+        if (popupWidget && popupWidget->isVisible()) {
+            popupWidget->setVisible(false);
+        }
+    } else
         m_proxyInter->itemAdded(this, BLUETOOTH_KEY);
 }
 


### PR DESCRIPTION
as title

Log: as title
Pms: BUG- 285035

## Summary by Sourcery

Bug Fixes:
- Close the Bluetooth applet popup when the underlying adapter is removed or the plugin is disabled.