### PR TITLE
chore: bump version to 1.99.28

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+dde-tray-loader (1.99.28) unstable; urgency=medium
+
+  * fix: timeDate plugin crash
+  * fix: dateTime plugin only responds to short format changes from dde-control-center
+  * [skip CI] Translate dde-dock.ts in es (#319)
+
+ -- zhangkun <zhangkun2@uniontech.com>  Thu, 12 Jun 2025 19:48:15 +0800
+
 dde-tray-loader (1.99.27) unstable; urgency=medium
 
   * refactor: move dock context menu implementation to loader module


### PR DESCRIPTION
as title

Log: as title

## Summary by Sourcery

Chores:
- Update Debian changelog entry to version 1.99.28