### PR TITLE
Revert "fix: playing sound when sound slider released"

### DIFF
--- a/plugins/dde-dock/common/slidercontainer.cpp
+++ b/plugins/dde-dock/common/slidercontainer.cpp
@@ -69,9 +69,6 @@ SliderContainer::SliderContainer(QWidget *parent)
     installEventFilter(this);
 
     connect(m_slider, &QSlider::valueChanged, this, &SliderContainer::sliderValueChanged);
-    connect(m_slider, &QSlider::sliderReleased, this, [this] {
-        Q_EMIT sliderReleased(m_slider->value());
-    });
 
     connect(DGuiApplicationHelper::instance(), &DGuiApplicationHelper::themeTypeChanged, this, [this]{
         QColor tipColor;
@@ -100,9 +97,6 @@ void SliderContainer::setSlider(QSlider *slider)
     m_slider->installEventFilter(this);
 
     connect(m_slider, &QSlider::valueChanged, this, &SliderContainer::sliderValueChanged);
-    connect(m_slider, &QSlider::sliderReleased, this, [this] {
-        Q_EMIT sliderReleased(m_slider->value());
-    });
 }
 
 void SliderContainer::setSlider(Dtk::Widget::DSlider *slider)
@@ -113,9 +107,6 @@ void SliderContainer::setSlider(Dtk::Widget::DSlider *slider)
     slider->installEventFilter(this);
 
     connect(m_slider, &QSlider::valueChanged, this, &SliderContainer::sliderValueChanged);
-    connect(m_slider, &QSlider::sliderReleased, this, [this] {
-        Q_EMIT sliderReleased(m_slider->value());
-    });
 }
 
 void SliderContainer::setTip(const QString &text, TitlePosition pos)

--- a/plugins/dde-dock/common/slidercontainer.h
+++ b/plugins/dde-dock/common/slidercontainer.h
@@ -71,7 +71,6 @@ Q_SIGNALS:
     void iconClicked(IconPosition pos);
     void sliderValueChanged(int value);
     void panelClicked();
-    void sliderReleased(int value);
 
 public slots:
     void updateSliderValue(int value);

--- a/plugins/dde-dock/sound/soundapplet.cpp
+++ b/plugins/dde-dock/sound/soundapplet.cpp
@@ -122,7 +122,7 @@ void SoundApplet::initConnections()
     connect(DGuiApplicationHelper::instance(), &DGuiApplicationHelper::themeTypeChanged, this, &SoundApplet::refreshIcon);
     connect(qApp, &DApplication::iconThemeChanged, this, &SoundApplet::refreshIcon);
 
-    connect(m_volumeSlider, &DockSlider::sliderReleased, this, &SoundApplet::volumeSliderValueChanged);
+    connect(m_volumeSlider, &DockSlider::valueChanged, this, &SoundApplet::volumeSliderValueChanged);
     connect(m_sliderContainer, &SliderContainer::iconClicked, this, [this](SliderContainer::IconPosition icon) {
         if (icon == SliderContainer::LeftIcon && SoundController::ref().existActiveOutputDevice() && m_defSinkInter) {
             m_defSinkInter->SetMuteQueued(!m_defSinkInter->mute());

--- a/plugins/dde-dock/sound/soundquickpanel.cpp
+++ b/plugins/dde-dock/sound/soundquickpanel.cpp
@@ -75,7 +75,7 @@ void SoundQuickPanel::initConnection()
         refreshWidget();
     });
 
-    connect(m_sliderContainer, &SliderContainer::sliderReleased, this, [this](int value) {
+    connect(m_sliderContainer, &SliderContainer::sliderValueChanged, this, [this](int value) {
         SoundController::ref().SetVolume(value * 0.01, true);
     });
     connect(&SoundModel::ref(), &SoundModel::activePortChanged, this, &SoundQuickPanel::refreshWidget);


### PR DESCRIPTION
Reverts linuxdeepin/dde-tray-loader#286

## Summary by Sourcery

Bug Fixes:
- Restore the behavior where sound actions are triggered immediately as the volume slider value changes.