### PR TITLE
chore: bump version to 2.0.8

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-tray-loader (2.0.8) unstable; urgency=medium
+
+  * Release 2.0.8
+
+ -- wujiangyu <wujiangyu@uniontech.com>  Tue, 12 Aug 2025 10:39:30 +0800
+
 dde-tray-loader (2.0.7) unstable; urgency=medium
 
   * feat: improve battery icon loading strategy


### PR DESCRIPTION
update changelog to 2.0.8

## Summary by Sourcery

Chores:
- Update Debian changelog with version 2.0.8 entry