### PR TITLE
fix: improve tray plugin color handling and initialization

### DIFF
--- a/src/tray-wayland-integration/plugin.cpp
+++ b/src/tray-wayland-integration/plugin.cpp
@@ -4,8 +4,11 @@
 
 #include "plugin.h"
 
+#include <DGuiApplicationHelper>
 #include <QMap>
 #include <cstdint>
+
+DGUI_USE_NAMESPACE
 
 namespace Plugin {
 class EmbedPluginPrivate
@@ -420,6 +423,10 @@ void PlatformInterfaceProxy::setFontPointSize(qreal newFontPointSize)
 
 QColor PlatformInterfaceProxy::activeColor() const
 {
+    if (!m_activeColor.isValid()) {
+        const auto palette = DGuiApplicationHelper::instance()->standardPalette(DGuiApplicationHelper::instance()->themeType());
+        return palette.color(QPalette::Highlight);
+    }
     return m_activeColor;
 }
 
@@ -468,5 +475,10 @@ void PlatformInterfaceProxy::setIconThemeName(const QByteArray &newIconThemeName
         return;
     m_iconThemeName = newIconThemeName;
     emit iconThemeNameChanged(newIconThemeName);
+}
+
+PlatformInterfaceProxy::PlatformInterfaceProxy(QObject *parent)
+    : QObject(parent)
+{
 }
 }

--- a/src/tray-wayland-integration/plugin.h
+++ b/src/tray-wayland-integration/plugin.h
@@ -190,8 +190,10 @@ Q_SIGNALS:
     void iconThemeNameChanged(QByteArray iconThemeName);
 
 private:
+    explicit PlatformInterfaceProxy(QObject *parent = nullptr);
+
     QByteArray m_fontName;
-    qreal m_fontPointSize;
+    qreal m_fontPointSize {0};
     QColor m_activeColor;
     QColor m_darkActiveColor;
     QByteArray m_themeName;

--- a/src/tray-wayland-integration/pluginmanagerintegration.cpp
+++ b/src/tray-wayland-integration/pluginmanagerintegration.cpp
@@ -12,6 +12,8 @@
 namespace Plugin {
 PluginManagerIntegration::PluginManagerIntegration()
     : QWaylandShellIntegrationTemplate<PluginManagerIntegration>(1)
+    , m_dockPosition(0)
+    , m_dockColorType(0)
 {
     qInfo() << "PluginManagerIntegration22";
 }


### PR DESCRIPTION
1. Added DGuiApplicationHelper dependency for proper theme support
2. Implemented fallback color handling in activeColor() using system
palette
3. Added explicit constructor for PlatformInterfaceProxy
4. Initialized fontPointSize with default value 0
5. Added initialization for dockPosition and dockColorType in
PluginManagerIntegration

These changes improve the robustness of the tray plugin by:
- Ensuring proper color theming support through DGuiApplicationHelper
- Preventing potential null pointer issues with proper initialization
- Adding fallback behavior when active color is not set
- Fixing potential uninitialized variable issues

fix: 改进托盘插件颜色处理和初始化

1. 添加 DGuiApplicationHelper 依赖以支持主题
2. 在 activeColor() 中实现使用系统调色板的备用颜色处理
3. 为 PlatformInterfaceProxy 添加显式构造函数
4. 将 fontPointSize 初始化为默认值 0
5. 在 PluginManagerIntegration 中初始化 dockPosition 和 dockColorType

这些改进通过以下方式增强了托盘插件的健壮性：
- 通过 DGuiApplicationHelper 确保正确的主题支持
- 通过适当的初始化防止潜在的指针问题
- 当活动颜色未设置时添加备用行为
- 修复潜在的未初始化变量问题

pms: BUG-314263

## Summary by Sourcery

Improve color handling and initialization within the Wayland tray plugin.

Bug Fixes:
- Initialize member variables (`fontPointSize`, `dockPosition`, `dockColorType`) to prevent potential errors.
- Ensure `PlatformInterfaceProxy` is properly constructed by adding an explicit constructor.

Enhancements:
- Implement fallback active color retrieval from the system theme palette.

Chores:
- Introduce `DGuiApplicationHelper` dependency to enhance theme support.