### PR TITLE
refactor: reorder power mode options in performance controller

### DIFF
--- a/plugins/dde-dock/power/performancemodecontroller.h
+++ b/plugins/dde-dock/power/performancemodecontroller.h
@@ -51,15 +51,15 @@ private:
     {
         m_sysPowerInter->setSync(false);
         const QList<QPair<QString, QString>> powerModeList = {
-            QPair<QString, QString>(BALANCE, tr("Balanced")),
-            QPair<QString, QString>(BALANCEPERFORMANCE, tr("Balance Performance")),
             QPair<QString, QString>(PERFORMANCE, tr("High Performance")),
+            QPair<QString, QString>(BALANCEPERFORMANCE, tr("Balance Performance")),
+            QPair<QString, QString>(BALANCE, tr("Balanced")),
             QPair<QString, QString>(POWERSAVE, tr("Power Saver"))
         };
         const QMap<QString, QString>powerModeProperty = {
-            {BALANCE, "IsBalanceSupported"},
-            {BALANCEPERFORMANCE, "IsBalancePerformanceSupported"},
             {PERFORMANCE, "IsHighPerformanceSupported"},
+            {BALANCEPERFORMANCE, "IsBalancePerformanceSupported"},
+            {BALANCE, "IsBalanceSupported"},
             {POWERSAVE, "IsPowerSaveSupported"}
         };
 


### PR DESCRIPTION
1. Changed the order of power mode options in PerformanceModeController
2. Now shows High Performance first, followed by Balance Performance and Balanced mode
3. Matching property map was also reordered to maintain consistency
4. This change likely reflects a new priority order for power modes where performance is emphasized

refactor: 性能控制器中电源模式选项重新排序

1. 修改了PerformanceModeController中电源模式选项的顺序
2. 现在首先显示高性能模式，然后是平衡性能和平衡模式
3. 匹配的属性映射也重新排序以保持一致性
4. 此变更可能反映了电源模式的新优先级顺序，其中性能被强调

pms: BUG-271001

## Summary by Sourcery

Enhancements:
- Adjust power mode list and corresponding property map order to prioritize High Performance over Balance Performance and Balanced