### PR TITLE
fix: airplane plugin does not show in tray area

### DIFF
--- a/plugins/dde-dock/airplane-mode/airplanemodeplugin.cpp
+++ b/plugins/dde-dock/airplane-mode/airplanemodeplugin.cpp
@@ -17,7 +17,7 @@ Q_LOGGING_CATEGORY(AIRPLANE, "org.deepin.dde.dock.airplane-mode")
 AirplaneModePlugin::AirplaneModePlugin(QObject *parent)
     : QObject(parent)
     , m_item(new AirplaneModeItem)
-    , m_dconfig(DConfig::create("org.deepin.dde.tray-loader", "org.deepin.dde.network", QString(), this))
+    , m_dconfig(DConfig::create("org.deepin.dde.network", "org.deepin.dde.network", QString(), this))
     , m_quickPanelWidget(new QuickPanelWidget)
     , m_messageCallback(nullptr)
 {


### PR DESCRIPTION
dconfig appId has error, because network module was removed form this repo.

Log: as title
Pms: BUG-313763

## Summary by Sourcery

Bug Fixes:
- Corrected the DConfig app identifier to resolve issues with the airplane mode plugin in the tray area