### PR TITLE
fix: add hardening build flags to debian/rules

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -2,6 +2,10 @@
 DPKG_EXPORT_BUILDFLAGS = 1
 include /usr/share/dpkg/default.mk
 export QT_SELECT = qt5
+export DEB_BUILD_MAINT_OPTIONS = hardening=+all
+export DEB_CFLAGS_MAINT_APPEND = -Wall
+export DEB_CXXFLAGS_MAINT_APPEND = -Wall
+export DEB_LDFLAGS_MAINT_APPEND = -Wl,--as-needed -Wl,-z,relro -Wl,-z,now -Wl,-z,noexecstack -Wl,-E
 
 DEB_HOST_MULTIARCH ?= $(shell dpkg-architecture -qDEB_HOST_MULTIARCH)
 


### PR DESCRIPTION
Added several security hardening build flags to the Debian package build configuration:
1. Set DEB_BUILD_MAINT_OPTIONS to enable all hardening features
2. Added -Wall warning flag for both C and C++ compilers
3. Added linker flags for security features including RELRO, immediate binding, noexecstack, and export dynamic
These changes improve the security of the resulting binary by enabling various compiler and linker protections against common exploitation techniques

fix: 在 debian/rules 中添加安全加固构建标志

在 Debian 软件包构建配置中添加了多个安全加固构建标志：
1. 设置 DEB_BUILD_MAINT_OPTIONS 以启用所有加固功能
2. 为 C 和 C++ 编译器添加 -Wall 警告标志
3. 添加链接器标志以实现安全功能，包括 RELRO、立即绑定、noexecstack 和导 出动态
这些更改通过启用各种编译器和链接器保护来防止常见利用技术，从而提高生成二
进制文件的安全性