### PR TITLE
fix: remove inner highlight from calendar selection box

### DIFF
--- a/plugins/dde-dock/datetime/calendar/sidebarcalendarwidget.cpp
+++ b/plugins/dde-dock/datetime/calendar/sidebarcalendarwidget.cpp
@@ -553,18 +553,6 @@ void SidebarCalendarKeyButton::paintEvent(QPaintEvent* event)
                                                -RECT_PENWIDTH,
                                                -RECT_PENWIDTH)
                                 , ROUND_CORNER, ROUND_CORNER);
-        //绘制选中框内圈白色高光
-        pen.setColor(Qt::white);
-        pen.setWidth(1);
-        painter.setPen(pen);
-        painter.drawRoundedRect(rectf.adjusted(RECT_PENWIDTH + RECT_MARGINS + 1,
-                                               RECT_PENWIDTH + RECT_MARGINS + 1,
-                                               -RECT_PENWIDTH - RECT_MARGINS - 1,
-                                               -RECT_PENWIDTH - RECT_MARGINS - 1)
-                                , ROUND_CORNER - RECT_PENWIDTH, ROUND_CORNER - RECT_PENWIDTH);
-
-        pen.setColor(pa.windowText().color());
-        painter.setPen(pen);
     } else if (!m_isThisMonth) {
         //设置正常显示状态下的字体颜色
         painter.setOpacity(0.3);


### PR DESCRIPTION
1. Removed the inner white highlight effect from selected date boxes in the calendar widget
2. The highlight was visually unnecessary and didn't match current design guidelines
3. Simplified the painting logic by removing redundant pen color changes
4. Maintains the outer selection indicator while removing the inner decoration

fix: 移除日历选择框的内层高光效果

1. 移除了日历组件中日期选择框的内层白色高光效果
2. 该高光效果视觉上不必要且不符合当前设计规范
3. 通过移除多余的画笔颜色变化简化了绘制逻辑
4. 保留外层选择指示器同时移除了内部装饰效果

Pms: BUG-317321

## Summary by Sourcery

Remove unnecessary inner decoration from calendar selection boxes while preserving the outer selection indicator

Bug Fixes:
- Remove inner white highlight effect from calendar date selection boxes

Enhancements:
- Simplify painting logic by removing redundant pen color changes