### PR TITLE
fix: dateTime plugin only responds to short format changes from dde-c…

### DIFF
--- a/plugins/dde-dock/datetime/datetimeplugin.cpp
+++ b/plugins/dde-dock/datetime/datetimeplugin.cpp
@@ -172,6 +172,7 @@ const QString DatetimePlugin::itemContextMenu(const QString &itemKey)
     QList<QVariant> items;
 
     QMap<QString, QVariant> settings;
+#if 0 // 隐藏时间设置:BUG-303071
     settings["itemId"] = "settings";
     if (m_centralWidget->is24HourFormat())
         settings["itemText"] = tr("12-hour time");
@@ -179,7 +180,7 @@ const QString DatetimePlugin::itemContextMenu(const QString &itemKey)
         settings["itemText"] = tr("24-hour time");
     settings["isActive"] = true;
     items.push_back(settings);
-
+#endif
     if (!QFile::exists(ICBC_CONF_FILE)) {
         QMap<QString, QVariant> open;
         open["itemId"] = "open";

--- a/plugins/dde-dock/datetime/datetimewidget.cpp
+++ b/plugins/dde-dock/datetime/datetimewidget.cpp
@@ -113,7 +113,7 @@ void DatetimeWidget::updateDateTimeString()
     const auto position = qApp->property(PROP_POSITION).value<Dock::Position>();
     QString timeStr, dateString;
     if (position == Dock::Bottom || position == Dock::Top) {
-        QString timeFormat = m_24HourFormat ? "hh:mm" : m_regionFormat->getShortTimeFormat();
+        QString timeFormat = m_regionFormat->getShortTimeFormat();
         timeStr = locale.toString(current, timeFormat);
         dateString = current.toString(m_regionFormat->getShortDateFormat());
 
@@ -124,9 +124,12 @@ void DatetimeWidget::updateDateTimeString()
             QString apText = locale.toString(current, "AP");
             m_apLabel->setText(apText);
 
-            timeStr = current.toString("h:mm");
+            QString timeFormat = m_regionFormat->getShortTimeFormat();
+            timeFormat.replace("AP", "");
+            timeFormat.replace(" ", "");
+            timeStr = current.toString(timeFormat);
         } else {
-            timeStr = current.toString("hh:mm");
+            timeStr = current.toString(m_regionFormat->getShortTimeFormat());
         }
 
         m_timeLabel->setText(timeStr);


### PR DESCRIPTION
…ontrol-center

1.datetime plugin has no time format menu
2.only responds to short format changes from dcc.

Pms: BUG-303071,BUG-286253

## Summary by Sourcery

Enforce region-based short time formatting in the datetime widget and remove the manual 12/24-hour toggle from the context menu.

Bug Fixes:
- Hide the nonfunctional 12/24-hour toggle menu item in the datetime plugin

Enhancements:
- Always use the region’s short time format for rendering time displays
- Strip ‘AP’ markers and extra spaces when displaying AM/PM times