### PR TITLE
fix: set page step for volume slider

### DIFF
--- a/plugins/dde-dock/sound/soundapplet.cpp
+++ b/plugins/dde-dock/sound/soundapplet.cpp
@@ -69,6 +69,7 @@ void SoundApplet::initUi()
     m_volumeSlider->setMinimum(0);
     m_volumeSlider->setMaximum(SoundModel::ref().maxVolumeUI());
     m_volumeSlider->slider()->setTracking(false);
+    m_volumeSlider->setPageStep(2);
     m_sliderContainer->setSlider(m_volumeSlider);
     m_sliderContainer->addBackground();
     m_sliderContainer->setButtonsSize(QSize(16, 16));


### PR DESCRIPTION
1. Added setPageStep(2) to volume slider initialization
2. This ensures consistent volume adjustment increments when using page up/down keys
3. Previously missing step value could cause inconsistent volume jumps
4. Matches expected behavior for system volume control

fix: 设置音量滑块的页面步长

1. 在音量滑块初始化中添加了 setPageStep(2)
2. 确保在使用页面上下键时音量调整增量为一致值
3. 之前缺少步长值可能导致音量跳跃不一致
4. 符合系统音量控制的预期行为

Pms: BUG-327497

## Summary by Sourcery

Bug Fixes:
- Set page step to 2 on volume slider initialization to prevent inconsistent volume jumps when using page navigation keys