### PR TITLE
feat: add Traditional Chinese translations for tray plugin

### DIFF
--- a/src/loader/translations/trayplugin-loader_zh_HK.ts
+++ b/src/loader/translations/trayplugin-loader_zh_HK.ts
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="zh_HK">
+<context>
+    <name>PluginItem</name>
+    <message>
+        <location filename="../pluginitem.cpp" line="89"/>
+        <source>Remove from dock</source>
+        <translation>拿掉駐留</translation>
+    </message>
+</context>
+<context>
+    <name>QuickPluginItem</name>
+    <message>
+        <location filename="../quickpluginitem.cpp" line="160"/>
+        <source>Remove from dock</source>
+        <translation>從任務列移除</translation>
+    </message>
+    <message>
+        <location filename="../quickpluginitem.cpp" line="160"/>
+        <source>Pin to dock</source>
+        <translation>固定到任務列</translation>
+    </message>
+</context>
+</TS>

--- a/src/loader/translations/trayplugin-loader_zh_TW.ts
+++ b/src/loader/translations/trayplugin-loader_zh_TW.ts
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="zh_TW">
+<context>
+    <name>PluginItem</name>
+    <message>
+        <location filename="../pluginitem.cpp" line="89"/>
+        <source>Remove from dock</source>
+        <translation>拿掉駐留</translation>
+    </message>
+</context>
+<context>
+    <name>QuickPluginItem</name>
+    <message>
+        <location filename="../quickpluginitem.cpp" line="160"/>
+        <source>Remove from dock</source>
+        <translation>從任務列移除</translation>
+    </message>
+    <message>
+        <location filename="../quickpluginitem.cpp" line="160"/>
+        <source>Pin to dock</source>
+        <translation>固定到任務列</translation>
+    </message>
+</context>
+</TS>


### PR DESCRIPTION
1. Added new translation files for Traditional Chinese (zh_HK and zh_TW)
2. Translated "Remove from dock" and "Pin to dock" strings
3. Different translations provided for PluginItem and QuickPluginItem contexts
4. Supports Hong Kong and Taiwan Chinese variants with appropriate terminology

feat: 添加托盘插件的繁体中文翻译

1. 新增繁体中文(香港和台湾)翻译文件
2. 翻译了"Remove from dock"和"Pin to dock"字符串
3. 为PluginItem和QuickPluginItem上下文提供不同的翻译
4. 支持香港和台湾的中文变体并使用适当的术语

## Summary by Sourcery

Add Traditional Chinese (Hong Kong and Taiwan) translations for the tray plugin by creating separate localization files and translating key UI actions.

New Features:
- Add zh_HK and zh_TW translation files for the tray plugin
- Localize ‘Remove from dock’ and ‘Pin to dock’ strings in PluginItem and QuickPluginItem for Hong Kong and Taiwan variants