### PR TITLE
chore: bump version to 2.0.2

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-tray-loader (2.0.2) unstable; urgency=medium
+
+  * chore: remove unused Spanish translation files
+
+ -- YeShanShan <yeshanshan@uniontech.com>  Mon, 23 Jun 2025 17:28:46 +0800
+
 dde-tray-loader (2.0.1) unstable; urgency=medium
 
   * refactor: replace DIconButton with DToolButton for calendar


### PR DESCRIPTION
update changelog to 2.0.2