### PR TITLE
fix: app crashed by recursive called for theme palette

### DIFF
--- a/src/tray-wayland-integration/plugin.cpp
+++ b/src/tray-wayland-integration/plugin.cpp
@@ -423,10 +423,6 @@ void PlatformInterfaceProxy::setFontPointSize(qreal newFontPointSize)
 
 QColor PlatformInterfaceProxy::activeColor() const
 {
-    if (!m_activeColor.isValid()) {
-        const auto palette = DGuiApplicationHelper::instance()->standardPalette(DGuiApplicationHelper::instance()->themeType());
-        return palette.color(QPalette::Highlight);
-    }
     return m_activeColor;
 }
 


### PR DESCRIPTION
DGuiApplicationHelper::themeType will fetch DPlatformTheme::activeColor.
and it's activeColor is only a fallback, it will be updated after.

pms: BUG-315473
