### PR TITLE
feat: improve battery icon loading strategy

### DIFF
--- a/plugins/dde-dock/power/powerapplet.cpp
+++ b/plugins/dde-dock/power/powerapplet.cpp
@@ -232,13 +232,29 @@ void PowerApplet::onHighPerformanceSupportChanged(const bool isSupport)
 
 void PowerApplet::refreshBatteryIcon(const QString &icon)
 {
-    QString path = ":/batteryicons/batteryicons/" + icon;
+    QString iconName = icon;
+    QString fallbackPath = ":/batteryicons/batteryicons/" + icon + ".svg";
+    
     if (DGuiApplicationHelper::instance()->themeType() == DGuiApplicationHelper::LightType) {
-        path.append("-dark");
+        iconName.append("-dark");
+        fallbackPath = ":/batteryicons/batteryicons/" + icon + "-dark.svg";
     }
-    path += ".svg";
-
-    QSvgRenderer renderer(path);
+    
+    // 首先尝试从主题加载图标
+    QIcon themeIcon = QIcon::fromTheme(iconName);
+    if (!themeIcon.isNull()) {
+        // 如果主题图标存在，使用主题图标
+        QPixmap pixmap = themeIcon.pixmap(m_batteryIcon->size());
+        m_batteryIcon->setPixmap(pixmap);
+        return;
+    }
+    
+    // fallback使用资源文件
+    QSvgRenderer renderer(fallbackPath);
+    if (!renderer.isValid()) {
+        QString normalPath = ":/batteryicons/batteryicons/" + icon + ".svg";
+        renderer.load(normalPath);
+    }
 
     QSize size = m_batteryIcon->size();
     QImage image(QSize(size * devicePixelRatioF()), QImage::Format_ARGB32_Premultiplied);

--- a/plugins/dde-dock/power/powerstatuswidget.cpp
+++ b/plugins/dde-dock/power/powerstatuswidget.cpp
@@ -82,7 +82,7 @@ void PowerStatusWidget::refreshIcon()
                   .arg(percentageStr, plugged ? "plugged-symbolic" : "symbolic");
     }
 
-    m_iconWidget->setIcon(iconStr, ":/batteryicons/resources/batteryicons/" + iconStr + ".svg");
+    m_iconWidget->setIcon(iconStr, ":/batteryicons/batteryicons/" + iconStr + ".svg");
     m_applet->refreshBatteryIcon(iconStr);
 }
 


### PR DESCRIPTION
1. Modified battery icon loading to first try system theme icons before falling back to built-in resources
2. Added proper handling for dark theme variants by appending "-dark" suffix
3. Improved SVG renderer fallback logic when theme icons are not available
4. Fixed resource path inconsistency in PowerStatusWidget
5. Added proper error handling for invalid SVG files

The changes improve icon loading reliability and maintainability by:
- Supporting system theme icons which allows for better customization
- Providing proper fallback mechanisms when theme icons are missing
- Ensuring consistent behavior across light/dark themes
- Fixing resource path inconsistencies between components

feat: 改进电池图标加载策略

1. 修改电池图标加载逻辑，优先尝试系统主题图标，再回退到内置资源
2. 添加了对暗色主题变体的正确处理，通过添加"-dark"后缀
3. 改进了当主题图标不可用时的SVG渲染器回退逻辑
4. 修复了PowerStatusWidget中的资源路径不一致问题
5. 为无效SVG文件添加了适当的错误处理

这些改进通过以下方式提高了图标加载的可靠性和可维护性：
- 支持系统主题图标，允许更好的自定义
- 当主题图标缺失时提供适当的回退机制
- 确保在亮/暗主题下行为一致
- 修复组件间的资源路径不一致问题 Pms: BUG-323767

## Summary by Sourcery

Improve battery icon loading by leveraging system theme icons, supporting dark theme variants, and enhancing fallback logic while fixing resource path inconsistencies.

New Features:
- Load battery icons from the system theme before falling back to built-in resources

Bug Fixes:
- Fix resource path inconsistency in PowerStatusWidget icon loading

Enhancements:
- Append "-dark" suffix for dark theme variants to ensure correct icon selection
- Enhance SVG renderer fallback by validating the renderer and loading a default resource if invalid
- Add error handling for invalid SVG files during icon rendering