### PR TITLE
fix: when hide plugin,setting button sholud be hided.

### DIFF
--- a/plugins/dde-dock/common/jumpsettingbutton.cpp
+++ b/plugins/dde-dock/common/jumpsettingbutton.cpp
@@ -79,6 +79,10 @@ bool JumpSettingButton::event(QEvent* e)
         m_hover = e->type() == QEvent::Enter;
         update();
         break;
+    case QEvent::Hide:
+        m_hover = false;
+        update();
+        break;
     default:
         break;
     }

--- a/plugins/dde-network-display-ui/plugins/dock-wirelesscasting-plugin/src/widget/jumpsettingbutton.cpp
+++ b/plugins/dde-network-display-ui/plugins/dock-wirelesscasting-plugin/src/widget/jumpsettingbutton.cpp
@@ -79,6 +79,10 @@ bool JumpSettingButton::event(QEvent* e)
         m_hover = e->type() == QEvent::Enter;
         update();
         break;
+    case QEvent::Hide:
+        m_hover = false;
+        update();
+        break;
     default:
         break;
     }


### PR DESCRIPTION
as title.

PMS-BUG-310045

## Summary by Sourcery

Reset and redraw JumpSettingButton on QEvent::Hide to ensure the settings button hides correctly when its plugin is hidden.

Bug Fixes:
- Handle QEvent::Hide in JumpSettingButton to clear hover state and trigger update in dde-dock.
- Handle QEvent::Hide in JumpSettingButton to clear hover state and trigger update in wireless casting plugin.