### PR TITLE
fix: bluetooth popup display error elided name

### DIFF
--- a/plugins/dde-dock/bluetooth/componments/bluetoothadapteritem.cpp
+++ b/plugins/dde-dock/bluetooth/componments/bluetoothadapteritem.cpp
@@ -123,9 +123,9 @@ void BluetoothAdapterItem::onTopDeviceItem(PluginStandardItem *item)
     }
 }
 
-void BluetoothAdapterItem::onAdapterNameChanged(const QString name)
+void BluetoothAdapterItem::onAdapterNameChanged(const QString &name)
 {
-    m_adapterLabel->label()->setText(name);
+    m_adapterLabel->setText(name);
 }
 
 QSize BluetoothAdapterItem::sizeHint() const

--- a/plugins/dde-dock/bluetooth/componments/bluetoothadapteritem.h
+++ b/plugins/dde-dock/bluetooth/componments/bluetoothadapteritem.h
@@ -158,7 +158,7 @@ public slots:
     // 将已连接的蓝牙设备放到列表第一个
     void onTopDeviceItem(PluginStandardItem *item);
     // 设置蓝牙适配器名称
-    void onAdapterNameChanged(const QString name);
+    void onAdapterNameChanged(const QString &name);
 
     QSize sizeHint() const override;
 

--- a/plugins/dde-dock/bluetooth/componments/bluetoothapplet.cpp
+++ b/plugins/dde-dock/bluetooth/componments/bluetoothapplet.cpp
@@ -57,6 +57,14 @@ void SettingLabel::addButton(QWidget *button, int space)
     m_layout->addSpacing(space);
 }
 
+void SettingLabel::setText(const QString &text)
+{
+    const QFontMetrics fm(m_label->fontMetrics());
+    QString elidedText = fm.elidedText(text, m_label->elideMode(), m_label->width());
+
+    m_label->setText(elidedText);
+}
+
 void SettingLabel::mousePressEvent(QMouseEvent *ev)
 {
     if (ev->button() == Qt::LeftButton) {

--- a/plugins/dde-dock/bluetooth/componments/bluetoothapplet.h
+++ b/plugins/dde-dock/bluetooth/componments/bluetoothapplet.h
@@ -41,6 +41,7 @@ public:
     void addButton(QWidget *button, int space);
 
     DLabel *label() { return m_label; }
+    void setText(const QString &text);
 
 signals:
     void clicked();


### PR DESCRIPTION
as title

Log: as title
Pms: BUG-285143

## Summary by Sourcery

Bug Fixes:
- Fix long Bluetooth adapter names overflowing by ensuring they are properly elided.