### PR TITLE
fix: adjust height calculation order in BluetoothApplet

### DIFF
--- a/plugins/dde-dock/bluetooth/componments/bluetoothapplet.cpp
+++ b/plugins/dde-dock/bluetooth/componments/bluetoothapplet.cpp
@@ -340,15 +340,15 @@ void BluetoothApplet::updateSize()
     static const int settingHeight = DeviceItemHeight + 10 + 10;
     height += settingHeight;
 
-    // 如果比快捷面板允许的最小高度还小，则以快捷面板允许的最小高度为准
-    const int hMargins = m_mainLayout->contentsMargins().top() + m_mainLayout->contentsMargins().bottom();
-    height = qMax(m_minHeight - hMargins, height);
-
     // 最大的高度为显示8个设备的高度
     static const int maxHeight = (TitleHeight + TitleSpace) + (MaxDeviceCount * DeviceItemHeight) + ((MaxDeviceCount-1) * 10) + settingHeight;
 
     // 如果比允许的最大高度还大，则以最大高度为准
     height = qMin(maxHeight, height);
+
+    // 如果比快捷面板允许的最小高度还小，则以快捷面板允许的最小高度为准
+    const int hMargins = m_mainLayout->contentsMargins().top() + m_mainLayout->contentsMargins().bottom();
+    height = qMax(m_minHeight - hMargins, height);
 
     // 加上飞行模式提示控件高度
     m_airplaneModeWidget->isVisibleTo(this) ? m_airplaneModeWidget->setFixedHeight(height - settingHeight - adapterHeight) : m_airplaneModeWidget->setFixedHeight(0);


### PR DESCRIPTION
1. Reordered the height calculation logic to prioritize maximum height check before minimum height check
2. This prevents potential layout issues when content height exceeds maximum allowed height
3. Maintains the same functionality but with more logical calculation flow
4. The change ensures consistent behavior when dealing with edge cases

fix: 调整蓝牙小程序高度计算顺序

1. 重新排序高度计算逻辑，优先检查最大高度限制再检查最小高度限制
2. 防止当内容高度超过允许最大值时可能出现的布局问题
3. 保持相同功能但采用更合理的计算流程
4. 此变更确保处理边界情况时行为一致

Pms: BUG-320239