### PR TITLE
fix: modify bluetooth scan timer interval

### DIFF
--- a/plugins/dde-dock/bluetooth/componments/bluetoothadapteritem.cpp
+++ b/plugins/dde-dock/bluetooth/componments/bluetoothadapteritem.cpp
@@ -397,9 +397,9 @@ void BluetoothAdapterItem::initUi()
 
 void BluetoothAdapterItem::initConnect()
 {
-    m_scanTimer->setInterval(DConfigHelper::instance()->getConfig("org.deepin.dde.dock", "org.deepin.dde.dock.plugin.bluetooth", "", "scanInterval", 10).toInt() * 1000);
+    m_scanTimer->setInterval(DConfigHelper::instance()->getConfig("org.deepin.dde.dock", "org.deepin.dde.dock.plugin.bluetooth", "", "scanInterval", 5).toInt() * 1000);
     DConfigHelper::instance()->bind("org.deepin.dde.dock", "org.deepin.dde.dock.plugin.bluetooth", "", this, "scanInterval", [this] (const QString&, const QVariant&, QObject*) {
-        m_scanTimer->setInterval(DConfigHelper::instance()->getConfig("org.deepin.dde.dock", "org.deepin.dde.dock.plugin.bluetooth", "", "scanInterval", 10).toInt() * 1000);
+        m_scanTimer->setInterval(DConfigHelper::instance()->getConfig("org.deepin.dde.dock", "org.deepin.dde.dock.plugin.bluetooth", "", "scanInterval", 5).toInt() * 1000);
     });
     connect(m_scanTimer, &QTimer::timeout, this, [this] {
         if (isVisible())

--- a/plugins/dde-dock/configs/org.deepin.dde.dock.plugin.bluetooth.json
+++ b/plugins/dde-dock/configs/org.deepin.dde.dock.plugin.bluetooth.json
@@ -3,7 +3,7 @@
     "version":"1.0",
     "contents":{
         "scanInterval":{
-            "value": 10,
+            "value":5,
             "serial": 0,
             "flags":[],
             "name":"scanInterval",


### PR DESCRIPTION
as title

Log: as title
Pms: BUG-285057

## Summary by Sourcery

Bug Fixes:
- Reduce the default Bluetooth scan interval from 10 seconds to 5 seconds.