### PR TITLE
chore: bump version to 2.0.0

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-tray-loader (2.0.0) unstable; urgency=medium
+
+  * i18n: Updates for project Deepin Desktop Environment (#324)
+
+ -- YeShanShan <yeshanshan@uniontech.com>  Thu, 19 Jun 2025 10:18:17 +0800
+
 dde-tray-loader (1.99.28) unstable; urgency=medium
 
   * fix: timeDate plugin crash


### PR DESCRIPTION
update changelog to 2.0.0

## Summary by Sourcery

Chores:
- Bump Debian package version to 2.0.0