### PR TITLE
chore: bump version to 2.0.1

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+dde-tray-loader (2.0.1) unstable; urgency=medium
+
+  * refactor: replace DIconButton with DToolButton for calendar
+    navigation
+
+ -- YeShanShan <yeshanshan@uniontech.com>  Thu, 19 Jun 2025 17:31:50 +0800
+
 dde-tray-loader (2.0.0) unstable; urgency=medium
 
   * i18n: Updates for project Deepin Desktop Environment (#324)


### PR DESCRIPTION
update changelog to 2.0.1

## Summary by Sourcery

Chores:
- Bump Debian changelog entry to version 2.0.1