### PR TITLE
fix: sound plugin display incorrect volume tips

### DIFF
--- a/plugins/dde-dock/sound/soundcontroller.cpp
+++ b/plugins/dde-dock/sound/soundcontroller.cpp
@@ -87,8 +87,8 @@ void SoundController::onDefaultSinkChanged(const QDBusObjectPath &path)
 
     // 音量和静音状态变化时手动获取下另外一个的状态，有时候收不到 changed 信号
     connect(m_defaultSinkInter, &DBusSink::MuteChanged, &SoundModel::ref(), [this] (bool value) {
-        SoundModel::ref().setVolume(m_defaultSinkInter->volume());
         SoundModel::ref().setMute(m_defaultSinkInter->mute());
+        SoundModel::ref().setVolume(m_defaultSinkInter->volume());
     });
     connect(m_defaultSinkInter, &DBusSink::VolumeChanged, &SoundModel::ref(), [this] (double value) {
         SoundModel::ref().setVolume(value);

--- a/plugins/dde-dock/sound/soundview.cpp
+++ b/plugins/dde-dock/sound/soundview.cpp
@@ -47,12 +47,12 @@ SoundView::SoundView(QWidget *parent)
     });
     connect(m_applet.data(), &SoundApplet::requestHideApplet, this, &SoundView::requestHideApplet);
 
-    refresh(SoundModel::ref().volume());
+    refresh();
 }
 
 QWidget *SoundView::tipsWidget()
 {
-    refreshTips(std::min(150, SoundModel::ref().volume()), true);
+    refreshTips(true);
     m_tipsLabel->resize(m_tipsLabel->sizeHint().width() + 10,
                         m_tipsLabel->sizeHint().height());
 
@@ -147,10 +147,10 @@ bool SoundView::eventFilter(QObject *watched, QEvent *event)
     return QWidget::eventFilter(watched, event);
 }
 
-void SoundView::refresh(const int volume)
+void SoundView::refresh()
 {
     refreshIcon();
-    refreshTips(volume, false);
+    refreshTips(false);
 }
 
 void SoundView::refreshIcon()
@@ -176,7 +176,7 @@ void SoundView::refreshIcon()
     m_iconWidget->setIcon(QIcon::fromTheme(iconString));
 }
 
-void SoundView::refreshTips(const int volume, const bool force)
+void SoundView::refreshTips(const bool force)
 {
     if (!force && !m_tipsLabel->isVisible())
         return;
@@ -187,6 +187,7 @@ void SoundView::refreshTips(const int volume, const bool force)
         if (SoundModel::ref().isMute()) {
             m_tipsLabel->setText(QString(tr("Mute")));
         } else {
+            auto volume = std::min(150, SoundModel::ref().volume());
             m_tipsLabel->setText(QString(tr("Volume %1").arg(QString::number(volume) + '%')));
         }
     }

--- a/plugins/dde-dock/sound/soundview.h
+++ b/plugins/dde-dock/sound/soundview.h
@@ -35,7 +35,7 @@ public:
     const QString contextMenu();
     void invokeMenuItem(const QString menuId, const bool checked);
     void refreshIcon();
-    void refreshTips(const int volume, const bool force = false);
+    void refreshTips(const bool force = false);
     void setAppletMinHeight(int minHeight);
 
 signals:
@@ -47,7 +47,7 @@ protected:
     bool eventFilter(QObject *watched, QEvent *event) override;
 
 private slots:
-    void refresh(const int volume);
+    void refresh();
 
 private:
     Dock::TipsWidget *m_tipsLabel;


### PR DESCRIPTION
mute status changed, then update volume tips, false status revert to zero, so tips show 0 value

Log: as title
Pms: BUG-313463

## Summary by Sourcery

Simplify the SoundView refresh logic by removing explicit volume arguments and always fetching the latest volume inside refreshTips, resolving wrong volume displays after mute toggles.

Bug Fixes:
- Fix incorrect volume tip display by ensuring volume is fetched after mute status changes

Enhancements:
- Refactor SoundView by removing explicit volume parameters and centralizing volume retrieval in refreshTips