### PR TITLE
chore: bump version to 2.0.6

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,13 @@
+dde-tray-loader (2.0.6) unstable; urgency=medium
+
+  * fix: correct popup position calculation in widget plugin
+  * fix: remove inner highlight from calendar selection box
+  * feat: add wheel event support for brightness and volume controls
+  * fix: adjust height calculation order in BluetoothApplet
+  * feat: implement custom PageButton for calendar navigation
+
+ -- WuJiangYu <wujiangyu@uniontech.com>  Mon, 04 Aug 2025 16:35:31 +0800
+
 dde-tray-loader (2.0.5) unstable; urgency=medium
 
   * fix: correct popup position calculation in widget plugin


### PR DESCRIPTION
update changelog to 2.0.6

## Summary by Sourcery

Chores:
- Update debian/changelog to reflect version 2.0.6