### PR TITLE
fix: airplane mode not clickable in bluetooth applet

### DIFF
--- a/plugins/dde-dock/CMakeLists.txt
+++ b/plugins/dde-dock/CMakeLists.txt
@@ -21,9 +21,19 @@ if (NOT (${CMAKE_BUILD_TYPE} MATCHES "Debug"))
 endif ()
 
 ## qm files
-file(GLOB TS_FILES "translations/*.ts")
-qt_add_translation(QM_FILES ${TS_FILES})
-add_custom_target(dde-dock_language ALL DEPENDS ${QM_FILES})
+file(GLOB DOCK_TS_FILES "translations/*.ts")
+file(GLOB_RECURSE CPP_SOURCE_FILES "*.cpp" "*.h")
+
+qt_add_lupdate(
+    TS_FILES ${DOCK_TS_FILES}
+    SOURCES ${CPP_SOURCE_FILES}
+    OPTIONS -no-obsolete -no-ui-lines -locations none
+)
+
+qt_add_lrelease(
+    TS_FILES ${DOCK_TS_FILES}
+    QM_FILES_OUTPUT_VARIABLE QM_FILES
+)
 
 install(FILES ${QM_FILES}
     DESTINATION ${CMAKE_INSTALL_DATADIR}/dde-dock/translations)

--- a/plugins/dde-dock/bluetooth/componments/bluetoothapplet.cpp
+++ b/plugins/dde-dock/bluetooth/componments/bluetoothapplet.cpp
@@ -243,7 +243,8 @@ void BluetoothApplet::initUi()
     airplaneLayout->setContentsMargins(20, 0, 10, 0);
     airplaneLayout->setSpacing(0);
     m_airplaneModeLabel->setAlignment(Qt::AlignLeft | Qt::AlignTop);
-    m_airplaneModeLabel->setText(tr("Disable Airplane Mode first if you want to connect to a Bluetooth"));
+    m_airplaneModeLabel->setText(tr("Disable [Airplane Mode](#) first if you want to connect to a Bluetooth"));
+    m_airplaneModeLabel->setTextFormat(Qt::MarkdownText);
     m_airplaneModeLabel->setWordWrap(true);
     DFontSizeManager::instance()->bind(m_airplaneModeLabel, DFontSizeManager::T8);
     airplaneLayout->addWidget(m_airplaneModeLabel, 0, Qt::AlignTop);
@@ -311,7 +312,7 @@ void BluetoothApplet::initConnect()
                 .interface("org.deepin.dde.ControlCenter1")
                 .method(QString("ShowPage"))
                 .arg(QString("network"))
-                //.arg(QString("Airplane Mode"))
+                .arg(QString("airplaneMode"))
                 .call();
         Q_EMIT requestHideApplet();
     });

--- a/plugins/dde-dock/translations/dde-dock.ts
+++ b/plugins/dde-dock/translations/dde-dock.ts
@@ -53,7 +53,7 @@
         <translation type="unfinished">Turned off</translation>
     </message>
     <message>
-        <source>Disable Airplane Mode first if you want to connect to a Bluetooth</source>
+        <source>Disable [Airplane Mode](#) first if you want to connect to a Bluetooth</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -385,61 +385,6 @@
     <message>
         <source>Theme</source>
         <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>MenuWorker</name>
-    <message>
-        <source>Fashion Mode</source>
-        <translation>Fashion Mode</translation>
-    </message>
-    <message>
-        <source>Efficient Mode</source>
-        <translation>Efficient Mode</translation>
-    </message>
-    <message>
-        <source>Top</source>
-        <translation>Top</translation>
-    </message>
-    <message>
-        <source>Bottom</source>
-        <translation>Bottom</translation>
-    </message>
-    <message>
-        <source>Left</source>
-        <translation>Left</translation>
-    </message>
-    <message>
-        <source>Right</source>
-        <translation>Right</translation>
-    </message>
-    <message>
-        <source>Keep Shown</source>
-        <translation>Keep Shown</translation>
-    </message>
-    <message>
-        <source>Keep Hidden</source>
-        <translation>Keep Hidden</translation>
-    </message>
-    <message>
-        <source>Smart Hide</source>
-        <translation>Smart Hide</translation>
-    </message>
-    <message>
-        <source>Mode</source>
-        <translation>Mode</translation>
-    </message>
-    <message>
-        <source>Location</source>
-        <translation>Location</translation>
-    </message>
-    <message>
-        <source>Status</source>
-        <translation>Status</translation>
-    </message>
-    <message>
-        <source>Dock settings</source>
-        <translation>Dock settings</translation>
     </message>
 </context>
 <context>

--- a/plugins/dde-dock/translations/dde-dock_ady.ts
+++ b/plugins/dde-dock/translations/dde-dock_ady.ts
@@ -53,7 +53,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Disable Airplane Mode first if you want to connect to a Bluetooth</source>
+        <source>Disable [Airplane Mode](#) first if you want to connect to a Bluetooth</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -384,61 +384,6 @@
     </message>
     <message>
         <source>Theme</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>MenuWorker</name>
-    <message>
-        <source>Fashion Mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Efficient Mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Top</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Bottom</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Left</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Right</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Keep Shown</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Keep Hidden</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Smart Hide</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Location</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Status</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Dock settings</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/plugins/dde-dock/translations/dde-dock_af.ts
+++ b/plugins/dde-dock/translations/dde-dock_af.ts
@@ -53,7 +53,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Disable Airplane Mode first if you want to connect to a Bluetooth</source>
+        <source>Disable [Airplane Mode](#) first if you want to connect to a Bluetooth</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -384,61 +384,6 @@
     </message>
     <message>
         <source>Theme</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>MenuWorker</name>
-    <message>
-        <source>Fashion Mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Efficient Mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Top</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Bottom</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Left</source>
-        <translation>Links</translation>
-    </message>
-    <message>
-        <source>Right</source>
-        <translation>Regs</translation>
-    </message>
-    <message>
-        <source>Keep Shown</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Keep Hidden</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Smart Hide</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Mode</source>
-        <translation>Modus</translation>
-    </message>
-    <message>
-        <source>Location</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Status</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Dock settings</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/plugins/dde-dock/translations/dde-dock_af_ZA.ts
+++ b/plugins/dde-dock/translations/dde-dock_af_ZA.ts
@@ -53,7 +53,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Disable Airplane Mode first if you want to connect to a Bluetooth</source>
+        <source>Disable [Airplane Mode](#) first if you want to connect to a Bluetooth</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -384,61 +384,6 @@
     </message>
     <message>
         <source>Theme</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>MenuWorker</name>
-    <message>
-        <source>Fashion Mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Efficient Mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Top</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Bottom</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Left</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Right</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Keep Shown</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Keep Hidden</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Smart Hide</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Location</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Status</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Dock settings</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/plugins/dde-dock/translations/dde-dock_am.ts
+++ b/plugins/dde-dock/translations/dde-dock_am.ts
@@ -53,7 +53,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Disable Airplane Mode first if you want to connect to a Bluetooth</source>
+        <source>Disable [Airplane Mode](#) first if you want to connect to a Bluetooth</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -384,61 +384,6 @@
     </message>
     <message>
         <source>Theme</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>MenuWorker</name>
-    <message>
-        <source>Fashion Mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Efficient Mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Top</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Bottom</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Left</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Right</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Keep Shown</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Keep Hidden</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Smart Hide</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Location</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Status</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Dock settings</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/plugins/dde-dock/translations/dde-dock_am_ET.ts
+++ b/plugins/dde-dock/translations/dde-dock_am_ET.ts
@@ -53,7 +53,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Disable Airplane Mode first if you want to connect to a Bluetooth</source>
+        <source>Disable [Airplane Mode](#) first if you want to connect to a Bluetooth</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -384,61 +384,6 @@
     </message>
     <message>
         <source>Theme</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>MenuWorker</name>
-    <message>
-        <source>Fashion Mode</source>
-        <translation>በ ዘመናዊ ዘዴ</translation>
-    </message>
-    <message>
-        <source>Efficient Mode</source>
-        <translation>በ አጥጋቢ ዘዴ</translation>
-    </message>
-    <message>
-        <source>Top</source>
-        <translation>ከ ላይ</translation>
-    </message>
-    <message>
-        <source>Bottom</source>
-        <translation>ከ ታች</translation>
-    </message>
-    <message>
-        <source>Left</source>
-        <translation>የ ግራ</translation>
-    </message>
-    <message>
-        <source>Right</source>
-        <translation>የ ቀኝ</translation>
-    </message>
-    <message>
-        <source>Keep Shown</source>
-        <translation>እንደ ታየ ማቆያ</translation>
-    </message>
-    <message>
-        <source>Keep Hidden</source>
-        <translation>እንደ ተደበቅ ማቆያ</translation>
-    </message>
-    <message>
-        <source>Smart Hide</source>
-        <translation>በራሱ መደበቂያ</translation>
-    </message>
-    <message>
-        <source>Mode</source>
-        <translation>ዘዴ</translation>
-    </message>
-    <message>
-        <source>Location</source>
-        <translation>አካባቢ</translation>
-    </message>
-    <message>
-        <source>Status</source>
-        <translation>ሁኔታው</translation>
-    </message>
-    <message>
-        <source>Dock settings</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/plugins/dde-dock/translations/dde-dock_ar.ts
+++ b/plugins/dde-dock/translations/dde-dock_ar.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="ar">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ar">
 <context>
     <name>AirplaneModeItem</name>
     <message>
@@ -51,8 +53,8 @@
         <translation>أطفئ</translation>
     </message>
     <message>
-        <source>Disable Airplane Mode first if you want to connect to a Bluetooth</source>
-        <translation>قم بقفل وضع الطائرة أولاً إذا كنت ترغب في الاتصال بلوحة بلوتوث</translation>
+        <source>Disable [Airplane Mode](#) first if you want to connect to a Bluetooth</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -383,61 +385,6 @@
     <message>
         <source>Theme</source>
         <translation>المظهر</translation>
-    </message>
-</context>
-<context>
-    <name>MenuWorker</name>
-    <message>
-        <source>Fashion Mode</source>
-        <translation>النمط الحداثي</translation>
-    </message>
-    <message>
-        <source>Efficient Mode</source>
-        <translation>النمط الفعال</translation>
-    </message>
-    <message>
-        <source>Top</source>
-        <translation>أعلى</translation>
-    </message>
-    <message>
-        <source>Bottom</source>
-        <translation>أسفل</translation>
-    </message>
-    <message>
-        <source>Left</source>
-        <translation>يسار</translation>
-    </message>
-    <message>
-        <source>Right</source>
-        <translation>يمين</translation>
-    </message>
-    <message>
-        <source>Keep Shown</source>
-        <translation>اﻹبقاء ظاهراً</translation>
-    </message>
-    <message>
-        <source>Keep Hidden</source>
-        <translation>الإبقاء مخفياً</translation>
-    </message>
-    <message>
-        <source>Smart Hide</source>
-        <translation>إخفاء ذكي</translation>
-    </message>
-    <message>
-        <source>Mode</source>
-        <translation>النمط</translation>
-    </message>
-    <message>
-        <source>Location</source>
-        <translation>الموقع</translation>
-    </message>
-    <message>
-        <source>Status</source>
-        <translation>الحالة</translation>
-    </message>
-    <message>
-        <source>Dock settings</source>
-        <translation>إعدادات الرصيف</translation>
     </message>
 </context>
 <context>

--- a/plugins/dde-dock/translations/dde-dock_ar_EG.ts
+++ b/plugins/dde-dock/translations/dde-dock_ar_EG.ts
@@ -53,7 +53,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Disable Airplane Mode first if you want to connect to a Bluetooth</source>
+        <source>Disable [Airplane Mode](#) first if you want to connect to a Bluetooth</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -384,61 +384,6 @@
     </message>
     <message>
         <source>Theme</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>MenuWorker</name>
-    <message>
-        <source>Fashion Mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Efficient Mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Top</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Bottom</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Left</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Right</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Keep Shown</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Keep Hidden</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Smart Hide</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Location</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Status</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Dock settings</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/plugins/dde-dock/translations/dde-dock_az.ts
+++ b/plugins/dde-dock/translations/dde-dock_az.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="az">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="az">
 <context>
     <name>AirplaneModeItem</name>
     <message>
@@ -51,8 +53,8 @@
         <translation>Söndürülüb</translation>
     </message>
     <message>
-        <source>Disable Airplane Mode first if you want to connect to a Bluetooth</source>
-        <translation>Bluetooth-a qatıla bilərsiz Airplane Modunu ilk olaraq söndürün</translation>
+        <source>Disable [Airplane Mode](#) first if you want to connect to a Bluetooth</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -383,61 +385,6 @@
     <message>
         <source>Theme</source>
         <translation>Görünüş mövzusu</translation>
-    </message>
-</context>
-<context>
-    <name>MenuWorker</name>
-    <message>
-        <source>Fashion Mode</source>
-        <translation>Müasir rejim</translation>
-    </message>
-    <message>
-        <source>Efficient Mode</source>
-        <translation>Səmərəli rejim</translation>
-    </message>
-    <message>
-        <source>Top</source>
-        <translation>Yuxarı</translation>
-    </message>
-    <message>
-        <source>Bottom</source>
-        <translation>Aşağı</translation>
-    </message>
-    <message>
-        <source>Left</source>
-        <translation>Sol</translation>
-    </message>
-    <message>
-        <source>Right</source>
-        <translation>Sağ</translation>
-    </message>
-    <message>
-        <source>Keep Shown</source>
-        <translation>Görünsün</translation>
-    </message>
-    <message>
-        <source>Keep Hidden</source>
-        <translation>Gizlədilsin</translation>
-    </message>
-    <message>
-        <source>Smart Hide</source>
-        <translation>Ağıllı gizlətmə</translation>
-    </message>
-    <message>
-        <source>Mode</source>
-        <translation>Rejim</translation>
-    </message>
-    <message>
-        <source>Location</source>
-        <translation>Yerləşmə</translation>
-    </message>
-    <message>
-        <source>Status</source>
-        <translation>Vəziyyəti</translation>
-    </message>
-    <message>
-        <source>Dock settings</source>
-        <translation>Dok panel ayarları</translation>
     </message>
 </context>
 <context>

--- a/plugins/dde-dock/translations/dde-dock_bg.ts
+++ b/plugins/dde-dock/translations/dde-dock_bg.ts
@@ -53,7 +53,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Disable Airplane Mode first if you want to connect to a Bluetooth</source>
+        <source>Disable [Airplane Mode](#) first if you want to connect to a Bluetooth</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -384,61 +384,6 @@
     </message>
     <message>
         <source>Theme</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>MenuWorker</name>
-    <message>
-        <source>Fashion Mode</source>
-        <translation>Модерен режим</translation>
-    </message>
-    <message>
-        <source>Efficient Mode</source>
-        <translation>Ефективен режим</translation>
-    </message>
-    <message>
-        <source>Top</source>
-        <translation>Отгоре</translation>
-    </message>
-    <message>
-        <source>Bottom</source>
-        <translation>Отдолу</translation>
-    </message>
-    <message>
-        <source>Left</source>
-        <translation>Ляво</translation>
-    </message>
-    <message>
-        <source>Right</source>
-        <translation>Дясно</translation>
-    </message>
-    <message>
-        <source>Keep Shown</source>
-        <translation>Показвай</translation>
-    </message>
-    <message>
-        <source>Keep Hidden</source>
-        <translation>Скрий</translation>
-    </message>
-    <message>
-        <source>Smart Hide</source>
-        <translation>Интелигентно скриване</translation>
-    </message>
-    <message>
-        <source>Mode</source>
-        <translation>Режим</translation>
-    </message>
-    <message>
-        <source>Location</source>
-        <translation>Местоположение</translation>
-    </message>
-    <message>
-        <source>Status</source>
-        <translation>Статус</translation>
-    </message>
-    <message>
-        <source>Dock settings</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/plugins/dde-dock/translations/dde-dock_bn.ts
+++ b/plugins/dde-dock/translations/dde-dock_bn.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="bn">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="bn">
 <context>
     <name>AirplaneModeItem</name>
     <message>
@@ -51,8 +53,8 @@
         <translation>অ্যাক্টিভ হয়নি</translation>
     </message>
     <message>
-        <source>Disable Airplane Mode first if you want to connect to a Bluetooth</source>
-        <translation>ব্লুটুথে সংযোগ করতে প্রথমে অ্যায়েন্ডার মোড দেক্টি করুন</translation>
+        <source>Disable [Airplane Mode](#) first if you want to connect to a Bluetooth</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -386,61 +388,6 @@
     </message>
 </context>
 <context>
-    <name>MenuWorker</name>
-    <message>
-        <source>Fashion Mode</source>
-        <translation>ফ্যাশন মোড</translation>
-    </message>
-    <message>
-        <source>Efficient Mode</source>
-        <translation>দক্ষ মোড</translation>
-    </message>
-    <message>
-        <source>Top</source>
-        <translation>শীর্ষ</translation>
-    </message>
-    <message>
-        <source>Bottom</source>
-        <translation>তলা</translation>
-    </message>
-    <message>
-        <source>Left</source>
-        <translation>বাম</translation>
-    </message>
-    <message>
-        <source>Right</source>
-        <translation>ডান</translation>
-    </message>
-    <message>
-        <source>Keep Shown</source>
-        <translation>দেখিয়ে রাখুন</translation>
-    </message>
-    <message>
-        <source>Keep Hidden</source>
-        <translation>লুকিয়ে রাখুন</translation>
-    </message>
-    <message>
-        <source>Smart Hide</source>
-        <translation>স্মার্টভাবে লুকান</translation>
-    </message>
-    <message>
-        <source>Mode</source>
-        <translation>মোড</translation>
-    </message>
-    <message>
-        <source>Location</source>
-        <translation>অবস্থান</translation>
-    </message>
-    <message>
-        <source>Status</source>
-        <translation>অবস্থা</translation>
-    </message>
-    <message>
-        <source>Dock settings</source>
-        <translation>ডক সেটিংস</translation>
-    </message>
-</context>
-<context>
     <name>NotificationPlugin</name>
     <message>
         <source>No messages</source>
@@ -603,7 +550,7 @@
     <name>PowerStatusWidget</name>
     <message>
         <source>Power settings</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">পাওয়ার সেটিংস</translation>
     </message>
 </context>
 <context>

--- a/plugins/dde-dock/translations/dde-dock_bo.ts
+++ b/plugins/dde-dock/translations/dde-dock_bo.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="bo">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="bo">
 <context>
     <name>AirplaneModeItem</name>
     <message>
@@ -51,8 +53,8 @@
         <translation>སོ་སྔོན་ཁ་རྒྱོབ།</translation>
     </message>
     <message>
-        <source>Disable Airplane Mode first if you want to connect to a Bluetooth</source>
-        <translation type="unfinished"/>
+        <source>Disable [Airplane Mode](#) first if you want to connect to a Bluetooth</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -386,61 +388,6 @@
     </message>
 </context>
 <context>
-    <name>MenuWorker</name>
-    <message>
-        <source>Fashion Mode</source>
-        <translation>དར་སྲོལ་དཔེ་རྣམ།</translation>
-    </message>
-    <message>
-        <source>Efficient Mode</source>
-        <translation>ལས་ཆོད་ཆེ་བའི་དཔེ་རྣམ།</translation>
-    </message>
-    <message>
-        <source>Top</source>
-        <translation>གོང་།</translation>
-    </message>
-    <message>
-        <source>Bottom</source>
-        <translation>འོག</translation>
-    </message>
-    <message>
-        <source>Left</source>
-        <translation>གཡོན།</translation>
-    </message>
-    <message>
-        <source>Right</source>
-        <translation>གཡས།</translation>
-    </message>
-    <message>
-        <source>Keep Shown</source>
-        <translation>རྟག་ཏུ་མངོན་སྟོན་བྱེད།</translation>
-    </message>
-    <message>
-        <source>Keep Hidden</source>
-        <translation>རྟག་ཏུ་ཡིབ་པ།</translation>
-    </message>
-    <message>
-        <source>Smart Hide</source>
-        <translation>རིག་ནུས་གབ་ཡིབ།</translation>
-    </message>
-    <message>
-        <source>Mode</source>
-        <translation>དཔེ་རྣམ།</translation>
-    </message>
-    <message>
-        <source>Location</source>
-        <translation>གནས་ས།</translation>
-    </message>
-    <message>
-        <source>Status</source>
-        <translation>རྣམ་པ།</translation>
-    </message>
-    <message>
-        <source>Dock settings</source>
-        <translation>ལས་འགན་ཚན་བྱང་སྒྲིག་འགོད།</translation>
-    </message>
-</context>
-<context>
     <name>NotificationPlugin</name>
     <message>
         <source>No messages</source>
@@ -494,7 +441,7 @@
     </message>
     <message>
         <source>Balance Performance</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/plugins/dde-dock/translations/dde-dock_br.ts
+++ b/plugins/dde-dock/translations/dde-dock_br.ts
@@ -53,7 +53,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Disable Airplane Mode first if you want to connect to a Bluetooth</source>
+        <source>Disable [Airplane Mode](#) first if you want to connect to a Bluetooth</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -384,61 +384,6 @@
     </message>
     <message>
         <source>Theme</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>MenuWorker</name>
-    <message>
-        <source>Fashion Mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Efficient Mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Top</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Bottom</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Left</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Right</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Keep Shown</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Keep Hidden</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Smart Hide</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Location</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Status</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Dock settings</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/plugins/dde-dock/translations/dde-dock_ca.ts
+++ b/plugins/dde-dock/translations/dde-dock_ca.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="ca">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ca">
 <context>
     <name>AirplaneModeItem</name>
     <message>
@@ -51,8 +53,8 @@
         <translation>Apagat</translation>
     </message>
     <message>
-        <source>Disable Airplane Mode first if you want to connect to a Bluetooth</source>
-        <translation>Desactiveu primer el mode d&apos;avió si voleu fer una connexió per bluetooth.</translation>
+        <source>Disable [Airplane Mode](#) first if you want to connect to a Bluetooth</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -383,61 +385,6 @@
     <message>
         <source>Theme</source>
         <translation>Tema</translation>
-    </message>
-</context>
-<context>
-    <name>MenuWorker</name>
-    <message>
-        <source>Fashion Mode</source>
-        <translation>Mode de moda</translation>
-    </message>
-    <message>
-        <source>Efficient Mode</source>
-        <translation>Mode eficient</translation>
-    </message>
-    <message>
-        <source>Top</source>
-        <translation>A dalt</translation>
-    </message>
-    <message>
-        <source>Bottom</source>
-        <translation>A baix</translation>
-    </message>
-    <message>
-        <source>Left</source>
-        <translation>A l&apos;esquerra</translation>
-    </message>
-    <message>
-        <source>Right</source>
-        <translation>A la dreta</translation>
-    </message>
-    <message>
-        <source>Keep Shown</source>
-        <translation>Mantén-ho visible</translation>
-    </message>
-    <message>
-        <source>Keep Hidden</source>
-        <translation>Mantén ocult</translation>
-    </message>
-    <message>
-        <source>Smart Hide</source>
-        <translation>Ocultació intel·ligent</translation>
-    </message>
-    <message>
-        <source>Mode</source>
-        <translation>Mode</translation>
-    </message>
-    <message>
-        <source>Location</source>
-        <translation>Ubicació</translation>
-    </message>
-    <message>
-        <source>Status</source>
-        <translation>Estat</translation>
-    </message>
-    <message>
-        <source>Dock settings</source>
-        <translation>Paràmetres de l&apos;acoblador</translation>
     </message>
 </context>
 <context>

--- a/plugins/dde-dock/translations/dde-dock_cgg.ts
+++ b/plugins/dde-dock/translations/dde-dock_cgg.ts
@@ -53,7 +53,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Disable Airplane Mode first if you want to connect to a Bluetooth</source>
+        <source>Disable [Airplane Mode](#) first if you want to connect to a Bluetooth</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -384,61 +384,6 @@
     </message>
     <message>
         <source>Theme</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>MenuWorker</name>
-    <message>
-        <source>Fashion Mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Efficient Mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Top</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Bottom</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Left</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Right</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Keep Shown</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Keep Hidden</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Smart Hide</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Location</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Status</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Dock settings</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/plugins/dde-dock/translations/dde-dock_cs.ts
+++ b/plugins/dde-dock/translations/dde-dock_cs.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="cs">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="cs">
 <context>
     <name>AirplaneModeItem</name>
     <message>
@@ -37,7 +39,7 @@
     <name>BluetoothAdapterItem</name>
     <message>
         <source>My Devices</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -51,8 +53,8 @@
         <translation>Vypnuto</translation>
     </message>
     <message>
-        <source>Disable Airplane Mode first if you want to connect to a Bluetooth</source>
-        <translation type="unfinished"/>
+        <source>Disable [Airplane Mode](#) first if you want to connect to a Bluetooth</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -87,7 +89,7 @@
     </message>
     <message>
         <source>Connected %1</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Not connected</source>
@@ -109,25 +111,25 @@
     <name>BrightnessApplet</name>
     <message>
         <source>Brightness</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Display settings</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>BrightnessItem</name>
     <message>
         <source>Display settings</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>BrightnessPlugin</name>
     <message>
         <source>Brightness</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -188,7 +190,7 @@
     </message>
     <message>
         <source>Open the calendar</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -254,7 +256,7 @@
     <name>DeviceControlWidget</name>
     <message>
         <source>Other Devices</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -307,164 +309,109 @@
     </message>
     <message>
         <source>Display settings</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Eye comfort</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Theme</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>On</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Off</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Vypnuto</translation>
     </message>
     <message>
         <source>Light</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Dark</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Auto</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Disable eye comfort</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Enable eye comfort</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Display Settings</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Theme: Light</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Theme: Dark</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Theme: Auto</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Visual effect</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>EyeComfortmodeApplet</name>
     <message>
         <source>Light</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Dark</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Auto</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Theme</source>
-        <translation type="unfinished"/>
-    </message>
-</context>
-<context>
-    <name>MenuWorker</name>
-    <message>
-        <source>Fashion Mode</source>
-        <translation>Líbivý režim</translation>
-    </message>
-    <message>
-        <source>Efficient Mode</source>
-        <translation>Účelný režim</translation>
-    </message>
-    <message>
-        <source>Top</source>
-        <translation>Nahoře</translation>
-    </message>
-    <message>
-        <source>Bottom</source>
-        <translation>Dole</translation>
-    </message>
-    <message>
-        <source>Left</source>
-        <translation>Vlevo</translation>
-    </message>
-    <message>
-        <source>Right</source>
-        <translation>Vpravo</translation>
-    </message>
-    <message>
-        <source>Keep Shown</source>
-        <translation>Vždy zobrazeno</translation>
-    </message>
-    <message>
-        <source>Keep Hidden</source>
-        <translation>Vždy skryto</translation>
-    </message>
-    <message>
-        <source>Smart Hide</source>
-        <translation>Chytré skrývání</translation>
-    </message>
-    <message>
-        <source>Mode</source>
-        <translation>Režim</translation>
-    </message>
-    <message>
-        <source>Location</source>
-        <translation>Umístění</translation>
-    </message>
-    <message>
-        <source>Status</source>
-        <translation>Stav</translation>
-    </message>
-    <message>
-        <source>Dock settings</source>
-        <translation>Nastavení panelu</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>NotificationPlugin</name>
     <message>
         <source>No messages</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Notification settings</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Notifications</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Turn off DND mode</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Turn on DND mode</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Notification</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -482,26 +429,26 @@
     <name>PerformanceModeController</name>
     <message>
         <source>High Performance</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Balanced</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Power Saver</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Balance Performance</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>PowerApplet</name>
     <message>
         <source>Power</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -552,58 +499,58 @@
     </message>
     <message>
         <source>Charging, calculating estimated charging time</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Calculating remaining usage time</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>%1 min remaining</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>%1 hr %2 min remaining</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Not charging</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Fully charged</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Charging, %1 min until full</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Charging, %1 hr %2 min until full</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Capacity %1, %2 hr remaining</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>%1 hr remaining</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Charging %1, %2 hr until full</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Charging, %1 hr until full</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>PowerStatusWidget</name>
     <message>
         <source>Power settings</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Nastavení správy napájení</translation>
     </message>
 </context>
 <context>
@@ -614,7 +561,7 @@
     </message>
     <message>
         <source>Unknown</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -657,142 +604,142 @@
     </message>
     <message>
         <source>Shut Down</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Switch user</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>SidebarCalendarWidget</name>
     <message>
         <source>Today</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Lunar</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>y</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>m</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>d</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Monday</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">pondělí</translation>
     </message>
     <message>
         <source>Tuesday</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">úterý</translation>
     </message>
     <message>
         <source>Wednesday</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">středa</translation>
     </message>
     <message>
         <source>Thursday</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">čtvrtek</translation>
     </message>
     <message>
         <source>Friday</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">pátek</translation>
     </message>
     <message>
         <source>Saturday</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">sobota</translation>
     </message>
     <message>
         <source>Sunday</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">neděle</translation>
     </message>
     <message>
         <source>Jan</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Feb</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Mar</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Apr</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>May</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Jun</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Jul</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Aug</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Sept</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Oct</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Nov</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Dec</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Open the calendar</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>monday</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">pondělí</translation>
     </message>
     <message>
         <source>tuesday</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">úterý</translation>
     </message>
     <message>
         <source>wednesday</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">středa</translation>
     </message>
     <message>
         <source>thursday</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">čtvrtek</translation>
     </message>
     <message>
         <source>friday</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">pátek</translation>
     </message>
     <message>
         <source>saturday</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">sobota</translation>
     </message>
     <message>
         <source>sunday</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">neděle</translation>
     </message>
 </context>
 <context>

--- a/plugins/dde-dock/translations/dde-dock_da.ts
+++ b/plugins/dde-dock/translations/dde-dock_da.ts
@@ -53,7 +53,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Disable Airplane Mode first if you want to connect to a Bluetooth</source>
+        <source>Disable [Airplane Mode](#) first if you want to connect to a Bluetooth</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -384,61 +384,6 @@
     </message>
     <message>
         <source>Theme</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>MenuWorker</name>
-    <message>
-        <source>Fashion Mode</source>
-        <translation>Fashion-tilstand</translation>
-    </message>
-    <message>
-        <source>Efficient Mode</source>
-        <translation>Effektiv tilstand</translation>
-    </message>
-    <message>
-        <source>Top</source>
-        <translation>Øverst</translation>
-    </message>
-    <message>
-        <source>Bottom</source>
-        <translation>Nederst</translation>
-    </message>
-    <message>
-        <source>Left</source>
-        <translation>Venstre</translation>
-    </message>
-    <message>
-        <source>Right</source>
-        <translation>Højre</translation>
-    </message>
-    <message>
-        <source>Keep Shown</source>
-        <translation>Hold vist</translation>
-    </message>
-    <message>
-        <source>Keep Hidden</source>
-        <translation>Hold skjult</translation>
-    </message>
-    <message>
-        <source>Smart Hide</source>
-        <translation>Smart skjul</translation>
-    </message>
-    <message>
-        <source>Mode</source>
-        <translation>Tilstand</translation>
-    </message>
-    <message>
-        <source>Location</source>
-        <translation>Placering</translation>
-    </message>
-    <message>
-        <source>Status</source>
-        <translation>Status</translation>
-    </message>
-    <message>
-        <source>Dock settings</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/plugins/dde-dock/translations/dde-dock_de.ts
+++ b/plugins/dde-dock/translations/dde-dock_de.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="de">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="de">
 <context>
     <name>AirplaneModeItem</name>
     <message>
@@ -51,8 +53,8 @@
         <translation>Ausgeschaltet</translation>
     </message>
     <message>
-        <source>Disable Airplane Mode first if you want to connect to a Bluetooth</source>
-        <translation type="unfinished"/>
+        <source>Disable [Airplane Mode](#) first if you want to connect to a Bluetooth</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -386,61 +388,6 @@
     </message>
 </context>
 <context>
-    <name>MenuWorker</name>
-    <message>
-        <source>Fashion Mode</source>
-        <translation>Design-Modus</translation>
-    </message>
-    <message>
-        <source>Efficient Mode</source>
-        <translation>Effizienzmodus</translation>
-    </message>
-    <message>
-        <source>Top</source>
-        <translation>Oben</translation>
-    </message>
-    <message>
-        <source>Bottom</source>
-        <translation>Unten</translation>
-    </message>
-    <message>
-        <source>Left</source>
-        <translation>Links</translation>
-    </message>
-    <message>
-        <source>Right</source>
-        <translation>Rechts</translation>
-    </message>
-    <message>
-        <source>Keep Shown</source>
-        <translation>Angezeigt lassen</translation>
-    </message>
-    <message>
-        <source>Keep Hidden</source>
-        <translation>Ausgeblendet lassen</translation>
-    </message>
-    <message>
-        <source>Smart Hide</source>
-        <translation>Intelligentes Ausblenden</translation>
-    </message>
-    <message>
-        <source>Mode</source>
-        <translation>Modus</translation>
-    </message>
-    <message>
-        <source>Location</source>
-        <translation>Ort</translation>
-    </message>
-    <message>
-        <source>Status</source>
-        <translation>Status</translation>
-    </message>
-    <message>
-        <source>Dock settings</source>
-        <translation>Dock-Einstellungen</translation>
-    </message>
-</context>
-<context>
     <name>NotificationPlugin</name>
     <message>
         <source>No messages</source>
@@ -494,14 +441,14 @@
     </message>
     <message>
         <source>Balance Performance</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>PowerApplet</name>
     <message>
         <source>Power</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -803,7 +750,7 @@
     </message>
     <message>
         <source>Output</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Sound settings</source>

--- a/plugins/dde-dock/translations/dde-dock_de_CH.ts
+++ b/plugins/dde-dock/translations/dde-dock_de_CH.ts
@@ -53,7 +53,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Disable Airplane Mode first if you want to connect to a Bluetooth</source>
+        <source>Disable [Airplane Mode](#) first if you want to connect to a Bluetooth</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -384,61 +384,6 @@
     </message>
     <message>
         <source>Theme</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>MenuWorker</name>
-    <message>
-        <source>Fashion Mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Efficient Mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Top</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Bottom</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Left</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Right</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Keep Shown</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Keep Hidden</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Smart Hide</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Location</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Status</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Dock settings</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/plugins/dde-dock/translations/dde-dock_de_DE.ts
+++ b/plugins/dde-dock/translations/dde-dock_de_DE.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="de_DE">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="de_DE">
 <context>
     <name>AirplaneModeItem</name>
     <message>
@@ -51,8 +53,8 @@
         <translation>Ausgeschaltet</translation>
     </message>
     <message>
-        <source>Disable Airplane Mode first if you want to connect to a Bluetooth</source>
-        <translation type="unfinished"/>
+        <source>Disable [Airplane Mode](#) first if you want to connect to a Bluetooth</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -386,61 +388,6 @@
     </message>
 </context>
 <context>
-    <name>MenuWorker</name>
-    <message>
-        <source>Fashion Mode</source>
-        <translation>Design-Modus</translation>
-    </message>
-    <message>
-        <source>Efficient Mode</source>
-        <translation>Effizienzmodus</translation>
-    </message>
-    <message>
-        <source>Top</source>
-        <translation>Oben</translation>
-    </message>
-    <message>
-        <source>Bottom</source>
-        <translation>nten</translation>
-    </message>
-    <message>
-        <source>Left</source>
-        <translation>Links</translation>
-    </message>
-    <message>
-        <source>Right</source>
-        <translation>Rechts</translation>
-    </message>
-    <message>
-        <source>Keep Shown</source>
-        <translation>Angezeigt lassen</translation>
-    </message>
-    <message>
-        <source>Keep Hidden</source>
-        <translation>Immer ausblenden</translation>
-    </message>
-    <message>
-        <source>Smart Hide</source>
-        <translation>Schlaues Ausblenden</translation>
-    </message>
-    <message>
-        <source>Mode</source>
-        <translation>Modus</translation>
-    </message>
-    <message>
-        <source>Location</source>
-        <translation>Ort</translation>
-    </message>
-    <message>
-        <source>Status</source>
-        <translation>Status</translation>
-    </message>
-    <message>
-        <source>Dock settings</source>
-        <translation>Dock-Einstellungen</translation>
-    </message>
-</context>
-<context>
     <name>NotificationPlugin</name>
     <message>
         <source>No messages</source>
@@ -494,7 +441,7 @@
     </message>
     <message>
         <source>Balance Performance</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/plugins/dde-dock/translations/dde-dock_el.ts
+++ b/plugins/dde-dock/translations/dde-dock_el.ts
@@ -53,7 +53,7 @@
         <translation type="unfinished">Απενεργοποιήθηκε</translation>
     </message>
     <message>
-        <source>Disable Airplane Mode first if you want to connect to a Bluetooth</source>
+        <source>Disable [Airplane Mode](#) first if you want to connect to a Bluetooth</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -384,61 +384,6 @@
     </message>
     <message>
         <source>Theme</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>MenuWorker</name>
-    <message>
-        <source>Fashion Mode</source>
-        <translation>Μοντέρνα λειτουργία</translation>
-    </message>
-    <message>
-        <source>Efficient Mode</source>
-        <translation>Αποτελεσματική λειτουργία</translation>
-    </message>
-    <message>
-        <source>Top</source>
-        <translation>Πάνω μέρος</translation>
-    </message>
-    <message>
-        <source>Bottom</source>
-        <translation>Κάτω μέρος</translation>
-    </message>
-    <message>
-        <source>Left</source>
-        <translation>Αριστερά</translation>
-    </message>
-    <message>
-        <source>Right</source>
-        <translation>Δεξιά</translation>
-    </message>
-    <message>
-        <source>Keep Shown</source>
-        <translation>Εμφάνιση  </translation>
-    </message>
-    <message>
-        <source>Keep Hidden</source>
-        <translation>Απόκρυψη </translation>
-    </message>
-    <message>
-        <source>Smart Hide</source>
-        <translation>Έξυπνη απόκρυψη </translation>
-    </message>
-    <message>
-        <source>Mode</source>
-        <translation>Λειτουργία</translation>
-    </message>
-    <message>
-        <source>Location</source>
-        <translation>Τοποθεσία</translation>
-    </message>
-    <message>
-        <source>Status</source>
-        <translation>Κατάσταση</translation>
-    </message>
-    <message>
-        <source>Dock settings</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/plugins/dde-dock/translations/dde-dock_el_GR.ts
+++ b/plugins/dde-dock/translations/dde-dock_el_GR.ts
@@ -53,7 +53,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Disable Airplane Mode first if you want to connect to a Bluetooth</source>
+        <source>Disable [Airplane Mode](#) first if you want to connect to a Bluetooth</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -384,61 +384,6 @@
     </message>
     <message>
         <source>Theme</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>MenuWorker</name>
-    <message>
-        <source>Fashion Mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Efficient Mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Top</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Bottom</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Left</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Right</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Keep Shown</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Keep Hidden</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Smart Hide</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Location</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Status</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Dock settings</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/plugins/dde-dock/translations/dde-dock_en_AU.ts
+++ b/plugins/dde-dock/translations/dde-dock_en_AU.ts
@@ -53,7 +53,7 @@
         <translation type="unfinished">Turned off</translation>
     </message>
     <message>
-        <source>Disable Airplane Mode first if you want to connect to a Bluetooth</source>
+        <source>Disable [Airplane Mode](#) first if you want to connect to a Bluetooth</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -384,61 +384,6 @@
     </message>
     <message>
         <source>Theme</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>MenuWorker</name>
-    <message>
-        <source>Fashion Mode</source>
-        <translation>Fashion Mode</translation>
-    </message>
-    <message>
-        <source>Efficient Mode</source>
-        <translation>Efficient Mode</translation>
-    </message>
-    <message>
-        <source>Top</source>
-        <translation>Top</translation>
-    </message>
-    <message>
-        <source>Bottom</source>
-        <translation>Bottom</translation>
-    </message>
-    <message>
-        <source>Left</source>
-        <translation>Left</translation>
-    </message>
-    <message>
-        <source>Right</source>
-        <translation>Right</translation>
-    </message>
-    <message>
-        <source>Keep Shown</source>
-        <translation>Keep Shown</translation>
-    </message>
-    <message>
-        <source>Keep Hidden</source>
-        <translation>Keep Hidden</translation>
-    </message>
-    <message>
-        <source>Smart Hide</source>
-        <translation>Smart Hide</translation>
-    </message>
-    <message>
-        <source>Mode</source>
-        <translation>Mode</translation>
-    </message>
-    <message>
-        <source>Location</source>
-        <translation>Location</translation>
-    </message>
-    <message>
-        <source>Status</source>
-        <translation>Status</translation>
-    </message>
-    <message>
-        <source>Dock settings</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/plugins/dde-dock/translations/dde-dock_en_GB.ts
+++ b/plugins/dde-dock/translations/dde-dock_en_GB.ts
@@ -53,7 +53,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Disable Airplane Mode first if you want to connect to a Bluetooth</source>
+        <source>Disable [Airplane Mode](#) first if you want to connect to a Bluetooth</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -384,61 +384,6 @@
     </message>
     <message>
         <source>Theme</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>MenuWorker</name>
-    <message>
-        <source>Fashion Mode</source>
-        <translation>Beautiful mode</translation>
-    </message>
-    <message>
-        <source>Efficient Mode</source>
-        <translation>Efficient mode</translation>
-    </message>
-    <message>
-        <source>Top</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Bottom</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Left</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Right</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Keep Shown</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Keep Hidden</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Smart Hide</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Mode</source>
-        <translation>Mode</translation>
-    </message>
-    <message>
-        <source>Location</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Status</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Dock settings</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/plugins/dde-dock/translations/dde-dock_en_NO.ts
+++ b/plugins/dde-dock/translations/dde-dock_en_NO.ts
@@ -53,7 +53,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Disable Airplane Mode first if you want to connect to a Bluetooth</source>
+        <source>Disable [Airplane Mode](#) first if you want to connect to a Bluetooth</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -384,61 +384,6 @@
     </message>
     <message>
         <source>Theme</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>MenuWorker</name>
-    <message>
-        <source>Fashion Mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Efficient Mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Top</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Bottom</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Left</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Right</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Keep Shown</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Keep Hidden</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Smart Hide</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Location</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Status</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Dock settings</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/plugins/dde-dock/translations/dde-dock_en_US.ts
+++ b/plugins/dde-dock/translations/dde-dock_en_US.ts
@@ -53,7 +53,7 @@
         <translation type="unfinished">Turned off</translation>
     </message>
     <message>
-        <source>Disable Airplane Mode first if you want to connect to a Bluetooth</source>
+        <source>Disable [Airplane Mode](#) first if you want to connect to a Bluetooth</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -385,61 +385,6 @@
     <message>
         <source>Theme</source>
         <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>MenuWorker</name>
-    <message>
-        <source>Fashion Mode</source>
-        <translation>Fashion Mode</translation>
-    </message>
-    <message>
-        <source>Efficient Mode</source>
-        <translation>Efficient Mode</translation>
-    </message>
-    <message>
-        <source>Top</source>
-        <translation>Top</translation>
-    </message>
-    <message>
-        <source>Bottom</source>
-        <translation>Bottom</translation>
-    </message>
-    <message>
-        <source>Left</source>
-        <translation>Left</translation>
-    </message>
-    <message>
-        <source>Right</source>
-        <translation>Right</translation>
-    </message>
-    <message>
-        <source>Keep Shown</source>
-        <translation>Keep Shown</translation>
-    </message>
-    <message>
-        <source>Keep Hidden</source>
-        <translation>Keep Hidden</translation>
-    </message>
-    <message>
-        <source>Smart Hide</source>
-        <translation>Smart Hide</translation>
-    </message>
-    <message>
-        <source>Mode</source>
-        <translation>Mode</translation>
-    </message>
-    <message>
-        <source>Location</source>
-        <translation>Location</translation>
-    </message>
-    <message>
-        <source>Status</source>
-        <translation>Status</translation>
-    </message>
-    <message>
-        <source>Dock settings</source>
-        <translation>Dock settings</translation>
     </message>
 </context>
 <context>

--- a/plugins/dde-dock/translations/dde-dock_eo.ts
+++ b/plugins/dde-dock/translations/dde-dock_eo.ts
@@ -53,7 +53,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Disable Airplane Mode first if you want to connect to a Bluetooth</source>
+        <source>Disable [Airplane Mode](#) first if you want to connect to a Bluetooth</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -384,61 +384,6 @@
     </message>
     <message>
         <source>Theme</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>MenuWorker</name>
-    <message>
-        <source>Fashion Mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Efficient Mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Top</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Bottom</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Left</source>
-        <translation>Maldekstra</translation>
-    </message>
-    <message>
-        <source>Right</source>
-        <translation>Dekstra</translation>
-    </message>
-    <message>
-        <source>Keep Shown</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Keep Hidden</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Smart Hide</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Mode</source>
-        <translation>Maniero</translation>
-    </message>
-    <message>
-        <source>Location</source>
-        <translation>Loko</translation>
-    </message>
-    <message>
-        <source>Status</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Dock settings</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/plugins/dde-dock/translations/dde-dock_es.ts
+++ b/plugins/dde-dock/translations/dde-dock_es.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="es">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="es">
 <context>
     <name>AirplaneModeItem</name>
     <message>
@@ -51,8 +53,8 @@
         <translation>Desactivado</translation>
     </message>
     <message>
-        <source>Disable Airplane Mode first if you want to connect to a Bluetooth</source>
-        <translation>Desactive primero el modo avión si desea conectarse a un Bluetooth</translation>
+        <source>Disable [Airplane Mode](#) first if you want to connect to a Bluetooth</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -383,61 +385,6 @@
     <message>
         <source>Theme</source>
         <translation>Tema</translation>
-    </message>
-</context>
-<context>
-    <name>MenuWorker</name>
-    <message>
-        <source>Fashion Mode</source>
-        <translation>Modo elegante</translation>
-    </message>
-    <message>
-        <source>Efficient Mode</source>
-        <translation>Modo eficiente</translation>
-    </message>
-    <message>
-        <source>Top</source>
-        <translation>Arriba</translation>
-    </message>
-    <message>
-        <source>Bottom</source>
-        <translation>Abajo</translation>
-    </message>
-    <message>
-        <source>Left</source>
-        <translation>Izquierda</translation>
-    </message>
-    <message>
-        <source>Right</source>
-        <translation>Derecha</translation>
-    </message>
-    <message>
-        <source>Keep Shown</source>
-        <translation>Mantener visible</translation>
-    </message>
-    <message>
-        <source>Keep Hidden</source>
-        <translation>Mantener oculto</translation>
-    </message>
-    <message>
-        <source>Smart Hide</source>
-        <translation>Ocultado inteligente</translation>
-    </message>
-    <message>
-        <source>Mode</source>
-        <translation>Modo</translation>
-    </message>
-    <message>
-        <source>Location</source>
-        <translation>Ubicación</translation>
-    </message>
-    <message>
-        <source>Status</source>
-        <translation>Estado</translation>
-    </message>
-    <message>
-        <source>Dock settings</source>
-        <translation>Ajustes del muelle</translation>
     </message>
 </context>
 <context>

--- a/plugins/dde-dock/translations/dde-dock_es_419.ts
+++ b/plugins/dde-dock/translations/dde-dock_es_419.ts
@@ -53,7 +53,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Disable Airplane Mode first if you want to connect to a Bluetooth</source>
+        <source>Disable [Airplane Mode](#) first if you want to connect to a Bluetooth</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -384,61 +384,6 @@
     </message>
     <message>
         <source>Theme</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>MenuWorker</name>
-    <message>
-        <source>Fashion Mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Efficient Mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Top</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Bottom</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Left</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Right</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Keep Shown</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Keep Hidden</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Smart Hide</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Location</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Status</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Dock settings</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/plugins/dde-dock/translations/dde-dock_es_AR.ts
+++ b/plugins/dde-dock/translations/dde-dock_es_AR.ts
@@ -53,7 +53,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Disable Airplane Mode first if you want to connect to a Bluetooth</source>
+        <source>Disable [Airplane Mode](#) first if you want to connect to a Bluetooth</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -384,61 +384,6 @@
     </message>
     <message>
         <source>Theme</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>MenuWorker</name>
-    <message>
-        <source>Fashion Mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Efficient Mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Top</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Bottom</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Left</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Right</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Keep Shown</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Keep Hidden</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Smart Hide</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Location</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Status</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Dock settings</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/plugins/dde-dock/translations/dde-dock_es_CL.ts
+++ b/plugins/dde-dock/translations/dde-dock_es_CL.ts
@@ -53,7 +53,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Disable Airplane Mode first if you want to connect to a Bluetooth</source>
+        <source>Disable [Airplane Mode](#) first if you want to connect to a Bluetooth</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -384,61 +384,6 @@
     </message>
     <message>
         <source>Theme</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>MenuWorker</name>
-    <message>
-        <source>Fashion Mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Efficient Mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Top</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Bottom</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Left</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Right</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Keep Shown</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Keep Hidden</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Smart Hide</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Location</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Status</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Dock settings</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/plugins/dde-dock/translations/dde-dock_es_MX.ts
+++ b/plugins/dde-dock/translations/dde-dock_es_MX.ts
@@ -53,7 +53,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Disable Airplane Mode first if you want to connect to a Bluetooth</source>
+        <source>Disable [Airplane Mode](#) first if you want to connect to a Bluetooth</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -384,61 +384,6 @@
     </message>
     <message>
         <source>Theme</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>MenuWorker</name>
-    <message>
-        <source>Fashion Mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Efficient Mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Top</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Bottom</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Left</source>
-        <translation>Izquierda</translation>
-    </message>
-    <message>
-        <source>Right</source>
-        <translation>Derecha</translation>
-    </message>
-    <message>
-        <source>Keep Shown</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Keep Hidden</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Smart Hide</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Location</source>
-        <translation>Ubicación</translation>
-    </message>
-    <message>
-        <source>Status</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Dock settings</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/plugins/dde-dock/translations/dde-dock_et.ts
+++ b/plugins/dde-dock/translations/dde-dock_et.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="et">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="et">
 <context>
     <name>AirplaneModeItem</name>
     <message>
@@ -51,8 +53,8 @@
         <translation>Lülitatud välja</translation>
     </message>
     <message>
-        <source>Disable Airplane Mode first if you want to connect to a Bluetooth</source>
-        <translation>Lülitage enne Bluetooth&apos;i ühendamist leet põhjusel välja</translation>
+        <source>Disable [Airplane Mode](#) first if you want to connect to a Bluetooth</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -386,61 +388,6 @@
     </message>
 </context>
 <context>
-    <name>MenuWorker</name>
-    <message>
-        <source>Fashion Mode</source>
-        <translation>Moodne režiim</translation>
-    </message>
-    <message>
-        <source>Efficient Mode</source>
-        <translation>Efektiivne režiim</translation>
-    </message>
-    <message>
-        <source>Top</source>
-        <translation>Üleval</translation>
-    </message>
-    <message>
-        <source>Bottom</source>
-        <translation>All</translation>
-    </message>
-    <message>
-        <source>Left</source>
-        <translation>Vasakul</translation>
-    </message>
-    <message>
-        <source>Right</source>
-        <translation>Paremal</translation>
-    </message>
-    <message>
-        <source>Keep Shown</source>
-        <translation>Hoia nähtavana</translation>
-    </message>
-    <message>
-        <source>Keep Hidden</source>
-        <translation>Hoia peidetuna</translation>
-    </message>
-    <message>
-        <source>Smart Hide</source>
-        <translation>Nutikas peitmine</translation>
-    </message>
-    <message>
-        <source>Mode</source>
-        <translation>Režiim</translation>
-    </message>
-    <message>
-        <source>Location</source>
-        <translation>Aukoht</translation>
-    </message>
-    <message>
-        <source>Status</source>
-        <translation>Staatus</translation>
-    </message>
-    <message>
-        <source>Dock settings</source>
-        <translation>Tahveli seaded</translation>
-    </message>
-</context>
-<context>
     <name>NotificationPlugin</name>
     <message>
         <source>No messages</source>
@@ -688,27 +635,27 @@
     </message>
     <message>
         <source>Monday</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Esmaspäev</translation>
     </message>
     <message>
         <source>Tuesday</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Teisipäev</translation>
     </message>
     <message>
         <source>Wednesday</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Kolmapäev</translation>
     </message>
     <message>
         <source>Thursday</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Neljapäev</translation>
     </message>
     <message>
         <source>Friday</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Reede</translation>
     </message>
     <message>
         <source>Saturday</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Laupäev</translation>
     </message>
     <message>
         <source>Sunday</source>

--- a/plugins/dde-dock/translations/dde-dock_eu.ts
+++ b/plugins/dde-dock/translations/dde-dock_eu.ts
@@ -53,7 +53,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Disable Airplane Mode first if you want to connect to a Bluetooth</source>
+        <source>Disable [Airplane Mode](#) first if you want to connect to a Bluetooth</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -384,61 +384,6 @@
     </message>
     <message>
         <source>Theme</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>MenuWorker</name>
-    <message>
-        <source>Fashion Mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Efficient Mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Top</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Bottom</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Left</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Right</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Keep Shown</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Keep Hidden</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Smart Hide</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Location</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Status</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Dock settings</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/plugins/dde-dock/translations/dde-dock_fa.ts
+++ b/plugins/dde-dock/translations/dde-dock_fa.ts
@@ -53,7 +53,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Disable Airplane Mode first if you want to connect to a Bluetooth</source>
+        <source>Disable [Airplane Mode](#) first if you want to connect to a Bluetooth</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -384,61 +384,6 @@
     </message>
     <message>
         <source>Theme</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>MenuWorker</name>
-    <message>
-        <source>Fashion Mode</source>
-        <translation>حالت فشن</translation>
-    </message>
-    <message>
-        <source>Efficient Mode</source>
-        <translation>حالت کارآمد</translation>
-    </message>
-    <message>
-        <source>Top</source>
-        <translation>بالا</translation>
-    </message>
-    <message>
-        <source>Bottom</source>
-        <translation>پایین</translation>
-    </message>
-    <message>
-        <source>Left</source>
-        <translation>چپ</translation>
-    </message>
-    <message>
-        <source>Right</source>
-        <translation>راست</translation>
-    </message>
-    <message>
-        <source>Keep Shown</source>
-        <translation>نمایش داده شود</translation>
-    </message>
-    <message>
-        <source>Keep Hidden</source>
-        <translation>مخفی نگاه داشتن</translation>
-    </message>
-    <message>
-        <source>Smart Hide</source>
-        <translation>مخفی سازی هوشمند</translation>
-    </message>
-    <message>
-        <source>Mode</source>
-        <translation>حالت</translation>
-    </message>
-    <message>
-        <source>Location</source>
-        <translation>مکان</translation>
-    </message>
-    <message>
-        <source>Status</source>
-        <translation>وضعیت </translation>
-    </message>
-    <message>
-        <source>Dock settings</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/plugins/dde-dock/translations/dde-dock_fi.ts
+++ b/plugins/dde-dock/translations/dde-dock_fi.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="fi">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="fi">
 <context>
     <name>AirplaneModeItem</name>
     <message>
@@ -51,8 +53,8 @@
         <translation>Pois päältä</translation>
     </message>
     <message>
-        <source>Disable Airplane Mode first if you want to connect to a Bluetooth</source>
-        <translation>Poista ensin &quot;Lentotila&quot; käytöstä, jos haluat muodostaa bluetooth yhteyden</translation>
+        <source>Disable [Airplane Mode](#) first if you want to connect to a Bluetooth</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -383,61 +385,6 @@
     <message>
         <source>Theme</source>
         <translation>Teema</translation>
-    </message>
-</context>
-<context>
-    <name>MenuWorker</name>
-    <message>
-        <source>Fashion Mode</source>
-        <translation>Keskitetty</translation>
-    </message>
-    <message>
-        <source>Efficient Mode</source>
-        <translation>Alavalikko</translation>
-    </message>
-    <message>
-        <source>Top</source>
-        <translation>Ylös</translation>
-    </message>
-    <message>
-        <source>Bottom</source>
-        <translation>Alas</translation>
-    </message>
-    <message>
-        <source>Left</source>
-        <translation>Vasen</translation>
-    </message>
-    <message>
-        <source>Right</source>
-        <translation>Oikea</translation>
-    </message>
-    <message>
-        <source>Keep Shown</source>
-        <translation>Näytä aina</translation>
-    </message>
-    <message>
-        <source>Keep Hidden</source>
-        <translation>Piilotta paneeli</translation>
-    </message>
-    <message>
-        <source>Smart Hide</source>
-        <translation>Piilota automaattisesti</translation>
-    </message>
-    <message>
-        <source>Mode</source>
-        <translation>Tila</translation>
-    </message>
-    <message>
-        <source>Location</source>
-        <translation>Sijainti</translation>
-    </message>
-    <message>
-        <source>Status</source>
-        <translation>Näytä</translation>
-    </message>
-    <message>
-        <source>Dock settings</source>
-        <translation>Paneeli asetukset</translation>
     </message>
 </context>
 <context>

--- a/plugins/dde-dock/translations/dde-dock_fil.ts
+++ b/plugins/dde-dock/translations/dde-dock_fil.ts
@@ -53,7 +53,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Disable Airplane Mode first if you want to connect to a Bluetooth</source>
+        <source>Disable [Airplane Mode](#) first if you want to connect to a Bluetooth</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -384,61 +384,6 @@
     </message>
     <message>
         <source>Theme</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>MenuWorker</name>
-    <message>
-        <source>Fashion Mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Efficient Mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Top</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Bottom</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Left</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Right</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Keep Shown</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Keep Hidden</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Smart Hide</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Location</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Status</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Dock settings</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/plugins/dde-dock/translations/dde-dock_fr.ts
+++ b/plugins/dde-dock/translations/dde-dock_fr.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="fr">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="fr">
 <context>
     <name>AirplaneModeItem</name>
     <message>
@@ -51,8 +53,8 @@
         <translation>Éteint</translation>
     </message>
     <message>
-        <source>Disable Airplane Mode first if you want to connect to a Bluetooth</source>
-        <translation>Désactivez d&apos;abord le mode avion si vous souhaitez vous connecter à un périphérique Bluetooth </translation>
+        <source>Disable [Airplane Mode](#) first if you want to connect to a Bluetooth</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -386,61 +388,6 @@
     </message>
 </context>
 <context>
-    <name>MenuWorker</name>
-    <message>
-        <source>Fashion Mode</source>
-        <translation>Mode dock</translation>
-    </message>
-    <message>
-        <source>Efficient Mode</source>
-        <translation>Mode étendu</translation>
-    </message>
-    <message>
-        <source>Top</source>
-        <translation>Haut</translation>
-    </message>
-    <message>
-        <source>Bottom</source>
-        <translation>Bas</translation>
-    </message>
-    <message>
-        <source>Left</source>
-        <translation>Gauche</translation>
-    </message>
-    <message>
-        <source>Right</source>
-        <translation>Droite</translation>
-    </message>
-    <message>
-        <source>Keep Shown</source>
-        <translation>Maintenir affiché</translation>
-    </message>
-    <message>
-        <source>Keep Hidden</source>
-        <translation>Maintenir caché</translation>
-    </message>
-    <message>
-        <source>Smart Hide</source>
-        <translation>Masquage intelligemment</translation>
-    </message>
-    <message>
-        <source>Mode</source>
-        <translation>Mode</translation>
-    </message>
-    <message>
-        <source>Location</source>
-        <translation>Emplacement</translation>
-    </message>
-    <message>
-        <source>Status</source>
-        <translation>Statut</translation>
-    </message>
-    <message>
-        <source>Dock settings</source>
-        <translation>Paramètres du dock</translation>
-    </message>
-</context>
-<context>
     <name>NotificationPlugin</name>
     <message>
         <source>No messages</source>
@@ -564,7 +511,7 @@
     </message>
     <message>
         <source>%1 hr %2 min remaining</source>
-        <translation>%1 h %2 restant</translation>
+        <translation>%1&#xa0;h&#xa0;%2 restant</translation>
     </message>
     <message>
         <source>Not charging</source>
@@ -580,7 +527,7 @@
     </message>
     <message>
         <source>Charging, %1 hr %2 min until full</source>
-        <translation>En charge, %1 h %2 avant la charge complète</translation>
+        <translation>En charge, %1&#xa0;h&#xa0;%2 avant la charge complète</translation>
     </message>
     <message>
         <source>Capacity %1, %2 hr remaining</source>

--- a/plugins/dde-dock/translations/dde-dock_gl.ts
+++ b/plugins/dde-dock/translations/dde-dock_gl.ts
@@ -53,7 +53,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Disable Airplane Mode first if you want to connect to a Bluetooth</source>
+        <source>Disable [Airplane Mode](#) first if you want to connect to a Bluetooth</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -384,61 +384,6 @@
     </message>
     <message>
         <source>Theme</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>MenuWorker</name>
-    <message>
-        <source>Fashion Mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Efficient Mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Top</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Bottom</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Left</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Right</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Keep Shown</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Keep Hidden</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Smart Hide</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Location</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Status</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Dock settings</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/plugins/dde-dock/translations/dde-dock_gl_ES.ts
+++ b/plugins/dde-dock/translations/dde-dock_gl_ES.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="gl_ES">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="gl_ES">
 <context>
     <name>AirplaneModeItem</name>
     <message>
@@ -48,11 +50,11 @@
     </message>
     <message>
         <source>Turned off</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Desactivado</translation>
     </message>
     <message>
-        <source>Disable Airplane Mode first if you want to connect to a Bluetooth</source>
-        <translation>Desactiva o modo de avión primeiro se queres conectarte a un Bluetooth</translation>
+        <source>Disable [Airplane Mode](#) first if you want to connect to a Bluetooth</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -386,61 +388,6 @@
     </message>
 </context>
 <context>
-    <name>MenuWorker</name>
-    <message>
-        <source>Fashion Mode</source>
-        <translation>Modo moderno</translation>
-    </message>
-    <message>
-        <source>Efficient Mode</source>
-        <translation>Modo eficiente</translation>
-    </message>
-    <message>
-        <source>Top</source>
-        <translation>Arriba</translation>
-    </message>
-    <message>
-        <source>Bottom</source>
-        <translation>Abaixo</translation>
-    </message>
-    <message>
-        <source>Left</source>
-        <translation>Esquerda</translation>
-    </message>
-    <message>
-        <source>Right</source>
-        <translation>Dereita</translation>
-    </message>
-    <message>
-        <source>Keep Shown</source>
-        <translation>Manter visible</translation>
-    </message>
-    <message>
-        <source>Keep Hidden</source>
-        <translation>Manter oculto</translation>
-    </message>
-    <message>
-        <source>Smart Hide</source>
-        <translation>Ocultar automaticamente</translation>
-    </message>
-    <message>
-        <source>Mode</source>
-        <translation>Modo</translation>
-    </message>
-    <message>
-        <source>Location</source>
-        <translation>Localización</translation>
-    </message>
-    <message>
-        <source>Status</source>
-        <translation>Estado</translation>
-    </message>
-    <message>
-        <source>Dock settings</source>
-        <translation>Configuración do cinto</translation>
-    </message>
-</context>
-<context>
     <name>NotificationPlugin</name>
     <message>
         <source>No messages</source>
@@ -603,7 +550,7 @@
     <name>PowerStatusWidget</name>
     <message>
         <source>Power settings</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Axustes de enerxía</translation>
     </message>
 </context>
 <context>
@@ -688,31 +635,31 @@
     </message>
     <message>
         <source>Monday</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Luns</translation>
     </message>
     <message>
         <source>Tuesday</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Martes</translation>
     </message>
     <message>
         <source>Wednesday</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Mércores</translation>
     </message>
     <message>
         <source>Thursday</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Xoves</translation>
     </message>
     <message>
         <source>Friday</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Venres</translation>
     </message>
     <message>
         <source>Saturday</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Sábado</translation>
     </message>
     <message>
         <source>Sunday</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Domingo</translation>
     </message>
     <message>
         <source>Jan</source>
@@ -768,7 +715,7 @@
     </message>
     <message>
         <source>monday</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">luns</translation>
     </message>
     <message>
         <source>tuesday</source>

--- a/plugins/dde-dock/translations/dde-dock_he.ts
+++ b/plugins/dde-dock/translations/dde-dock_he.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="he">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="he">
 <context>
     <name>AirplaneModeItem</name>
     <message>
@@ -51,8 +53,8 @@
         <translation>נOFF</translation>
     </message>
     <message>
-        <source>Disable Airplane Mode first if you want to connect to a Bluetooth</source>
-        <translation>השבת את מצב המטוס קודם אם אתה רוצה להתחבר לbluetooth</translation>
+        <source>Disable [Airplane Mode](#) first if you want to connect to a Bluetooth</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -386,61 +388,6 @@
     </message>
 </context>
 <context>
-    <name>MenuWorker</name>
-    <message>
-        <source>Fashion Mode</source>
-        <translation>מצב מופע</translation>
-    </message>
-    <message>
-        <source>Efficient Mode</source>
-        <translation>מצב יעיל</translation>
-    </message>
-    <message>
-        <source>Top</source>
-        <translation>למעלה</translation>
-    </message>
-    <message>
-        <source>Bottom</source>
-        <translation>למטה</translation>
-    </message>
-    <message>
-        <source>Left</source>
-        <translation>שמאל</translation>
-    </message>
-    <message>
-        <source>Right</source>
-        <translation>ימין</translation>
-    </message>
-    <message>
-        <source>Keep Shown</source>
-        <translation>הישאר מוצג</translation>
-    </message>
-    <message>
-        <source>Keep Hidden</source>
-        <translation>הישאר נסתר</translation>
-    </message>
-    <message>
-        <source>Smart Hide</source>
-        <translation>הסתר חכם</translation>
-    </message>
-    <message>
-        <source>Mode</source>
-        <translation>מצב</translation>
-    </message>
-    <message>
-        <source>Location</source>
-        <translation>מקום</translation>
-    </message>
-    <message>
-        <source>Status</source>
-        <translation>מצב</translation>
-    </message>
-    <message>
-        <source>Dock settings</source>
-        <translation>הגדרות מונח</translation>
-    </message>
-</context>
-<context>
     <name>NotificationPlugin</name>
     <message>
         <source>No messages</source>
@@ -448,30 +395,30 @@
     </message>
     <message>
         <source>Notification settings</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Notifications</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Turn off DND mode</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Turn on DND mode</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Notification</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>OnboardPlugin</name>
     <message>
         <source>Onboard</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Settings</source>
@@ -482,69 +429,69 @@
     <name>PerformanceModeController</name>
     <message>
         <source>High Performance</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Balanced</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Power Saver</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Balance Performance</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>PowerApplet</name>
     <message>
         <source>Power</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>PowerPlugin</name>
     <message>
         <source>Power settings</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">הגדרות החשמל</translation>
     </message>
     <message>
         <source>Capacity %1, %2 min remaining</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Capacity %1, %2 hr %3 min remaining</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Charging %1, %2 min until full</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Charging %1, %2 hr %3 min until full</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Capacity %1</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Charging %1</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Capacity %1 ...</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Capacity %1, fully charged</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Capacity %1, not charging</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Battery</source>
@@ -552,19 +499,19 @@
     </message>
     <message>
         <source>Charging, calculating estimated charging time</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Calculating remaining usage time</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>%1 min remaining</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>%1 hr %2 min remaining</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Not charging</source>
@@ -688,31 +635,31 @@
     </message>
     <message>
         <source>Monday</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">יום שני</translation>
     </message>
     <message>
         <source>Tuesday</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">יום שלישי</translation>
     </message>
     <message>
         <source>Wednesday</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">יום רביעי</translation>
     </message>
     <message>
         <source>Thursday</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">יום חמישי</translation>
     </message>
     <message>
         <source>Friday</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">יום שישי</translation>
     </message>
     <message>
         <source>Saturday</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">יום שבת</translation>
     </message>
     <message>
         <source>Sunday</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">יום ראשון</translation>
     </message>
     <message>
         <source>Jan</source>

--- a/plugins/dde-dock/translations/dde-dock_hi.ts
+++ b/plugins/dde-dock/translations/dde-dock_hi.ts
@@ -53,7 +53,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Disable Airplane Mode first if you want to connect to a Bluetooth</source>
+        <source>Disable [Airplane Mode](#) first if you want to connect to a Bluetooth</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -384,61 +384,6 @@
     </message>
     <message>
         <source>Theme</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>MenuWorker</name>
-    <message>
-        <source>Fashion Mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Efficient Mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Top</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Bottom</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Left</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Right</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Location</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Keep Shown</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Keep Hidden</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Smart Hide</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Status</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Dock settings</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/plugins/dde-dock/translations/dde-dock_hi_IN.ts
+++ b/plugins/dde-dock/translations/dde-dock_hi_IN.ts
@@ -53,7 +53,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Disable Airplane Mode first if you want to connect to a Bluetooth</source>
+        <source>Disable [Airplane Mode](#) first if you want to connect to a Bluetooth</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -384,61 +384,6 @@
     </message>
     <message>
         <source>Theme</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>MenuWorker</name>
-    <message>
-        <source>Fashion Mode</source>
-        <translation>फैशन मोड</translation>
-    </message>
-    <message>
-        <source>Efficient Mode</source>
-        <translation>दक्षता मोड</translation>
-    </message>
-    <message>
-        <source>Top</source>
-        <translation>ऊपर</translation>
-    </message>
-    <message>
-        <source>Bottom</source>
-        <translation>नीचे</translation>
-    </message>
-    <message>
-        <source>Left</source>
-        <translation>बाएँ</translation>
-    </message>
-    <message>
-        <source>Right</source>
-        <translation>दाएँ</translation>
-    </message>
-    <message>
-        <source>Keep Shown</source>
-        <translation>दृश्यमान रखें</translation>
-    </message>
-    <message>
-        <source>Keep Hidden</source>
-        <translation>छिपाएँ रखें</translation>
-    </message>
-    <message>
-        <source>Smart Hide</source>
-        <translation>उपयोग अनुरूप छिपाएँ</translation>
-    </message>
-    <message>
-        <source>Mode</source>
-        <translation>मोड </translation>
-    </message>
-    <message>
-        <source>Location</source>
-        <translation>स्थान</translation>
-    </message>
-    <message>
-        <source>Status</source>
-        <translation>स्थिति</translation>
-    </message>
-    <message>
-        <source>Dock settings</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/plugins/dde-dock/translations/dde-dock_hr.ts
+++ b/plugins/dde-dock/translations/dde-dock_hr.ts
@@ -53,7 +53,7 @@
         <translation type="unfinished">Isključeno</translation>
     </message>
     <message>
-        <source>Disable Airplane Mode first if you want to connect to a Bluetooth</source>
+        <source>Disable [Airplane Mode](#) first if you want to connect to a Bluetooth</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -384,61 +384,6 @@
     </message>
     <message>
         <source>Theme</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>MenuWorker</name>
-    <message>
-        <source>Fashion Mode</source>
-        <translation>Popularan način</translation>
-    </message>
-    <message>
-        <source>Efficient Mode</source>
-        <translation>Efikasan način</translation>
-    </message>
-    <message>
-        <source>Top</source>
-        <translation>Gore</translation>
-    </message>
-    <message>
-        <source>Bottom</source>
-        <translation>Dolje</translation>
-    </message>
-    <message>
-        <source>Left</source>
-        <translation>Lijevo</translation>
-    </message>
-    <message>
-        <source>Right</source>
-        <translation>Desno</translation>
-    </message>
-    <message>
-        <source>Keep Shown</source>
-        <translation>Drži prikazano</translation>
-    </message>
-    <message>
-        <source>Keep Hidden</source>
-        <translation>Drži skriveno</translation>
-    </message>
-    <message>
-        <source>Smart Hide</source>
-        <translation>Pametno skrivanje</translation>
-    </message>
-    <message>
-        <source>Mode</source>
-        <translation>Način</translation>
-    </message>
-    <message>
-        <source>Location</source>
-        <translation>Lokacija</translation>
-    </message>
-    <message>
-        <source>Status</source>
-        <translation>Status</translation>
-    </message>
-    <message>
-        <source>Dock settings</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/plugins/dde-dock/translations/dde-dock_hu.ts
+++ b/plugins/dde-dock/translations/dde-dock_hu.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="hu">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="hu">
 <context>
     <name>AirplaneModeItem</name>
     <message>
@@ -51,8 +53,8 @@
         <translation>Kikapcsolva</translation>
     </message>
     <message>
-        <source>Disable Airplane Mode first if you want to connect to a Bluetooth</source>
-        <translation>Először tiltsa le a Repülőgép üzemmódot, ha Bluetooth eszközt szeretne csatlakoztatni</translation>
+        <source>Disable [Airplane Mode](#) first if you want to connect to a Bluetooth</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -383,61 +385,6 @@
     <message>
         <source>Theme</source>
         <translation>Téma</translation>
-    </message>
-</context>
-<context>
-    <name>MenuWorker</name>
-    <message>
-        <source>Fashion Mode</source>
-        <translation>Stílusos mód</translation>
-    </message>
-    <message>
-        <source>Efficient Mode</source>
-        <translation>Hatékony mód</translation>
-    </message>
-    <message>
-        <source>Top</source>
-        <translation>Fent</translation>
-    </message>
-    <message>
-        <source>Bottom</source>
-        <translation>Lent</translation>
-    </message>
-    <message>
-        <source>Left</source>
-        <translation>Bal oldalt</translation>
-    </message>
-    <message>
-        <source>Right</source>
-        <translation>Jobb oldalt</translation>
-    </message>
-    <message>
-        <source>Keep Shown</source>
-        <translation>Folyamatosan látható</translation>
-    </message>
-    <message>
-        <source>Keep Hidden</source>
-        <translation>Rejtett</translation>
-    </message>
-    <message>
-        <source>Smart Hide</source>
-        <translation>Intelligens elrejtés</translation>
-    </message>
-    <message>
-        <source>Mode</source>
-        <translation>Mód</translation>
-    </message>
-    <message>
-        <source>Location</source>
-        <translation>Hely</translation>
-    </message>
-    <message>
-        <source>Status</source>
-        <translation>Állapot</translation>
-    </message>
-    <message>
-        <source>Dock settings</source>
-        <translation>Dokkoló beállításai</translation>
     </message>
 </context>
 <context>

--- a/plugins/dde-dock/translations/dde-dock_hy.ts
+++ b/plugins/dde-dock/translations/dde-dock_hy.ts
@@ -53,7 +53,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Disable Airplane Mode first if you want to connect to a Bluetooth</source>
+        <source>Disable [Airplane Mode](#) first if you want to connect to a Bluetooth</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -384,61 +384,6 @@
     </message>
     <message>
         <source>Theme</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>MenuWorker</name>
-    <message>
-        <source>Fashion Mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Efficient Mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Top</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Bottom</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Left</source>
-        <translation>Ձախ</translation>
-    </message>
-    <message>
-        <source>Right</source>
-        <translation>Աջ</translation>
-    </message>
-    <message>
-        <source>Keep Shown</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Keep Hidden</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Smart Hide</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Location</source>
-        <translation>Վայր</translation>
-    </message>
-    <message>
-        <source>Status</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Dock settings</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/plugins/dde-dock/translations/dde-dock_id.ts
+++ b/plugins/dde-dock/translations/dde-dock_id.ts
@@ -53,7 +53,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Disable Airplane Mode first if you want to connect to a Bluetooth</source>
+        <source>Disable [Airplane Mode](#) first if you want to connect to a Bluetooth</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -384,61 +384,6 @@
     </message>
     <message>
         <source>Theme</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>MenuWorker</name>
-    <message>
-        <source>Fashion Mode</source>
-        <translation>Mode fasion</translation>
-    </message>
-    <message>
-        <source>Efficient Mode</source>
-        <translation>Mode efesien</translation>
-    </message>
-    <message>
-        <source>Top</source>
-        <translation>Atas</translation>
-    </message>
-    <message>
-        <source>Bottom</source>
-        <translation>Bawah</translation>
-    </message>
-    <message>
-        <source>Left</source>
-        <translation>Kiri</translation>
-    </message>
-    <message>
-        <source>Right</source>
-        <translation>Kanan</translation>
-    </message>
-    <message>
-        <source>Keep Shown</source>
-        <translation>Tetap tampilkan</translation>
-    </message>
-    <message>
-        <source>Keep Hidden</source>
-        <translation>Tetap sembunyikan</translation>
-    </message>
-    <message>
-        <source>Smart Hide</source>
-        <translation>Sembunyi pintar</translation>
-    </message>
-    <message>
-        <source>Mode</source>
-        <translation>Mode</translation>
-    </message>
-    <message>
-        <source>Location</source>
-        <translation>Lokasi</translation>
-    </message>
-    <message>
-        <source>Status</source>
-        <translation>Status</translation>
-    </message>
-    <message>
-        <source>Dock settings</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/plugins/dde-dock/translations/dde-dock_id_ID.ts
+++ b/plugins/dde-dock/translations/dde-dock_id_ID.ts
@@ -53,7 +53,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Disable Airplane Mode first if you want to connect to a Bluetooth</source>
+        <source>Disable [Airplane Mode](#) first if you want to connect to a Bluetooth</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -384,61 +384,6 @@
     </message>
     <message>
         <source>Theme</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>MenuWorker</name>
-    <message>
-        <source>Fashion Mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Efficient Mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Top</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Bottom</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Left</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Right</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Keep Shown</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Keep Hidden</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Smart Hide</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Location</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Status</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Dock settings</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/plugins/dde-dock/translations/dde-dock_it.ts
+++ b/plugins/dde-dock/translations/dde-dock_it.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="it">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="it">
 <context>
     <name>AirplaneModeItem</name>
     <message>
@@ -37,7 +39,7 @@
     <name>BluetoothAdapterItem</name>
     <message>
         <source>My Devices</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -51,8 +53,8 @@
         <translation>Disattivato</translation>
     </message>
     <message>
-        <source>Disable Airplane Mode first if you want to connect to a Bluetooth</source>
-        <translation type="unfinished"/>
+        <source>Disable [Airplane Mode](#) first if you want to connect to a Bluetooth</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -188,7 +190,7 @@
     </message>
     <message>
         <source>Open the calendar</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -254,7 +256,7 @@
     <name>DeviceControlWidget</name>
     <message>
         <source>Other Devices</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -307,137 +309,82 @@
     </message>
     <message>
         <source>Display settings</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Impostazioni schermo</translation>
     </message>
     <message>
         <source>Eye comfort</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Theme</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>On</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Off</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Spento</translation>
     </message>
     <message>
         <source>Light</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Dark</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Auto</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Disable eye comfort</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Enable eye comfort</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Display Settings</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Theme: Light</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Theme: Dark</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Theme: Auto</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Visual effect</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>EyeComfortmodeApplet</name>
     <message>
         <source>Light</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Dark</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Auto</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Theme</source>
-        <translation type="unfinished"/>
-    </message>
-</context>
-<context>
-    <name>MenuWorker</name>
-    <message>
-        <source>Fashion Mode</source>
-        <translation>Fashion</translation>
-    </message>
-    <message>
-        <source>Efficient Mode</source>
-        <translation>Efficient</translation>
-    </message>
-    <message>
-        <source>Top</source>
-        <translation>Sopra</translation>
-    </message>
-    <message>
-        <source>Bottom</source>
-        <translation>Sotto</translation>
-    </message>
-    <message>
-        <source>Left</source>
-        <translation>Sinistra</translation>
-    </message>
-    <message>
-        <source>Right</source>
-        <translation>Destra</translation>
-    </message>
-    <message>
-        <source>Keep Shown</source>
-        <translation>Mostra sempre</translation>
-    </message>
-    <message>
-        <source>Keep Hidden</source>
-        <translation>Lascia nascosta</translation>
-    </message>
-    <message>
-        <source>Smart Hide</source>
-        <translation>Nascondi automaticamente</translation>
-    </message>
-    <message>
-        <source>Mode</source>
-        <translation>Modalità</translation>
-    </message>
-    <message>
-        <source>Location</source>
-        <translation>Posizione</translation>
-    </message>
-    <message>
-        <source>Status</source>
-        <translation>Comportamento</translation>
-    </message>
-    <message>
-        <source>Dock settings</source>
-        <translation>Impostazioni Dock</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -494,14 +441,14 @@
     </message>
     <message>
         <source>Balance Performance</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>PowerApplet</name>
     <message>
         <source>Power</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -552,58 +499,58 @@
     </message>
     <message>
         <source>Charging, calculating estimated charging time</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Calculating remaining usage time</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>%1 min remaining</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>%1 hr %2 min remaining</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Not charging</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Fully charged</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Charging, %1 min until full</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Charging, %1 hr %2 min until full</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Capacity %1, %2 hr remaining</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>%1 hr remaining</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Charging %1, %2 hr until full</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Charging, %1 hr until full</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>PowerStatusWidget</name>
     <message>
         <source>Power settings</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Impostazioni Alimentazione</translation>
     </message>
 </context>
 <context>
@@ -614,7 +561,7 @@
     </message>
     <message>
         <source>Unknown</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -657,142 +604,142 @@
     </message>
     <message>
         <source>Shut Down</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Switch user</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>SidebarCalendarWidget</name>
     <message>
         <source>Today</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Lunar</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>y</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>m</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>d</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Monday</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Lunedì</translation>
     </message>
     <message>
         <source>Tuesday</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Martedì</translation>
     </message>
     <message>
         <source>Wednesday</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Mercoledì</translation>
     </message>
     <message>
         <source>Thursday</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Giovedì</translation>
     </message>
     <message>
         <source>Friday</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Venerdì</translation>
     </message>
     <message>
         <source>Saturday</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Sabato</translation>
     </message>
     <message>
         <source>Sunday</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Domenica</translation>
     </message>
     <message>
         <source>Jan</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Feb</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Mar</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Apr</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>May</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Jun</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Jul</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Aug</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Sept</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Oct</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Nov</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Dec</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Open the calendar</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>monday</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">lunedì</translation>
     </message>
     <message>
         <source>tuesday</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">martedì</translation>
     </message>
     <message>
         <source>wednesday</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">mercoledì</translation>
     </message>
     <message>
         <source>thursday</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">giovedì</translation>
     </message>
     <message>
         <source>friday</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">venerdì</translation>
     </message>
     <message>
         <source>saturday</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">sabato</translation>
     </message>
     <message>
         <source>sunday</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">domenica</translation>
     </message>
 </context>
 <context>

--- a/plugins/dde-dock/translations/dde-dock_ja.ts
+++ b/plugins/dde-dock/translations/dde-dock_ja.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="ja">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ja">
 <context>
     <name>AirplaneModeItem</name>
     <message>
@@ -37,7 +39,7 @@
     <name>BluetoothAdapterItem</name>
     <message>
         <source>My Devices</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -51,8 +53,8 @@
         <translation>オフにしました</translation>
     </message>
     <message>
-        <source>Disable Airplane Mode first if you want to connect to a Bluetooth</source>
-        <translation>Bluetoothに接続するには、機内モードを無効化してください</translation>
+        <source>Disable [Airplane Mode](#) first if you want to connect to a Bluetooth</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -254,7 +256,7 @@
     <name>DeviceControlWidget</name>
     <message>
         <source>Other Devices</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -307,164 +309,109 @@
     </message>
     <message>
         <source>Display settings</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">ディスプレイ設定</translation>
     </message>
     <message>
         <source>Eye comfort</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Theme</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>On</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Off</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Off</translation>
     </message>
     <message>
         <source>Light</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Dark</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Auto</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Disable eye comfort</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Enable eye comfort</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Display Settings</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Theme: Light</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Theme: Dark</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Theme: Auto</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Visual effect</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>EyeComfortmodeApplet</name>
     <message>
         <source>Light</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Dark</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Auto</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Theme</source>
-        <translation type="unfinished"/>
-    </message>
-</context>
-<context>
-    <name>MenuWorker</name>
-    <message>
-        <source>Fashion Mode</source>
-        <translation>ファッションモード</translation>
-    </message>
-    <message>
-        <source>Efficient Mode</source>
-        <translation>エフィシェントモード</translation>
-    </message>
-    <message>
-        <source>Top</source>
-        <translation>上</translation>
-    </message>
-    <message>
-        <source>Bottom</source>
-        <translation>下</translation>
-    </message>
-    <message>
-        <source>Left</source>
-        <translation>左</translation>
-    </message>
-    <message>
-        <source>Right</source>
-        <translation>右</translation>
-    </message>
-    <message>
-        <source>Keep Shown</source>
-        <translation>常に表示</translation>
-    </message>
-    <message>
-        <source>Keep Hidden</source>
-        <translation>常に非表示</translation>
-    </message>
-    <message>
-        <source>Smart Hide</source>
-        <translation>賢く非表示にする</translation>
-    </message>
-    <message>
-        <source>Mode</source>
-        <translation>モード</translation>
-    </message>
-    <message>
-        <source>Location</source>
-        <translation>位置</translation>
-    </message>
-    <message>
-        <source>Status</source>
-        <translation>状態</translation>
-    </message>
-    <message>
-        <source>Dock settings</source>
-        <translation>ドックの設定</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>NotificationPlugin</name>
     <message>
         <source>No messages</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Notification settings</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Notifications</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Turn off DND mode</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Turn on DND mode</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Notification</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -494,14 +441,14 @@
     </message>
     <message>
         <source>Balance Performance</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>PowerApplet</name>
     <message>
         <source>Power</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -544,7 +491,7 @@
     </message>
     <message>
         <source>Capacity %1, not charging</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Battery</source>
@@ -552,69 +499,69 @@
     </message>
     <message>
         <source>Charging, calculating estimated charging time</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Calculating remaining usage time</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>%1 min remaining</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>%1 hr %2 min remaining</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Not charging</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Fully charged</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Charging, %1 min until full</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Charging, %1 hr %2 min until full</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Capacity %1, %2 hr remaining</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>%1 hr remaining</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Charging %1, %2 hr until full</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Charging, %1 hr until full</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>PowerStatusWidget</name>
     <message>
         <source>Power settings</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">電源の設定</translation>
     </message>
 </context>
 <context>
     <name>QuickPanelWidget</name>
     <message>
         <source>Music</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Unknown</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -649,150 +596,150 @@
     </message>
     <message>
         <source>Update and Shut Down</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Update and Reboot</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Shut Down</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Switch user</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>SidebarCalendarWidget</name>
     <message>
         <source>Today</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Lunar</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>y</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>m</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>d</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Monday</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">月曜日</translation>
     </message>
     <message>
         <source>Tuesday</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">火曜日</translation>
     </message>
     <message>
         <source>Wednesday</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">水曜日</translation>
     </message>
     <message>
         <source>Thursday</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">木曜日</translation>
     </message>
     <message>
         <source>Friday</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">金曜日</translation>
     </message>
     <message>
         <source>Saturday</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">土曜日</translation>
     </message>
     <message>
         <source>Sunday</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">日曜日</translation>
     </message>
     <message>
         <source>Jan</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Feb</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Mar</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Apr</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>May</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Jun</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Jul</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Aug</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Sept</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Oct</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Nov</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Dec</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Open the calendar</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">カレンダーを開く</translation>
     </message>
     <message>
         <source>monday</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">月曜日</translation>
     </message>
     <message>
         <source>tuesday</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">火曜日</translation>
     </message>
     <message>
         <source>wednesday</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">水曜日</translation>
     </message>
     <message>
         <source>thursday</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">木曜日</translation>
     </message>
     <message>
         <source>friday</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">金曜日</translation>
     </message>
     <message>
         <source>saturday</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">土曜日</translation>
     </message>
     <message>
         <source>sunday</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">日曜日</translation>
     </message>
 </context>
 <context>
@@ -803,11 +750,11 @@
     </message>
     <message>
         <source>Output</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Sound settings</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -821,23 +768,23 @@
     <name>SoundView</name>
     <message>
         <source>Unmute</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Mute</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Sound settings</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>No output devices</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Volume %1</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/plugins/dde-dock/translations/dde-dock_ka.ts
+++ b/plugins/dde-dock/translations/dde-dock_ka.ts
@@ -53,7 +53,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Disable Airplane Mode first if you want to connect to a Bluetooth</source>
+        <source>Disable [Airplane Mode](#) first if you want to connect to a Bluetooth</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -384,61 +384,6 @@
     </message>
     <message>
         <source>Theme</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>MenuWorker</name>
-    <message>
-        <source>Fashion Mode</source>
-        <translation>მიმზიდველი რეჟიმი</translation>
-    </message>
-    <message>
-        <source>Efficient Mode</source>
-        <translation>ეფექტური რეჟიმი</translation>
-    </message>
-    <message>
-        <source>Top</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Bottom</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Left</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Right</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Keep Shown</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Keep Hidden</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Smart Hide</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Location</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Status</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Dock settings</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/plugins/dde-dock/translations/dde-dock_kk.ts
+++ b/plugins/dde-dock/translations/dde-dock_kk.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="kk">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="kk">
 <context>
     <name>AirplaneModeItem</name>
     <message>
@@ -51,8 +53,8 @@
         <translation>Отты</translation>
     </message>
     <message>
-        <source>Disable Airplane Mode first if you want to connect to a Bluetooth</source>
-        <translation>Bluetooth-ға байланыс істейсіңіз, біріншілік хабарлама режимін деактивді</translation>
+        <source>Disable [Airplane Mode](#) first if you want to connect to a Bluetooth</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -383,61 +385,6 @@
     <message>
         <source>Theme</source>
         <translation>Тема</translation>
-    </message>
-</context>
-<context>
-    <name>MenuWorker</name>
-    <message>
-        <source>Fashion Mode</source>
-        <translation>Жаңылыктык режим</translation>
-    </message>
-    <message>
-        <source>Efficient Mode</source>
-        <translation>Эффективдік режим</translation>
-    </message>
-    <message>
-        <source>Top</source>
-        <translation>Жоғары</translation>
-    </message>
-    <message>
-        <source>Bottom</source>
-        <translation>Төмөнкү</translation>
-    </message>
-    <message>
-        <source>Left</source>
-        <translation>Коңырақ</translation>
-    </message>
-    <message>
-        <source>Right</source>
-        <translation>Сулу</translation>
-    </message>
-    <message>
-        <source>Keep Shown</source>
-        <translation>Көрсөтілгенін сақтау</translation>
-    </message>
-    <message>
-        <source>Keep Hidden</source>
-        <translation>Сакталып калу</translation>
-    </message>
-    <message>
-        <source>Smart Hide</source>
-        <translation>Сәліктік сакталу</translation>
-    </message>
-    <message>
-        <source>Mode</source>
-        <translation>Режим</translation>
-    </message>
-    <message>
-        <source>Location</source>
-        <translation>Расположение</translation>
-    </message>
-    <message>
-        <source>Status</source>
-        <translation>Статус</translation>
-    </message>
-    <message>
-        <source>Dock settings</source>
-        <translation>Булоқ айланасындын алагы</translation>
     </message>
 </context>
 <context>

--- a/plugins/dde-dock/translations/dde-dock_km_KH.ts
+++ b/plugins/dde-dock/translations/dde-dock_km_KH.ts
@@ -53,7 +53,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Disable Airplane Mode first if you want to connect to a Bluetooth</source>
+        <source>Disable [Airplane Mode](#) first if you want to connect to a Bluetooth</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -384,61 +384,6 @@
     </message>
     <message>
         <source>Theme</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>MenuWorker</name>
-    <message>
-        <source>Fashion Mode</source>
-        <translation>Fashion Mode</translation>
-    </message>
-    <message>
-        <source>Efficient Mode</source>
-        <translation>ម៉ូដប្រសិទ្ធភាព</translation>
-    </message>
-    <message>
-        <source>Top</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Bottom</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Left</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Right</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Keep Shown</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Keep Hidden</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Smart Hide</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Location</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Status</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Dock settings</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/plugins/dde-dock/translations/dde-dock_kn_IN.ts
+++ b/plugins/dde-dock/translations/dde-dock_kn_IN.ts
@@ -53,7 +53,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Disable Airplane Mode first if you want to connect to a Bluetooth</source>
+        <source>Disable [Airplane Mode](#) first if you want to connect to a Bluetooth</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -384,61 +384,6 @@
     </message>
     <message>
         <source>Theme</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>MenuWorker</name>
-    <message>
-        <source>Fashion Mode</source>
-        <translation>ಅಲಂಕೃತ ರೂಪ</translation>
-    </message>
-    <message>
-        <source>Efficient Mode</source>
-        <translation>ದಕ್ಷ ರೂಪ</translation>
-    </message>
-    <message>
-        <source>Top</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Bottom</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Left</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Right</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Keep Shown</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Keep Hidden</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Smart Hide</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Location</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Status</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Dock settings</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/plugins/dde-dock/translations/dde-dock_ko.ts
+++ b/plugins/dde-dock/translations/dde-dock_ko.ts
@@ -53,7 +53,7 @@
         <translation type="unfinished">꺼짐</translation>
     </message>
     <message>
-        <source>Disable Airplane Mode first if you want to connect to a Bluetooth</source>
+        <source>Disable [Airplane Mode](#) first if you want to connect to a Bluetooth</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -384,61 +384,6 @@
     </message>
     <message>
         <source>Theme</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>MenuWorker</name>
-    <message>
-        <source>Fashion Mode</source>
-        <translation>시각 모드</translation>
-    </message>
-    <message>
-        <source>Efficient Mode</source>
-        <translation>효율 모드</translation>
-    </message>
-    <message>
-        <source>Top</source>
-        <translation>상단</translation>
-    </message>
-    <message>
-        <source>Bottom</source>
-        <translation>하단</translation>
-    </message>
-    <message>
-        <source>Left</source>
-        <translation>왼쪽</translation>
-    </message>
-    <message>
-        <source>Right</source>
-        <translation>오른쪽</translation>
-    </message>
-    <message>
-        <source>Keep Shown</source>
-        <translation>표시된 상태로 유지</translation>
-    </message>
-    <message>
-        <source>Keep Hidden</source>
-        <translation>숨겨진 상태로 유지</translation>
-    </message>
-    <message>
-        <source>Smart Hide</source>
-        <translation>스마트 숨기기</translation>
-    </message>
-    <message>
-        <source>Mode</source>
-        <translation>모드</translation>
-    </message>
-    <message>
-        <source>Location</source>
-        <translation>위치</translation>
-    </message>
-    <message>
-        <source>Status</source>
-        <translation>상태</translation>
-    </message>
-    <message>
-        <source>Dock settings</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/plugins/dde-dock/translations/dde-dock_ku.ts
+++ b/plugins/dde-dock/translations/dde-dock_ku.ts
@@ -53,7 +53,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Disable Airplane Mode first if you want to connect to a Bluetooth</source>
+        <source>Disable [Airplane Mode](#) first if you want to connect to a Bluetooth</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -384,61 +384,6 @@
     </message>
     <message>
         <source>Theme</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>MenuWorker</name>
-    <message>
-        <source>Fashion Mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Efficient Mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Top</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Bottom</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Left</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Right</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Keep Shown</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Keep Hidden</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Smart Hide</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Location</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Status</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Dock settings</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/plugins/dde-dock/translations/dde-dock_ku_IQ.ts
+++ b/plugins/dde-dock/translations/dde-dock_ku_IQ.ts
@@ -53,7 +53,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Disable Airplane Mode first if you want to connect to a Bluetooth</source>
+        <source>Disable [Airplane Mode](#) first if you want to connect to a Bluetooth</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -384,61 +384,6 @@
     </message>
     <message>
         <source>Theme</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>MenuWorker</name>
-    <message>
-        <source>Fashion Mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Efficient Mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Top</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Bottom</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Left</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Right</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Keep Shown</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Keep Hidden</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Smart Hide</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Location</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Status</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Dock settings</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/plugins/dde-dock/translations/dde-dock_ky.ts
+++ b/plugins/dde-dock/translations/dde-dock_ky.ts
@@ -53,7 +53,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Disable Airplane Mode first if you want to connect to a Bluetooth</source>
+        <source>Disable [Airplane Mode](#) first if you want to connect to a Bluetooth</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -384,61 +384,6 @@
     </message>
     <message>
         <source>Theme</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>MenuWorker</name>
-    <message>
-        <source>Fashion Mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Efficient Mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Top</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Bottom</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Left</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Right</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Keep Shown</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Keep Hidden</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Smart Hide</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Location</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Status</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Dock settings</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/plugins/dde-dock/translations/dde-dock_la.ts
+++ b/plugins/dde-dock/translations/dde-dock_la.ts
@@ -53,7 +53,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Disable Airplane Mode first if you want to connect to a Bluetooth</source>
+        <source>Disable [Airplane Mode](#) first if you want to connect to a Bluetooth</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -384,61 +384,6 @@
     </message>
     <message>
         <source>Theme</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>MenuWorker</name>
-    <message>
-        <source>Fashion Mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Efficient Mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Top</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Bottom</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Left</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Right</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Keep Shown</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Keep Hidden</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Smart Hide</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Location</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Status</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Dock settings</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/plugins/dde-dock/translations/dde-dock_lo.ts
+++ b/plugins/dde-dock/translations/dde-dock_lo.ts
@@ -53,7 +53,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Disable Airplane Mode first if you want to connect to a Bluetooth</source>
+        <source>Disable [Airplane Mode](#) first if you want to connect to a Bluetooth</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -384,61 +384,6 @@
     </message>
     <message>
         <source>Theme</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>MenuWorker</name>
-    <message>
-        <source>Fashion Mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Efficient Mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Top</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Bottom</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Left</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Right</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Keep Shown</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Keep Hidden</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Smart Hide</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Location</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Status</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Dock settings</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/plugins/dde-dock/translations/dde-dock_lt.ts
+++ b/plugins/dde-dock/translations/dde-dock_lt.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="lt">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="lt">
 <context>
     <name>AirplaneModeItem</name>
     <message>
@@ -51,8 +53,8 @@
         <translation>Išjungta</translation>
     </message>
     <message>
-        <source>Disable Airplane Mode first if you want to connect to a Bluetooth</source>
-        <translation>Pirmiausia išjungkite laivinio režimą, jei norite prisijungti prie Bluetooth</translation>
+        <source>Disable [Airplane Mode](#) first if you want to connect to a Bluetooth</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -383,61 +385,6 @@
     <message>
         <source>Theme</source>
         <translation>Apipavidalinimas</translation>
-    </message>
-</context>
-<context>
-    <name>MenuWorker</name>
-    <message>
-        <source>Fashion Mode</source>
-        <translation>Madinga veiksena</translation>
-    </message>
-    <message>
-        <source>Efficient Mode</source>
-        <translation>Efektyvi veiksena</translation>
-    </message>
-    <message>
-        <source>Top</source>
-        <translation>Viršus</translation>
-    </message>
-    <message>
-        <source>Bottom</source>
-        <translation>Apačia</translation>
-    </message>
-    <message>
-        <source>Left</source>
-        <translation>Kairė</translation>
-    </message>
-    <message>
-        <source>Right</source>
-        <translation>Dešinė</translation>
-    </message>
-    <message>
-        <source>Keep Shown</source>
-        <translation>Laikyti rodomą</translation>
-    </message>
-    <message>
-        <source>Keep Hidden</source>
-        <translation>Laikyti paslėptą</translation>
-    </message>
-    <message>
-        <source>Smart Hide</source>
-        <translation>Išmaniai slėpti</translation>
-    </message>
-    <message>
-        <source>Mode</source>
-        <translation>Veiksena</translation>
-    </message>
-    <message>
-        <source>Location</source>
-        <translation>Vieta</translation>
-    </message>
-    <message>
-        <source>Status</source>
-        <translation>Būsena</translation>
-    </message>
-    <message>
-        <source>Dock settings</source>
-        <translation>Doko nustatymai</translation>
     </message>
 </context>
 <context>

--- a/plugins/dde-dock/translations/dde-dock_lv.ts
+++ b/plugins/dde-dock/translations/dde-dock_lv.ts
@@ -53,7 +53,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Disable Airplane Mode first if you want to connect to a Bluetooth</source>
+        <source>Disable [Airplane Mode](#) first if you want to connect to a Bluetooth</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -384,61 +384,6 @@
     </message>
     <message>
         <source>Theme</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>MenuWorker</name>
-    <message>
-        <source>Fashion Mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Efficient Mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Top</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Bottom</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Left</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Right</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Keep Shown</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Keep Hidden</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Smart Hide</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Location</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Status</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Dock settings</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/plugins/dde-dock/translations/dde-dock_ml.ts
+++ b/plugins/dde-dock/translations/dde-dock_ml.ts
@@ -53,7 +53,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Disable Airplane Mode first if you want to connect to a Bluetooth</source>
+        <source>Disable [Airplane Mode](#) first if you want to connect to a Bluetooth</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -384,61 +384,6 @@
     </message>
     <message>
         <source>Theme</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>MenuWorker</name>
-    <message>
-        <source>Fashion Mode</source>
-        <translation>ഫാഷൻ രീതി</translation>
-    </message>
-    <message>
-        <source>Efficient Mode</source>
-        <translation>കാര്യക്ഷമമായ രീതി</translation>
-    </message>
-    <message>
-        <source>Top</source>
-        <translation>മുകളിൽ</translation>
-    </message>
-    <message>
-        <source>Bottom</source>
-        <translation>താഴെ</translation>
-    </message>
-    <message>
-        <source>Left</source>
-        <translation>ഇടതു്</translation>
-    </message>
-    <message>
-        <source>Right</source>
-        <translation>വലതു്</translation>
-    </message>
-    <message>
-        <source>Keep Shown</source>
-        <translation>എപ്പോഴും ദൃശ്യമാക്കുക</translation>
-    </message>
-    <message>
-        <source>Keep Hidden</source>
-        <translation>എപ്പോഴും അദൃശ്യമാക്കുക</translation>
-    </message>
-    <message>
-        <source>Smart Hide</source>
-        <translation>സമർത്ഥമായ അദൃശ്യമാക്കൽ</translation>
-    </message>
-    <message>
-        <source>Mode</source>
-        <translation>രീതി</translation>
-    </message>
-    <message>
-        <source>Location</source>
-        <translation>സ്ഥാനം</translation>
-    </message>
-    <message>
-        <source>Status</source>
-        <translation>അവസ്ഥ</translation>
-    </message>
-    <message>
-        <source>Dock settings</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/plugins/dde-dock/translations/dde-dock_mn.ts
+++ b/plugins/dde-dock/translations/dde-dock_mn.ts
@@ -53,7 +53,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Disable Airplane Mode first if you want to connect to a Bluetooth</source>
+        <source>Disable [Airplane Mode](#) first if you want to connect to a Bluetooth</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -384,61 +384,6 @@
     </message>
     <message>
         <source>Theme</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>MenuWorker</name>
-    <message>
-        <source>Fashion Mode</source>
-        <translation>Загварлаг горим</translation>
-    </message>
-    <message>
-        <source>Efficient Mode</source>
-        <translation>Ашигтай горим</translation>
-    </message>
-    <message>
-        <source>Top</source>
-        <translation>Дээр</translation>
-    </message>
-    <message>
-        <source>Bottom</source>
-        <translation>Доор</translation>
-    </message>
-    <message>
-        <source>Left</source>
-        <translation>Зүүн</translation>
-    </message>
-    <message>
-        <source>Right</source>
-        <translation>Баруун</translation>
-    </message>
-    <message>
-        <source>Keep Shown</source>
-        <translation>Үргэлж харах</translation>
-    </message>
-    <message>
-        <source>Keep Hidden</source>
-        <translation>Үргэлж нуух</translation>
-    </message>
-    <message>
-        <source>Smart Hide</source>
-        <translation>Ухаалгаар нуух</translation>
-    </message>
-    <message>
-        <source>Mode</source>
-        <translation>Горим</translation>
-    </message>
-    <message>
-        <source>Location</source>
-        <translation>Байршил</translation>
-    </message>
-    <message>
-        <source>Status</source>
-        <translation>Төлөв</translation>
-    </message>
-    <message>
-        <source>Dock settings</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/plugins/dde-dock/translations/dde-dock_mr.ts
+++ b/plugins/dde-dock/translations/dde-dock_mr.ts
@@ -53,7 +53,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Disable Airplane Mode first if you want to connect to a Bluetooth</source>
+        <source>Disable [Airplane Mode](#) first if you want to connect to a Bluetooth</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -384,61 +384,6 @@
     </message>
     <message>
         <source>Theme</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>MenuWorker</name>
-    <message>
-        <source>Fashion Mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Efficient Mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Top</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Bottom</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Left</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Right</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Keep Shown</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Keep Hidden</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Smart Hide</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Location</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Status</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Dock settings</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/plugins/dde-dock/translations/dde-dock_ms.ts
+++ b/plugins/dde-dock/translations/dde-dock_ms.ts
@@ -53,7 +53,7 @@
         <translation type="unfinished">Dimatikan</translation>
     </message>
     <message>
-        <source>Disable Airplane Mode first if you want to connect to a Bluetooth</source>
+        <source>Disable [Airplane Mode](#) first if you want to connect to a Bluetooth</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -384,61 +384,6 @@
     </message>
     <message>
         <source>Theme</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>MenuWorker</name>
-    <message>
-        <source>Fashion Mode</source>
-        <translation>Mod Berfesyen</translation>
-    </message>
-    <message>
-        <source>Efficient Mode</source>
-        <translation>Mod Efisyen</translation>
-    </message>
-    <message>
-        <source>Top</source>
-        <translation>Teratas</translation>
-    </message>
-    <message>
-        <source>Bottom</source>
-        <translation>Bawah</translation>
-    </message>
-    <message>
-        <source>Left</source>
-        <translation>Kiri</translation>
-    </message>
-    <message>
-        <source>Right</source>
-        <translation>Kanan</translation>
-    </message>
-    <message>
-        <source>Keep Shown</source>
-        <translation>Kekal Ditunjukkan</translation>
-    </message>
-    <message>
-        <source>Keep Hidden</source>
-        <translation>Kekal Tersembunyi</translation>
-    </message>
-    <message>
-        <source>Smart Hide</source>
-        <translation>Sembunyi Pintar</translation>
-    </message>
-    <message>
-        <source>Mode</source>
-        <translation>Mod</translation>
-    </message>
-    <message>
-        <source>Location</source>
-        <translation>Lokasi</translation>
-    </message>
-    <message>
-        <source>Status</source>
-        <translation>Status</translation>
-    </message>
-    <message>
-        <source>Dock settings</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/plugins/dde-dock/translations/dde-dock_nb.ts
+++ b/plugins/dde-dock/translations/dde-dock_nb.ts
@@ -53,7 +53,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Disable Airplane Mode first if you want to connect to a Bluetooth</source>
+        <source>Disable [Airplane Mode](#) first if you want to connect to a Bluetooth</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -384,61 +384,6 @@
     </message>
     <message>
         <source>Theme</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>MenuWorker</name>
-    <message>
-        <source>Fashion Mode</source>
-        <translation>Fashion Mode</translation>
-    </message>
-    <message>
-        <source>Efficient Mode</source>
-        <translation>Efficient Mode</translation>
-    </message>
-    <message>
-        <source>Top</source>
-        <translation>Toppen</translation>
-    </message>
-    <message>
-        <source>Bottom</source>
-        <translation>Bunn</translation>
-    </message>
-    <message>
-        <source>Left</source>
-        <translation>Venstre</translation>
-    </message>
-    <message>
-        <source>Right</source>
-        <translation>Høyre</translation>
-    </message>
-    <message>
-        <source>Keep Shown</source>
-        <translation>Hold Vist</translation>
-    </message>
-    <message>
-        <source>Keep Hidden</source>
-        <translation>Hold Skjult</translation>
-    </message>
-    <message>
-        <source>Smart Hide</source>
-        <translation>Smart Skjuling</translation>
-    </message>
-    <message>
-        <source>Mode</source>
-        <translation>Modus</translation>
-    </message>
-    <message>
-        <source>Location</source>
-        <translation>Lokasjon</translation>
-    </message>
-    <message>
-        <source>Status</source>
-        <translation>Status</translation>
-    </message>
-    <message>
-        <source>Dock settings</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/plugins/dde-dock/translations/dde-dock_ne.ts
+++ b/plugins/dde-dock/translations/dde-dock_ne.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="ne">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ne">
 <context>
     <name>AirplaneModeItem</name>
     <message>
@@ -51,8 +53,8 @@
         <translation>कुनैही बाहिर छ</translation>
     </message>
     <message>
-        <source>Disable Airplane Mode first if you want to connect to a Bluetooth</source>
-        <translation>ब्लूटूथसँग जोड्न चाहने तर आयरनीन मोडलाई पहिले अक्रिय गर्न</translation>
+        <source>Disable [Airplane Mode](#) first if you want to connect to a Bluetooth</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -386,61 +388,6 @@
     </message>
 </context>
 <context>
-    <name>MenuWorker</name>
-    <message>
-        <source>Fashion Mode</source>
-        <translation>आधुनिक शैली</translation>
-    </message>
-    <message>
-        <source>Efficient Mode</source>
-        <translation>परम्परागत शैली</translation>
-    </message>
-    <message>
-        <source>Top</source>
-        <translation>माथी</translation>
-    </message>
-    <message>
-        <source>Bottom</source>
-        <translation>तल</translation>
-    </message>
-    <message>
-        <source>Left</source>
-        <translation>बाँया</translation>
-    </message>
-    <message>
-        <source>Right</source>
-        <translation>दाँया</translation>
-    </message>
-    <message>
-        <source>Keep Shown</source>
-        <translation>देखाउनुहोस्</translation>
-    </message>
-    <message>
-        <source>Keep Hidden</source>
-        <translation>लुकाउनुहोस्</translation>
-    </message>
-    <message>
-        <source>Smart Hide</source>
-        <translation>स्वचालित लुकाउने</translation>
-    </message>
-    <message>
-        <source>Mode</source>
-        <translation>मोड</translation>
-    </message>
-    <message>
-        <source>Location</source>
-        <translation>स्थान</translation>
-    </message>
-    <message>
-        <source>Status</source>
-        <translation>स्थिती</translation>
-    </message>
-    <message>
-        <source>Dock settings</source>
-        <translation>डॉक सेटिङहरू</translation>
-    </message>
-</context>
-<context>
     <name>NotificationPlugin</name>
     <message>
         <source>No messages</source>
@@ -603,7 +550,7 @@
     <name>PowerStatusWidget</name>
     <message>
         <source>Power settings</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">पावर सेटिङहरू</translation>
     </message>
 </context>
 <context>
@@ -688,31 +635,31 @@
     </message>
     <message>
         <source>Monday</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">सोमबार</translation>
     </message>
     <message>
         <source>Tuesday</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">मंगलबार</translation>
     </message>
     <message>
         <source>Wednesday</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">बुधबार</translation>
     </message>
     <message>
         <source>Thursday</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">बिहिबार</translation>
     </message>
     <message>
         <source>Friday</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">शुक्रबार</translation>
     </message>
     <message>
         <source>Saturday</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">शनिबार</translation>
     </message>
     <message>
         <source>Sunday</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">आइतबार</translation>
     </message>
     <message>
         <source>Jan</source>

--- a/plugins/dde-dock/translations/dde-dock_nl.ts
+++ b/plugins/dde-dock/translations/dde-dock_nl.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="nl">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="nl">
 <context>
     <name>AirplaneModeItem</name>
     <message>
@@ -51,8 +53,8 @@
         <translation>Uitgeschakeld</translation>
     </message>
     <message>
-        <source>Disable Airplane Mode first if you want to connect to a Bluetooth</source>
-        <translation>Schakel de vliegtuigstand uit als je verbinding wilt maken via bluetooth</translation>
+        <source>Disable [Airplane Mode](#) first if you want to connect to a Bluetooth</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -383,61 +385,6 @@
     <message>
         <source>Theme</source>
         <translation>Thema</translation>
-    </message>
-</context>
-<context>
-    <name>MenuWorker</name>
-    <message>
-        <source>Fashion Mode</source>
-        <translation>Moderne modus</translation>
-    </message>
-    <message>
-        <source>Efficient Mode</source>
-        <translation>Efficiënte modus</translation>
-    </message>
-    <message>
-        <source>Top</source>
-        <translation>Bovenaan</translation>
-    </message>
-    <message>
-        <source>Bottom</source>
-        <translation>Onderaan</translation>
-    </message>
-    <message>
-        <source>Left</source>
-        <translation>Links</translation>
-    </message>
-    <message>
-        <source>Right</source>
-        <translation>Rechts</translation>
-    </message>
-    <message>
-        <source>Keep Shown</source>
-        <translation>Altijd tonen</translation>
-    </message>
-    <message>
-        <source>Keep Hidden</source>
-        <translation>Altijd verbergen</translation>
-    </message>
-    <message>
-        <source>Smart Hide</source>
-        <translation>Slim verbergen</translation>
-    </message>
-    <message>
-        <source>Mode</source>
-        <translation>Modus</translation>
-    </message>
-    <message>
-        <source>Location</source>
-        <translation>Locatie</translation>
-    </message>
-    <message>
-        <source>Status</source>
-        <translation>Status</translation>
-    </message>
-    <message>
-        <source>Dock settings</source>
-        <translation>Dockinstellingen</translation>
     </message>
 </context>
 <context>

--- a/plugins/dde-dock/translations/dde-dock_pa.ts
+++ b/plugins/dde-dock/translations/dde-dock_pa.ts
@@ -53,7 +53,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Disable Airplane Mode first if you want to connect to a Bluetooth</source>
+        <source>Disable [Airplane Mode](#) first if you want to connect to a Bluetooth</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -384,61 +384,6 @@
     </message>
     <message>
         <source>Theme</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>MenuWorker</name>
-    <message>
-        <source>Fashion Mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Efficient Mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Top</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Bottom</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Left</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Right</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Keep Shown</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Keep Hidden</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Smart Hide</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Location</source>
-        <translation>ਟਿਕਾਣਆ</translation>
-    </message>
-    <message>
-        <source>Status</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Dock settings</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/plugins/dde-dock/translations/dde-dock_pl.ts
+++ b/plugins/dde-dock/translations/dde-dock_pl.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="pl">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="pl">
 <context>
     <name>AirplaneModeItem</name>
     <message>
@@ -51,8 +53,8 @@
         <translation>Wyłączony</translation>
     </message>
     <message>
-        <source>Disable Airplane Mode first if you want to connect to a Bluetooth</source>
-        <translation>Najpierw wyłącz Tryb Samolotowy, aby połączyć się z Bluetooth</translation>
+        <source>Disable [Airplane Mode](#) first if you want to connect to a Bluetooth</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -383,61 +385,6 @@
     <message>
         <source>Theme</source>
         <translation>Motyw</translation>
-    </message>
-</context>
-<context>
-    <name>MenuWorker</name>
-    <message>
-        <source>Fashion Mode</source>
-        <translation>Tryb modny</translation>
-    </message>
-    <message>
-        <source>Efficient Mode</source>
-        <translation>Tryb wydajny</translation>
-    </message>
-    <message>
-        <source>Top</source>
-        <translation>Góra</translation>
-    </message>
-    <message>
-        <source>Bottom</source>
-        <translation>Dół</translation>
-    </message>
-    <message>
-        <source>Left</source>
-        <translation>Lewo</translation>
-    </message>
-    <message>
-        <source>Right</source>
-        <translation>Prawo</translation>
-    </message>
-    <message>
-        <source>Keep Shown</source>
-        <translation>Zawsze wyświetlaj</translation>
-    </message>
-    <message>
-        <source>Keep Hidden</source>
-        <translation>Zawsze ukrywaj</translation>
-    </message>
-    <message>
-        <source>Smart Hide</source>
-        <translation>Inteligentne ukrywanie</translation>
-    </message>
-    <message>
-        <source>Mode</source>
-        <translation>Tryb</translation>
-    </message>
-    <message>
-        <source>Location</source>
-        <translation>Położenie</translation>
-    </message>
-    <message>
-        <source>Status</source>
-        <translation>Status</translation>
-    </message>
-    <message>
-        <source>Dock settings</source>
-        <translation>Ustawienia doku</translation>
     </message>
 </context>
 <context>

--- a/plugins/dde-dock/translations/dde-dock_ps.ts
+++ b/plugins/dde-dock/translations/dde-dock_ps.ts
@@ -53,7 +53,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Disable Airplane Mode first if you want to connect to a Bluetooth</source>
+        <source>Disable [Airplane Mode](#) first if you want to connect to a Bluetooth</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -384,61 +384,6 @@
     </message>
     <message>
         <source>Theme</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>MenuWorker</name>
-    <message>
-        <source>Fashion Mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Efficient Mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Top</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Bottom</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Left</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Right</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Keep Shown</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Keep Hidden</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Smart Hide</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Location</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Status</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Dock settings</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/plugins/dde-dock/translations/dde-dock_pt.ts
+++ b/plugins/dde-dock/translations/dde-dock_pt.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="pt">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="pt">
 <context>
     <name>AirplaneModeItem</name>
     <message>
@@ -51,8 +53,8 @@
         <translation>Desligado</translation>
     </message>
     <message>
-        <source>Disable Airplane Mode first if you want to connect to a Bluetooth</source>
-        <translation type="unfinished"/>
+        <source>Disable [Airplane Mode](#) first if you want to connect to a Bluetooth</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -386,61 +388,6 @@
     </message>
 </context>
 <context>
-    <name>MenuWorker</name>
-    <message>
-        <source>Fashion Mode</source>
-        <translation>Modo Elegante</translation>
-    </message>
-    <message>
-        <source>Efficient Mode</source>
-        <translation>Modo Eficiente</translation>
-    </message>
-    <message>
-        <source>Top</source>
-        <translation>Superior</translation>
-    </message>
-    <message>
-        <source>Bottom</source>
-        <translation>Inferior</translation>
-    </message>
-    <message>
-        <source>Left</source>
-        <translation>Esquerda</translation>
-    </message>
-    <message>
-        <source>Right</source>
-        <translation>Direita</translation>
-    </message>
-    <message>
-        <source>Keep Shown</source>
-        <translation>Manter visível</translation>
-    </message>
-    <message>
-        <source>Keep Hidden</source>
-        <translation>Manter oculta</translation>
-    </message>
-    <message>
-        <source>Smart Hide</source>
-        <translation>Ocultar inteligente</translation>
-    </message>
-    <message>
-        <source>Mode</source>
-        <translation>Modo</translation>
-    </message>
-    <message>
-        <source>Location</source>
-        <translation>Localização</translation>
-    </message>
-    <message>
-        <source>Status</source>
-        <translation>Estado</translation>
-    </message>
-    <message>
-        <source>Dock settings</source>
-        <translation>Definições da doca</translation>
-    </message>
-</context>
-<context>
     <name>NotificationPlugin</name>
     <message>
         <source>No messages</source>
@@ -494,7 +441,7 @@
     </message>
     <message>
         <source>Balance Performance</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/plugins/dde-dock/translations/dde-dock_pt_BR.ts
+++ b/plugins/dde-dock/translations/dde-dock_pt_BR.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="pt_BR">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="pt_BR">
 <context>
     <name>AirplaneModeItem</name>
     <message>
@@ -51,8 +53,8 @@
         <translation>Desligado</translation>
     </message>
     <message>
-        <source>Disable Airplane Mode first if you want to connect to a Bluetooth</source>
-        <translation>Primeiro, desative o Modo Avião para conectar-se a um dispositivo Bluetooth</translation>
+        <source>Disable [Airplane Mode](#) first if you want to connect to a Bluetooth</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -383,61 +385,6 @@
     <message>
         <source>Theme</source>
         <translation>Tema</translation>
-    </message>
-</context>
-<context>
-    <name>MenuWorker</name>
-    <message>
-        <source>Fashion Mode</source>
-        <translation>Fashion</translation>
-    </message>
-    <message>
-        <source>Efficient Mode</source>
-        <translation>Eficiente</translation>
-    </message>
-    <message>
-        <source>Top</source>
-        <translation>Superior</translation>
-    </message>
-    <message>
-        <source>Bottom</source>
-        <translation>Inferior</translation>
-    </message>
-    <message>
-        <source>Left</source>
-        <translation>Esquerda</translation>
-    </message>
-    <message>
-        <source>Right</source>
-        <translation>Direita</translation>
-    </message>
-    <message>
-        <source>Keep Shown</source>
-        <translation>Sempre exibir</translation>
-    </message>
-    <message>
-        <source>Keep Hidden</source>
-        <translation>Sempre ocultar</translation>
-    </message>
-    <message>
-        <source>Smart Hide</source>
-        <translation>Ocultar automaticamente</translation>
-    </message>
-    <message>
-        <source>Mode</source>
-        <translation>Modo</translation>
-    </message>
-    <message>
-        <source>Location</source>
-        <translation>Posição</translation>
-    </message>
-    <message>
-        <source>Status</source>
-        <translation>Exibição</translation>
-    </message>
-    <message>
-        <source>Dock settings</source>
-        <translation>Configurações do dock</translation>
     </message>
 </context>
 <context>

--- a/plugins/dde-dock/translations/dde-dock_ro.ts
+++ b/plugins/dde-dock/translations/dde-dock_ro.ts
@@ -53,7 +53,7 @@
         <translation type="unfinished">Oprit</translation>
     </message>
     <message>
-        <source>Disable Airplane Mode first if you want to connect to a Bluetooth</source>
+        <source>Disable [Airplane Mode](#) first if you want to connect to a Bluetooth</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -384,61 +384,6 @@
     </message>
     <message>
         <source>Theme</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>MenuWorker</name>
-    <message>
-        <source>Fashion Mode</source>
-        <translation>Mod aspectuos</translation>
-    </message>
-    <message>
-        <source>Efficient Mode</source>
-        <translation>Mod eficient</translation>
-    </message>
-    <message>
-        <source>Top</source>
-        <translation>Sus</translation>
-    </message>
-    <message>
-        <source>Bottom</source>
-        <translation>Jos</translation>
-    </message>
-    <message>
-        <source>Left</source>
-        <translation>Stânga</translation>
-    </message>
-    <message>
-        <source>Right</source>
-        <translation>Dreapta</translation>
-    </message>
-    <message>
-        <source>Keep Shown</source>
-        <translation>Păstrați docul afișat</translation>
-    </message>
-    <message>
-        <source>Keep Hidden</source>
-        <translation>Păstrați docul ascuns</translation>
-    </message>
-    <message>
-        <source>Smart Hide</source>
-        <translation>Ascundere inteligentă</translation>
-    </message>
-    <message>
-        <source>Mode</source>
-        <translation>Mod</translation>
-    </message>
-    <message>
-        <source>Location</source>
-        <translation>Locație</translation>
-    </message>
-    <message>
-        <source>Status</source>
-        <translation>Stare</translation>
-    </message>
-    <message>
-        <source>Dock settings</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/plugins/dde-dock/translations/dde-dock_ru.ts
+++ b/plugins/dde-dock/translations/dde-dock_ru.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="ru">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ru">
 <context>
     <name>AirplaneModeItem</name>
     <message>
@@ -51,8 +53,8 @@
         <translation>Выключено</translation>
     </message>
     <message>
-        <source>Disable Airplane Mode first if you want to connect to a Bluetooth</source>
-        <translation>Сначала отключите режим полета, если вы хотите подключиться к Bluetooth.</translation>
+        <source>Disable [Airplane Mode](#) first if you want to connect to a Bluetooth</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -383,61 +385,6 @@
     <message>
         <source>Theme</source>
         <translation>Тема</translation>
-    </message>
-</context>
-<context>
-    <name>MenuWorker</name>
-    <message>
-        <source>Fashion Mode</source>
-        <translation>Современный режим</translation>
-    </message>
-    <message>
-        <source>Efficient Mode</source>
-        <translation>Эффективный режим</translation>
-    </message>
-    <message>
-        <source>Top</source>
-        <translation>Сверху</translation>
-    </message>
-    <message>
-        <source>Bottom</source>
-        <translation>Снизу</translation>
-    </message>
-    <message>
-        <source>Left</source>
-        <translation>Слева</translation>
-    </message>
-    <message>
-        <source>Right</source>
-        <translation>Справа</translation>
-    </message>
-    <message>
-        <source>Keep Shown</source>
-        <translation>Отображать Всегда</translation>
-    </message>
-    <message>
-        <source>Keep Hidden</source>
-        <translation>Держать Скрытым</translation>
-    </message>
-    <message>
-        <source>Smart Hide</source>
-        <translation>Умное скрытие</translation>
-    </message>
-    <message>
-        <source>Mode</source>
-        <translation>Режим</translation>
-    </message>
-    <message>
-        <source>Location</source>
-        <translation>Расположение</translation>
-    </message>
-    <message>
-        <source>Status</source>
-        <translation>Состояние</translation>
-    </message>
-    <message>
-        <source>Dock settings</source>
-        <translation>Настройки Dock</translation>
     </message>
 </context>
 <context>

--- a/plugins/dde-dock/translations/dde-dock_ru_UA.ts
+++ b/plugins/dde-dock/translations/dde-dock_ru_UA.ts
@@ -53,7 +53,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Disable Airplane Mode first if you want to connect to a Bluetooth</source>
+        <source>Disable [Airplane Mode](#) first if you want to connect to a Bluetooth</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -384,61 +384,6 @@
     </message>
     <message>
         <source>Theme</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>MenuWorker</name>
-    <message>
-        <source>Fashion Mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Efficient Mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Top</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Bottom</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Left</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Right</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Keep Shown</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Keep Hidden</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Smart Hide</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Location</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Status</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Dock settings</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/plugins/dde-dock/translations/dde-dock_sc.ts
+++ b/plugins/dde-dock/translations/dde-dock_sc.ts
@@ -53,7 +53,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Disable Airplane Mode first if you want to connect to a Bluetooth</source>
+        <source>Disable [Airplane Mode](#) first if you want to connect to a Bluetooth</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -384,61 +384,6 @@
     </message>
     <message>
         <source>Theme</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>MenuWorker</name>
-    <message>
-        <source>Fashion Mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Efficient Mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Top</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Bottom</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Left</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Right</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Keep Shown</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Keep Hidden</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Smart Hide</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Location</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Status</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Dock settings</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/plugins/dde-dock/translations/dde-dock_si.ts
+++ b/plugins/dde-dock/translations/dde-dock_si.ts
@@ -53,7 +53,7 @@
         <translation type="unfinished">වසා දමා ඇත</translation>
     </message>
     <message>
-        <source>Disable Airplane Mode first if you want to connect to a Bluetooth</source>
+        <source>Disable [Airplane Mode](#) first if you want to connect to a Bluetooth</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -384,61 +384,6 @@
     </message>
     <message>
         <source>Theme</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>MenuWorker</name>
-    <message>
-        <source>Fashion Mode</source>
-        <translation>විචිත්‍ර ආකාරය</translation>
-    </message>
-    <message>
-        <source>Efficient Mode</source>
-        <translation>කාර්යක්ෂම ආකාරය</translation>
-    </message>
-    <message>
-        <source>Top</source>
-        <translation>ඉහළ</translation>
-    </message>
-    <message>
-        <source>Bottom</source>
-        <translation>පහළ</translation>
-    </message>
-    <message>
-        <source>Left</source>
-        <translation>වම</translation>
-    </message>
-    <message>
-        <source>Right</source>
-        <translation>දකුණ</translation>
-    </message>
-    <message>
-        <source>Keep Shown</source>
-        <translation>පෙනීමට සලස්වා තබන්න</translation>
-    </message>
-    <message>
-        <source>Keep Hidden</source>
-        <translation>සඟවා තබන්න</translation>
-    </message>
-    <message>
-        <source>Smart Hide</source>
-        <translation>ගැලපෙන ආකාරයට සඟවන්න</translation>
-    </message>
-    <message>
-        <source>Mode</source>
-        <translation>ප්‍රකාරය</translation>
-    </message>
-    <message>
-        <source>Location</source>
-        <translation>පිහිටුම</translation>
-    </message>
-    <message>
-        <source>Status</source>
-        <translation>තත්ත්වය</translation>
-    </message>
-    <message>
-        <source>Dock settings</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/plugins/dde-dock/translations/dde-dock_sk.ts
+++ b/plugins/dde-dock/translations/dde-dock_sk.ts
@@ -53,7 +53,7 @@
         <translation>Vypnuté</translation>
     </message>
     <message>
-        <source>Disable Airplane Mode first if you want to connect to a Bluetooth</source>
+        <source>Disable [Airplane Mode](#) first if you want to connect to a Bluetooth</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -385,61 +385,6 @@
     <message>
         <source>Theme</source>
         <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>MenuWorker</name>
-    <message>
-        <source>Fashion Mode</source>
-        <translation>Módny režim</translation>
-    </message>
-    <message>
-        <source>Efficient Mode</source>
-        <translation>Efektívny režim</translation>
-    </message>
-    <message>
-        <source>Top</source>
-        <translation>Hore</translation>
-    </message>
-    <message>
-        <source>Bottom</source>
-        <translation>Dolu</translation>
-    </message>
-    <message>
-        <source>Left</source>
-        <translation>Vľavo</translation>
-    </message>
-    <message>
-        <source>Right</source>
-        <translation>Vpravo</translation>
-    </message>
-    <message>
-        <source>Keep Shown</source>
-        <translation>Ponechať zobrazené</translation>
-    </message>
-    <message>
-        <source>Keep Hidden</source>
-        <translation>Ponechať skryté</translation>
-    </message>
-    <message>
-        <source>Smart Hide</source>
-        <translation>Inteligentné skrývanie</translation>
-    </message>
-    <message>
-        <source>Mode</source>
-        <translation>Režim</translation>
-    </message>
-    <message>
-        <source>Location</source>
-        <translation>Umiestnenie</translation>
-    </message>
-    <message>
-        <source>Status</source>
-        <translation>Stav</translation>
-    </message>
-    <message>
-        <source>Dock settings</source>
-        <translation>Nastavenia panela</translation>
     </message>
 </context>
 <context>

--- a/plugins/dde-dock/translations/dde-dock_sl.ts
+++ b/plugins/dde-dock/translations/dde-dock_sl.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="sl">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="sl">
 <context>
     <name>AirplaneModeItem</name>
     <message>
@@ -48,11 +50,11 @@
     </message>
     <message>
         <source>Turned off</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Izklopljen</translation>
     </message>
     <message>
-        <source>Disable Airplane Mode first if you want to connect to a Bluetooth</source>
-        <translation>Najprej onemogočite režim letalne ploščice, če želite povezati z Bluetooth</translation>
+        <source>Disable [Airplane Mode](#) first if you want to connect to a Bluetooth</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -386,61 +388,6 @@
     </message>
 </context>
 <context>
-    <name>MenuWorker</name>
-    <message>
-        <source>Fashion Mode</source>
-        <translation>Modni način</translation>
-    </message>
-    <message>
-        <source>Efficient Mode</source>
-        <translation>Učinkovit način</translation>
-    </message>
-    <message>
-        <source>Top</source>
-        <translation>Vrh</translation>
-    </message>
-    <message>
-        <source>Bottom</source>
-        <translation>Dno</translation>
-    </message>
-    <message>
-        <source>Left</source>
-        <translation>Levo</translation>
-    </message>
-    <message>
-        <source>Right</source>
-        <translation>Desno</translation>
-    </message>
-    <message>
-        <source>Keep Shown</source>
-        <translation>Ohrani prikazano</translation>
-    </message>
-    <message>
-        <source>Keep Hidden</source>
-        <translation>Ohrani skrito</translation>
-    </message>
-    <message>
-        <source>Smart Hide</source>
-        <translation>Pametno skrivanje</translation>
-    </message>
-    <message>
-        <source>Mode</source>
-        <translation>Način</translation>
-    </message>
-    <message>
-        <source>Location</source>
-        <translation>Položaj</translation>
-    </message>
-    <message>
-        <source>Status</source>
-        <translation>Status</translation>
-    </message>
-    <message>
-        <source>Dock settings</source>
-        <translation>Nastavitve podloge</translation>
-    </message>
-</context>
-<context>
     <name>NotificationPlugin</name>
     <message>
         <source>No messages</source>
@@ -603,7 +550,7 @@
     <name>PowerStatusWidget</name>
     <message>
         <source>Power settings</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Nastavitve energijske porabe</translation>
     </message>
 </context>
 <context>
@@ -688,31 +635,31 @@
     </message>
     <message>
         <source>Monday</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Ponedeljek</translation>
     </message>
     <message>
         <source>Tuesday</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Torek</translation>
     </message>
     <message>
         <source>Wednesday</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Sreda</translation>
     </message>
     <message>
         <source>Thursday</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Četrtek</translation>
     </message>
     <message>
         <source>Friday</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Petek</translation>
     </message>
     <message>
         <source>Saturday</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Sobota</translation>
     </message>
     <message>
         <source>Sunday</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Nedelja</translation>
     </message>
     <message>
         <source>Jan</source>
@@ -768,7 +715,7 @@
     </message>
     <message>
         <source>monday</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">ponedeljek</translation>
     </message>
     <message>
         <source>tuesday</source>

--- a/plugins/dde-dock/translations/dde-dock_sq.ts
+++ b/plugins/dde-dock/translations/dde-dock_sq.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="sq">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="sq">
 <context>
     <name>AirplaneModeItem</name>
     <message>
@@ -51,8 +53,8 @@
         <translation>Çaktivizuar</translation>
     </message>
     <message>
-        <source>Disable Airplane Mode first if you want to connect to a Bluetooth</source>
-        <translation>Nëse doni të lidheni me Bluetooth, së pari çaktivizoni Mënyrën Aeroplan</translation>
+        <source>Disable [Airplane Mode](#) first if you want to connect to a Bluetooth</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -383,61 +385,6 @@
     <message>
         <source>Theme</source>
         <translation>Temë</translation>
-    </message>
-</context>
-<context>
-    <name>MenuWorker</name>
-    <message>
-        <source>Fashion Mode</source>
-        <translation>Mënyra Modë</translation>
-    </message>
-    <message>
-        <source>Efficient Mode</source>
-        <translation>Mënyra Efikasitet</translation>
-    </message>
-    <message>
-        <source>Top</source>
-        <translation>Në krye</translation>
-    </message>
-    <message>
-        <source>Bottom</source>
-        <translation>Në fund</translation>
-    </message>
-    <message>
-        <source>Left</source>
-        <translation>Majtas</translation>
-    </message>
-    <message>
-        <source>Right</source>
-        <translation>Djathtas</translation>
-    </message>
-    <message>
-        <source>Keep Shown</source>
-        <translation>Mbaje të Shfaqur</translation>
-    </message>
-    <message>
-        <source>Keep Hidden</source>
-        <translation>Mbaje të Fshehur</translation>
-    </message>
-    <message>
-        <source>Smart Hide</source>
-        <translation>Fshehje e Mençur</translation>
-    </message>
-    <message>
-        <source>Mode</source>
-        <translation>Mënyrë</translation>
-    </message>
-    <message>
-        <source>Location</source>
-        <translation>Vendndodhje</translation>
-    </message>
-    <message>
-        <source>Status</source>
-        <translation>Gjendje</translation>
-    </message>
-    <message>
-        <source>Dock settings</source>
-        <translation>Rregullime paneli</translation>
     </message>
 </context>
 <context>

--- a/plugins/dde-dock/translations/dde-dock_sr.ts
+++ b/plugins/dde-dock/translations/dde-dock_sr.ts
@@ -53,7 +53,7 @@
         <translation type="unfinished">Искључен</translation>
     </message>
     <message>
-        <source>Disable Airplane Mode first if you want to connect to a Bluetooth</source>
+        <source>Disable [Airplane Mode](#) first if you want to connect to a Bluetooth</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -384,61 +384,6 @@
     </message>
     <message>
         <source>Theme</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>MenuWorker</name>
-    <message>
-        <source>Fashion Mode</source>
-        <translation>Модеран режим</translation>
-    </message>
-    <message>
-        <source>Efficient Mode</source>
-        <translation>Ефикасан режим</translation>
-    </message>
-    <message>
-        <source>Top</source>
-        <translation>Врх</translation>
-    </message>
-    <message>
-        <source>Bottom</source>
-        <translation>Дно</translation>
-    </message>
-    <message>
-        <source>Left</source>
-        <translation>Лево</translation>
-    </message>
-    <message>
-        <source>Right</source>
-        <translation>Десно</translation>
-    </message>
-    <message>
-        <source>Keep Shown</source>
-        <translation>Остави приказано</translation>
-    </message>
-    <message>
-        <source>Keep Hidden</source>
-        <translation>Остави скривено</translation>
-    </message>
-    <message>
-        <source>Smart Hide</source>
-        <translation>Паметно скривање</translation>
-    </message>
-    <message>
-        <source>Mode</source>
-        <translation>Режим</translation>
-    </message>
-    <message>
-        <source>Location</source>
-        <translation>Позиција</translation>
-    </message>
-    <message>
-        <source>Status</source>
-        <translation>Стање</translation>
-    </message>
-    <message>
-        <source>Dock settings</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/plugins/dde-dock/translations/dde-dock_sv.ts
+++ b/plugins/dde-dock/translations/dde-dock_sv.ts
@@ -53,7 +53,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Disable Airplane Mode first if you want to connect to a Bluetooth</source>
+        <source>Disable [Airplane Mode](#) first if you want to connect to a Bluetooth</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -384,61 +384,6 @@
     </message>
     <message>
         <source>Theme</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>MenuWorker</name>
-    <message>
-        <source>Fashion Mode</source>
-        <translation>Mode läge</translation>
-    </message>
-    <message>
-        <source>Efficient Mode</source>
-        <translation>Effektivt läge</translation>
-    </message>
-    <message>
-        <source>Top</source>
-        <translation>Toppen</translation>
-    </message>
-    <message>
-        <source>Bottom</source>
-        <translation>Botten</translation>
-    </message>
-    <message>
-        <source>Left</source>
-        <translation>Vänster</translation>
-    </message>
-    <message>
-        <source>Right</source>
-        <translation>Höger</translation>
-    </message>
-    <message>
-        <source>Keep Shown</source>
-        <translation>Behåll visad</translation>
-    </message>
-    <message>
-        <source>Keep Hidden</source>
-        <translation>Behåll gömd</translation>
-    </message>
-    <message>
-        <source>Smart Hide</source>
-        <translation>Smart gömd</translation>
-    </message>
-    <message>
-        <source>Mode</source>
-        <translation>Läge</translation>
-    </message>
-    <message>
-        <source>Location</source>
-        <translation>Plats</translation>
-    </message>
-    <message>
-        <source>Status</source>
-        <translation>Status</translation>
-    </message>
-    <message>
-        <source>Dock settings</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/plugins/dde-dock/translations/dde-dock_sv_SE.ts
+++ b/plugins/dde-dock/translations/dde-dock_sv_SE.ts
@@ -53,7 +53,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Disable Airplane Mode first if you want to connect to a Bluetooth</source>
+        <source>Disable [Airplane Mode](#) first if you want to connect to a Bluetooth</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -384,61 +384,6 @@
     </message>
     <message>
         <source>Theme</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>MenuWorker</name>
-    <message>
-        <source>Fashion Mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Efficient Mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Top</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Bottom</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Left</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Right</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Keep Shown</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Keep Hidden</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Smart Hide</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Location</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Status</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Dock settings</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/plugins/dde-dock/translations/dde-dock_sw.ts
+++ b/plugins/dde-dock/translations/dde-dock_sw.ts
@@ -53,7 +53,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Disable Airplane Mode first if you want to connect to a Bluetooth</source>
+        <source>Disable [Airplane Mode](#) first if you want to connect to a Bluetooth</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -384,61 +384,6 @@
     </message>
     <message>
         <source>Theme</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>MenuWorker</name>
-    <message>
-        <source>Fashion Mode</source>
-        <translation>Hali urembo</translation>
-    </message>
-    <message>
-        <source>Efficient Mode</source>
-        <translation>Hali uhifadhi</translation>
-    </message>
-    <message>
-        <source>Top</source>
-        <translation>Juu</translation>
-    </message>
-    <message>
-        <source>Bottom</source>
-        <translation>Chini</translation>
-    </message>
-    <message>
-        <source>Left</source>
-        <translation>Kushoto</translation>
-    </message>
-    <message>
-        <source>Right</source>
-        <translation>Kulia</translation>
-    </message>
-    <message>
-        <source>Keep Shown</source>
-        <translation>Tunza ionekane</translation>
-    </message>
-    <message>
-        <source>Keep Hidden</source>
-        <translation>Tunza ifiche</translation>
-    </message>
-    <message>
-        <source>Smart Hide</source>
-        <translation>Ficha maizi</translation>
-    </message>
-    <message>
-        <source>Mode</source>
-        <translation>Hali</translation>
-    </message>
-    <message>
-        <source>Location</source>
-        <translation>Pahali</translation>
-    </message>
-    <message>
-        <source>Status</source>
-        <translation>Hadhi</translation>
-    </message>
-    <message>
-        <source>Dock settings</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/plugins/dde-dock/translations/dde-dock_ta.ts
+++ b/plugins/dde-dock/translations/dde-dock_ta.ts
@@ -53,7 +53,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Disable Airplane Mode first if you want to connect to a Bluetooth</source>
+        <source>Disable [Airplane Mode](#) first if you want to connect to a Bluetooth</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -384,61 +384,6 @@
     </message>
     <message>
         <source>Theme</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>MenuWorker</name>
-    <message>
-        <source>Fashion Mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Efficient Mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Top</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Bottom</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Left</source>
-        <translation>இடது</translation>
-    </message>
-    <message>
-        <source>Right</source>
-        <translation>வலது</translation>
-    </message>
-    <message>
-        <source>Keep Shown</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Keep Hidden</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Smart Hide</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Mode</source>
-        <translation>முறை</translation>
-    </message>
-    <message>
-        <source>Location</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Status</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Dock settings</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/plugins/dde-dock/translations/dde-dock_te.ts
+++ b/plugins/dde-dock/translations/dde-dock_te.ts
@@ -53,7 +53,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Disable Airplane Mode first if you want to connect to a Bluetooth</source>
+        <source>Disable [Airplane Mode](#) first if you want to connect to a Bluetooth</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -384,61 +384,6 @@
     </message>
     <message>
         <source>Theme</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>MenuWorker</name>
-    <message>
-        <source>Fashion Mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Efficient Mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Top</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Bottom</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Left</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Right</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Keep Shown</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Keep Hidden</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Smart Hide</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Location</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Status</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Dock settings</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/plugins/dde-dock/translations/dde-dock_th.ts
+++ b/plugins/dde-dock/translations/dde-dock_th.ts
@@ -53,7 +53,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Disable Airplane Mode first if you want to connect to a Bluetooth</source>
+        <source>Disable [Airplane Mode](#) first if you want to connect to a Bluetooth</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -384,61 +384,6 @@
     </message>
     <message>
         <source>Theme</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>MenuWorker</name>
-    <message>
-        <source>Fashion Mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Efficient Mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Top</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Bottom</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Left</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Right</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Keep Shown</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Keep Hidden</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Smart Hide</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Location</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Status</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Dock settings</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/plugins/dde-dock/translations/dde-dock_tr.ts
+++ b/plugins/dde-dock/translations/dde-dock_tr.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="tr">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="tr">
 <context>
     <name>AirplaneModeItem</name>
     <message>
@@ -51,8 +53,8 @@
         <translation>Kapatıldı</translation>
     </message>
     <message>
-        <source>Disable Airplane Mode first if you want to connect to a Bluetooth</source>
-        <translation>Bluetooth&apos;a bağlanmak istiyorsanız önce Uçak Kipi&apos;ni devre dışı bırakın</translation>
+        <source>Disable [Airplane Mode](#) first if you want to connect to a Bluetooth</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -386,61 +388,6 @@
     </message>
 </context>
 <context>
-    <name>MenuWorker</name>
-    <message>
-        <source>Fashion Mode</source>
-        <translation>Moda Kipi</translation>
-    </message>
-    <message>
-        <source>Efficient Mode</source>
-        <translation>Verimli Kip</translation>
-    </message>
-    <message>
-        <source>Top</source>
-        <translation>Üst</translation>
-    </message>
-    <message>
-        <source>Bottom</source>
-        <translation>Alt</translation>
-    </message>
-    <message>
-        <source>Left</source>
-        <translation>Sol</translation>
-    </message>
-    <message>
-        <source>Right</source>
-        <translation>Sağ</translation>
-    </message>
-    <message>
-        <source>Keep Shown</source>
-        <translation>Sürekli Göster</translation>
-    </message>
-    <message>
-        <source>Keep Hidden</source>
-        <translation>Sürekli Gizle</translation>
-    </message>
-    <message>
-        <source>Smart Hide</source>
-        <translation>Akıllı Gizle</translation>
-    </message>
-    <message>
-        <source>Mode</source>
-        <translation>Kip</translation>
-    </message>
-    <message>
-        <source>Location</source>
-        <translation>Konum</translation>
-    </message>
-    <message>
-        <source>Status</source>
-        <translation>Durum</translation>
-    </message>
-    <message>
-        <source>Dock settings</source>
-        <translation>Rıhtım ayarları</translation>
-    </message>
-</context>
-<context>
     <name>NotificationPlugin</name>
     <message>
         <source>No messages</source>
@@ -494,7 +441,7 @@
     </message>
     <message>
         <source>Balance Performance</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -544,7 +491,7 @@
     </message>
     <message>
         <source>Capacity %1, not charging</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Battery</source>
@@ -564,7 +511,7 @@
     </message>
     <message>
         <source>%1 hr %2 min remaining</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Not charging</source>
@@ -576,15 +523,15 @@
     </message>
     <message>
         <source>Charging, %1 min until full</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Charging, %1 hr %2 min until full</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Capacity %1, %2 hr remaining</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>%1 hr remaining</source>
@@ -592,11 +539,11 @@
     </message>
     <message>
         <source>Charging %1, %2 hr until full</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Charging, %1 hr until full</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/plugins/dde-dock/translations/dde-dock_ug.ts
+++ b/plugins/dde-dock/translations/dde-dock_ug.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="ug">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ug">
 <context>
     <name>AirplaneModeItem</name>
     <message>
@@ -51,8 +53,8 @@
         <translation>كۆكچىشنى تاقاش</translation>
     </message>
     <message>
-        <source>Disable Airplane Mode first if you want to connect to a Bluetooth</source>
-        <translation type="unfinished"/>
+        <source>Disable [Airplane Mode](#) first if you want to connect to a Bluetooth</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -386,61 +388,6 @@
     </message>
 </context>
 <context>
-    <name>MenuWorker</name>
-    <message>
-        <source>Fashion Mode</source>
-        <translation>مودا ھالەت</translation>
-    </message>
-    <message>
-        <source>Efficient Mode</source>
-        <translation>يۇقىرى ئۈنۈملۈك ھالەت</translation>
-    </message>
-    <message>
-        <source>Top</source>
-        <translation>ئۈستى</translation>
-    </message>
-    <message>
-        <source>Bottom</source>
-        <translation>ئاستى تەرەپ</translation>
-    </message>
-    <message>
-        <source>Left</source>
-        <translation>سول تەرەپ</translation>
-    </message>
-    <message>
-        <source>Right</source>
-        <translation>ئوڭ تەرەپ</translation>
-    </message>
-    <message>
-        <source>Keep Shown</source>
-        <translation>كۆرسىتىش</translation>
-    </message>
-    <message>
-        <source>Keep Hidden</source>
-        <translation>يوشۇرۇش</translation>
-    </message>
-    <message>
-        <source>Smart Hide</source>
-        <translation>ئەقلىي يوشۇرۇش</translation>
-    </message>
-    <message>
-        <source>Mode</source>
-        <translation>ھالىتى</translation>
-    </message>
-    <message>
-        <source>Location</source>
-        <translation>ئورنى</translation>
-    </message>
-    <message>
-        <source>Status</source>
-        <translation>ھالىتى </translation>
-    </message>
-    <message>
-        <source>Dock settings</source>
-        <translation>ۋەزىپە ئىستونى تەڭشىكى</translation>
-    </message>
-</context>
-<context>
     <name>NotificationPlugin</name>
     <message>
         <source>No messages</source>
@@ -494,7 +441,7 @@
     </message>
     <message>
         <source>Balance Performance</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/plugins/dde-dock/translations/dde-dock_uk.ts
+++ b/plugins/dde-dock/translations/dde-dock_uk.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="uk">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="uk">
 <context>
     <name>AirplaneModeItem</name>
     <message>
@@ -51,8 +53,8 @@
         <translation>Вимкнено</translation>
     </message>
     <message>
-        <source>Disable Airplane Mode first if you want to connect to a Bluetooth</source>
-        <translation>Якщо ви хочете встановити з&apos;єднання з Bluetooth, спочатку вимкніть «Режим польоту»</translation>
+        <source>Disable [Airplane Mode](#) first if you want to connect to a Bluetooth</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -383,61 +385,6 @@
     <message>
         <source>Theme</source>
         <translation>Тема</translation>
-    </message>
-</context>
-<context>
-    <name>MenuWorker</name>
-    <message>
-        <source>Fashion Mode</source>
-        <translation>Модний режим</translation>
-    </message>
-    <message>
-        <source>Efficient Mode</source>
-        <translation>Практичний режим</translation>
-    </message>
-    <message>
-        <source>Top</source>
-        <translation>Вгорі</translation>
-    </message>
-    <message>
-        <source>Bottom</source>
-        <translation>Внизу</translation>
-    </message>
-    <message>
-        <source>Left</source>
-        <translation>Ліворуч</translation>
-    </message>
-    <message>
-        <source>Right</source>
-        <translation>Праворуч</translation>
-    </message>
-    <message>
-        <source>Keep Shown</source>
-        <translation>Показувати постійно</translation>
-    </message>
-    <message>
-        <source>Keep Hidden</source>
-        <translation>Приховувати</translation>
-    </message>
-    <message>
-        <source>Smart Hide</source>
-        <translation>Розумне приховування</translation>
-    </message>
-    <message>
-        <source>Mode</source>
-        <translation>Режим</translation>
-    </message>
-    <message>
-        <source>Location</source>
-        <translation>Розташування</translation>
-    </message>
-    <message>
-        <source>Status</source>
-        <translation>Статус</translation>
-    </message>
-    <message>
-        <source>Dock settings</source>
-        <translation>Параметри бічної панелі</translation>
     </message>
 </context>
 <context>

--- a/plugins/dde-dock/translations/dde-dock_ur.ts
+++ b/plugins/dde-dock/translations/dde-dock_ur.ts
@@ -53,7 +53,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Disable Airplane Mode first if you want to connect to a Bluetooth</source>
+        <source>Disable [Airplane Mode](#) first if you want to connect to a Bluetooth</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -384,61 +384,6 @@
     </message>
     <message>
         <source>Theme</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>MenuWorker</name>
-    <message>
-        <source>Fashion Mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Efficient Mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Top</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Bottom</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Left</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Right</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Keep Shown</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Keep Hidden</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Smart Hide</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Location</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Status</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Dock settings</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/plugins/dde-dock/translations/dde-dock_uz.ts
+++ b/plugins/dde-dock/translations/dde-dock_uz.ts
@@ -53,7 +53,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Disable Airplane Mode first if you want to connect to a Bluetooth</source>
+        <source>Disable [Airplane Mode](#) first if you want to connect to a Bluetooth</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -384,61 +384,6 @@
     </message>
     <message>
         <source>Theme</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>MenuWorker</name>
-    <message>
-        <source>Fashion Mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Efficient Mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Top</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Bottom</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Left</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Right</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Keep Shown</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Keep Hidden</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Smart Hide</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Location</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Status</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Dock settings</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/plugins/dde-dock/translations/dde-dock_vi.ts
+++ b/plugins/dde-dock/translations/dde-dock_vi.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="vi">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="vi">
 <context>
     <name>AirplaneModeItem</name>
     <message>
@@ -48,11 +50,11 @@
     </message>
     <message>
         <source>Turned off</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Đã tắt</translation>
     </message>
     <message>
-        <source>Disable Airplane Mode first if you want to connect to a Bluetooth</source>
-        <translation>Tắt chế độ máy bay trước nếu bạn muốn kết nối với Bluetooth</translation>
+        <source>Disable [Airplane Mode](#) first if you want to connect to a Bluetooth</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -386,61 +388,6 @@
     </message>
 </context>
 <context>
-    <name>MenuWorker</name>
-    <message>
-        <source>Fashion Mode</source>
-        <translation>Chế độ Thời trang</translation>
-    </message>
-    <message>
-        <source>Efficient Mode</source>
-        <translation>Chế độ Hiệu quả</translation>
-    </message>
-    <message>
-        <source>Top</source>
-        <translation>Trên đỉnh</translation>
-    </message>
-    <message>
-        <source>Bottom</source>
-        <translation>Dưới đáy</translation>
-    </message>
-    <message>
-        <source>Left</source>
-        <translation>Trái</translation>
-    </message>
-    <message>
-        <source>Right</source>
-        <translation>Phải</translation>
-    </message>
-    <message>
-        <source>Keep Shown</source>
-        <translation>Tiếp tục Hiển thị</translation>
-    </message>
-    <message>
-        <source>Keep Hidden</source>
-        <translation>Tiếp tục Ẩn</translation>
-    </message>
-    <message>
-        <source>Smart Hide</source>
-        <translation>Ẩn Thông minh</translation>
-    </message>
-    <message>
-        <source>Mode</source>
-        <translation>Chế độ</translation>
-    </message>
-    <message>
-        <source>Location</source>
-        <translation>Nơi chốn</translation>
-    </message>
-    <message>
-        <source>Status</source>
-        <translation>Tình trạng</translation>
-    </message>
-    <message>
-        <source>Dock settings</source>
-        <translation>Cài đặt thanh đế</translation>
-    </message>
-</context>
-<context>
     <name>NotificationPlugin</name>
     <message>
         <source>No messages</source>
@@ -603,7 +550,7 @@
     <name>PowerStatusWidget</name>
     <message>
         <source>Power settings</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Thiết lập năng lượng</translation>
     </message>
 </context>
 <context>
@@ -688,31 +635,31 @@
     </message>
     <message>
         <source>Monday</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Thứ hai</translation>
     </message>
     <message>
         <source>Tuesday</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Thứ ba</translation>
     </message>
     <message>
         <source>Wednesday</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Thứ tư</translation>
     </message>
     <message>
         <source>Thursday</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Thứ năm</translation>
     </message>
     <message>
         <source>Friday</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Thứ sáu</translation>
     </message>
     <message>
         <source>Saturday</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Thứ bảy</translation>
     </message>
     <message>
         <source>Sunday</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Chủ nhật</translation>
     </message>
     <message>
         <source>Jan</source>

--- a/plugins/dde-dock/translations/dde-dock_zh_CN.ts
+++ b/plugins/dde-dock/translations/dde-dock_zh_CN.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="zh_CN">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="zh_CN">
 <context>
     <name>AirplaneModeItem</name>
     <message>
@@ -51,8 +53,8 @@
         <translation>蓝牙关闭</translation>
     </message>
     <message>
-        <source>Disable Airplane Mode first if you want to connect to a Bluetooth</source>
-        <translation>如果要连接蓝牙，请先禁用飞行模式</translation>
+        <source>Disable [Airplane Mode](#) first if you want to connect to a Bluetooth</source>
+        <translation>如果要连接蓝牙，请先禁用[飞行模式](#)</translation>
     </message>
 </context>
 <context>
@@ -383,61 +385,6 @@
     <message>
         <source>Theme</source>
         <translation>主题</translation>
-    </message>
-</context>
-<context>
-    <name>MenuWorker</name>
-    <message>
-        <source>Fashion Mode</source>
-        <translation>时尚模式</translation>
-    </message>
-    <message>
-        <source>Efficient Mode</source>
-        <translation>高效模式</translation>
-    </message>
-    <message>
-        <source>Top</source>
-        <translation>上</translation>
-    </message>
-    <message>
-        <source>Bottom</source>
-        <translation>下</translation>
-    </message>
-    <message>
-        <source>Left</source>
-        <translation>左</translation>
-    </message>
-    <message>
-        <source>Right</source>
-        <translation>右</translation>
-    </message>
-    <message>
-        <source>Keep Shown</source>
-        <translation>一直显示</translation>
-    </message>
-    <message>
-        <source>Keep Hidden</source>
-        <translation>一直隐藏</translation>
-    </message>
-    <message>
-        <source>Smart Hide</source>
-        <translation>智能隐藏</translation>
-    </message>
-    <message>
-        <source>Mode</source>
-        <translation>模式</translation>
-    </message>
-    <message>
-        <source>Location</source>
-        <translation>位置</translation>
-    </message>
-    <message>
-        <source>Status</source>
-        <translation>状态</translation>
-    </message>
-    <message>
-        <source>Dock settings</source>
-        <translation>任务栏设置</translation>
     </message>
 </context>
 <context>

--- a/plugins/dde-dock/translations/dde-dock_zh_HK.ts
+++ b/plugins/dde-dock/translations/dde-dock_zh_HK.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="zh_HK">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="zh_HK">
 <context>
     <name>AirplaneModeItem</name>
     <message>
@@ -51,8 +53,8 @@
         <translation>藍牙關閉</translation>
     </message>
     <message>
-        <source>Disable Airplane Mode first if you want to connect to a Bluetooth</source>
-        <translation type="unfinished"/>
+        <source>Disable [Airplane Mode](#) first if you want to connect to a Bluetooth</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -386,85 +388,30 @@
     </message>
 </context>
 <context>
-    <name>MenuWorker</name>
-    <message>
-        <source>Fashion Mode</source>
-        <translation>時尚模式</translation>
-    </message>
-    <message>
-        <source>Efficient Mode</source>
-        <translation>高效模式</translation>
-    </message>
-    <message>
-        <source>Top</source>
-        <translation>上</translation>
-    </message>
-    <message>
-        <source>Bottom</source>
-        <translation>下</translation>
-    </message>
-    <message>
-        <source>Left</source>
-        <translation>左</translation>
-    </message>
-    <message>
-        <source>Right</source>
-        <translation>右</translation>
-    </message>
-    <message>
-        <source>Keep Shown</source>
-        <translation>一直顯示</translation>
-    </message>
-    <message>
-        <source>Keep Hidden</source>
-        <translation>一直隱藏</translation>
-    </message>
-    <message>
-        <source>Smart Hide</source>
-        <translation>智能隱藏</translation>
-    </message>
-    <message>
-        <source>Mode</source>
-        <translation>模式</translation>
-    </message>
-    <message>
-        <source>Location</source>
-        <translation>位置</translation>
-    </message>
-    <message>
-        <source>Status</source>
-        <translation>狀態</translation>
-    </message>
-    <message>
-        <source>Dock settings</source>
-        <translation>任務欄設置</translation>
-    </message>
-</context>
-<context>
     <name>NotificationPlugin</name>
     <message>
         <source>No messages</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Notification settings</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Notifications</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Turn off DND mode</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Turn on DND mode</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Notification</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -494,7 +441,7 @@
     </message>
     <message>
         <source>Balance Performance</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/plugins/dde-dock/translations/dde-dock_zh_TW.ts
+++ b/plugins/dde-dock/translations/dde-dock_zh_TW.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="zh_TW">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="zh_TW">
 <context>
     <name>AirplaneModeItem</name>
     <message>
@@ -51,8 +53,8 @@
         <translation>藍牙關閉</translation>
     </message>
     <message>
-        <source>Disable Airplane Mode first if you want to connect to a Bluetooth</source>
-        <translation type="unfinished"/>
+        <source>Disable [Airplane Mode](#) first if you want to connect to a Bluetooth</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -386,85 +388,30 @@
     </message>
 </context>
 <context>
-    <name>MenuWorker</name>
-    <message>
-        <source>Fashion Mode</source>
-        <translation>時尚模式</translation>
-    </message>
-    <message>
-        <source>Efficient Mode</source>
-        <translation>高效模式</translation>
-    </message>
-    <message>
-        <source>Top</source>
-        <translation>上</translation>
-    </message>
-    <message>
-        <source>Bottom</source>
-        <translation>下</translation>
-    </message>
-    <message>
-        <source>Left</source>
-        <translation>左</translation>
-    </message>
-    <message>
-        <source>Right</source>
-        <translation>右</translation>
-    </message>
-    <message>
-        <source>Keep Shown</source>
-        <translation>一直顯示</translation>
-    </message>
-    <message>
-        <source>Keep Hidden</source>
-        <translation>一直隱藏</translation>
-    </message>
-    <message>
-        <source>Smart Hide</source>
-        <translation>智慧隱藏</translation>
-    </message>
-    <message>
-        <source>Mode</source>
-        <translation>模式</translation>
-    </message>
-    <message>
-        <source>Location</source>
-        <translation>位置</translation>
-    </message>
-    <message>
-        <source>Status</source>
-        <translation>狀態</translation>
-    </message>
-    <message>
-        <source>Dock settings</source>
-        <translation>任務欄設定</translation>
-    </message>
-</context>
-<context>
     <name>NotificationPlugin</name>
     <message>
         <source>No messages</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Notification settings</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Notifications</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Turn off DND mode</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Turn on DND mode</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Notification</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -494,7 +441,7 @@
     </message>
     <message>
         <source>Balance Performance</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>


### PR DESCRIPTION
修正蓝牙插件中的飞行模式链接无法点击的问题(对应文案需后续更新)

另外修正了tray loader插件翻译无法正常更新的问题

PMS: BUG-284977
Log:

## Summary by Sourcery

Make the "Airplane Mode" text in the Bluetooth applet a clickable link to network settings and improve the build system's handling of translations.

Bug Fixes:
- Implement the "Airplane Mode" text in the Bluetooth applet as a clickable link.
- Ensure clicking the link opens the correct network settings page.

Build:
- Update CMake configuration for improved handling and updating of translation files.

Chores:
- Remove unused translations related to `MenuWorker`.
- Standardize XML encoding declarations and formatting in translation files.