### PR TITLE
fix: close applet popup after bluetooth adaptor was removed

### DIFF
--- a/plugins/dde-dock/bluetooth/bluetoothitem.cpp
+++ b/plugins/dde-dock/bluetooth/bluetoothitem.cpp
@@ -54,7 +54,12 @@ BluetoothItem::BluetoothItem(AdaptersManager *adapterManager, QWidget *parent)
         refreshTips();
     });
     connect(DGuiApplicationHelper::instance(), &DGuiApplicationHelper::themeTypeChanged, this, &BluetoothItem::refreshIcon);
-    connect(m_applet, &BluetoothApplet::noAdapter, this, &BluetoothItem::noAdapter);
+    connect(m_applet, &BluetoothApplet::noAdapter, this, [this] {
+        if (m_applet->isVisible()) {
+            m_applet->setVisible(false);
+        }
+        Q_EMIT noAdapter();
+    });
     connect(m_applet, &BluetoothApplet::justHasAdapter, this, &BluetoothItem::justHasAdapter);
     connect(m_applet, &BluetoothApplet::requestHideApplet, this, &BluetoothItem::requestHideApplet);
     connect(m_quickPanel, &QuickPanelWidget::panelClicked, this, &BluetoothItem::requestExpand);

--- a/plugins/dde-dock/bluetooth/bluetoothplugin.cpp
+++ b/plugins/dde-dock/bluetooth/bluetoothplugin.cpp
@@ -160,13 +160,9 @@ void BluetoothPlugin::refreshPluginItemsVisible()
     if(!m_proxyInter)
         return;
 
-    if (pluginIsDisable() || !m_enableState) {
+    if (pluginIsDisable() || !m_enableState)
         m_proxyInter->itemRemoved(this, BLUETOOTH_KEY);
-        auto popupWidget = m_bluetoothItem->popupApplet();
-        if (popupWidget && popupWidget->isVisible()) {
-            popupWidget->setVisible(false);
-        }
-    } else
+    else
         m_proxyInter->itemAdded(this, BLUETOOTH_KEY);
 }
 


### PR DESCRIPTION
as title

Log: as title
Pms: BUG-285035

## Summary by Sourcery

Bug Fixes:
- Ensure the Bluetooth applet popup is hidden when no Bluetooth adapters are present