### PR TITLE
fix: correct popup position calculation in widget plugin

### DIFF
--- a/src/loader/widgetplugin.cpp
+++ b/src/loader/widgetplugin.cpp
@@ -55,8 +55,15 @@ private:
 
         const auto toolTipWindow = *iter;
         if (auto pluginPopup = Plugin::PluginPopup::getWithoutCreating(toolTipWindow)) {
-            pluginPopup->setX(toolTipWindow->transientParent()->x() + pos.x());
-            pluginPopup->setY(toolTipWindow->transientParent()->y() + pos.y());
+            auto parentWindow = toolTipWindow->transientParent();
+            if (parentWindow) {
+                // 通过EmbedPlugin获取正确的插件位置
+                if (auto plugin = Plugin::EmbedPlugin::getWithoutCreating(parentWindow)) {
+                    auto pluginPos = plugin->pluginPos();
+                    pluginPopup->setX(pluginPos.x() + pos.x());
+                    pluginPopup->setY(pluginPos.y() + pos.y());
+                } 
+            }
         }
     }
 };


### PR DESCRIPTION
1. Modified position calculation for plugin popups to use EmbedPlugin's position
2. Added null check for transient parent window
3. Uses pluginPos() from EmbedPlugin instead of direct window coordinates
4. Ensures popups appear in correct relative position to their parent plugin

The previous implementation directly used the transient parent window's coordinates which could lead to incorrect positioning when the plugin was embedded in a complex layout. The new approach gets the accurate position from the EmbedPlugin itself.

fix: 修正小部件插件中弹出窗口位置计算

1. 修改插件弹出窗口的位置计算以使用 EmbedPlugin 的位置
2. 为 transient 父窗口添加空值检查
3. 使用 EmbedPlugin 的 pluginPos() 而非直接窗口坐标
4. 确保弹出窗口相对于父插件显示在正确位置

之前的实现直接使用 transient 父窗口的坐标，当插件嵌入复杂布局时可能导致
位置计算错误。新方法从 EmbedPlugin 自身获取准确位置。
Pms: BUG-321795

## Summary by Sourcery

Fix widget plugin popup positioning by using EmbedPlugin’s accurate coordinates and adding a transient parent null check

Bug Fixes:
- Use EmbedPlugin::pluginPos() instead of transientParent window coordinates for popup placement
- Add null check for transient parent window before calculating popup position