### PR TITLE
fix: fix building warnings.

### DIFF
--- a/plugins/application-tray/abstracttrayprotocol.h
+++ b/plugins/application-tray/abstracttrayprotocol.h
@@ -42,7 +42,7 @@ class AbstractTrayProtocolHandler : public QObject
     Q_PROPERTY(bool enabled READ enabled NOTIFY enabledChanged FINAL)
 
 public:
-    AbstractTrayProtocolHandler(QObject *parent = nullptr) {};
+    AbstractTrayProtocolHandler(QObject *parent = nullptr) { Q_UNUSED(parent) };
     ~AbstractTrayProtocolHandler() {};
 
     virtual uint32_t windowId() const = 0;
@@ -64,7 +64,7 @@ public:
     QWidget *window() const {return m_window;}
 
 protected:
-    virtual bool eventFilter(QObject *watched, QEvent *event) {return false;};
+    virtual bool eventFilter(QObject *watched, QEvent *event) { Q_UNUSED(watched) Q_UNUSED(event) return false; };
 
 Q_SIGNALS:
     void titleChanged();

--- a/plugins/application-tray/sniprotocolhandler.cpp
+++ b/plugins/application-tray/sniprotocolhandler.cpp
@@ -120,6 +120,7 @@ SniTrayProtocolHandler::SniTrayProtocolHandler(const QString &sniServicePath, QO
     connect(m_sniInter, &StatusNotifierItem::NewStatus, this, &SniTrayProtocolHandler::statusChanged);
     connect(m_sniInter, &StatusNotifierItem::NewToolTip, this, &SniTrayProtocolHandler::tooltiChanged);
     connect(DGuiApplicationHelper::instance(), &DGuiApplicationHelper::themeTypeChanged, this, [this](DGuiApplicationHelper::ColorType themeType) {
+        Q_UNUSED(themeType)
         m_dbusMenuImporter->updateMenu(true);
     });
 }

--- a/plugins/application-tray/trayplugin.cpp
+++ b/plugins/application-tray/trayplugin.cpp
@@ -16,6 +16,7 @@
 namespace tray {
 TrayPlugin::TrayPlugin(QObject *parent)
 {
+    Q_UNUSED(parent)
     qRegisterMetaType<TrayList>("TrayList");
     qDBusRegisterMetaType<TrayList>();
 

--- a/plugins/application-tray/traywidget.cpp
+++ b/plugins/application-tray/traywidget.cpp
@@ -46,6 +46,7 @@ TrayWidget::~TrayWidget()
 
 void TrayWidget::showEvent(QShowEvent* event)
 {
+    Q_UNUSED(event)
     m_handler->setWindow(window());
     window()->installEventFilter(m_handler);
     window()->setMouseTracking(true);

--- a/plugins/application-tray/xembedprotocolhandler.cpp
+++ b/plugins/application-tray/xembedprotocolhandler.cpp
@@ -201,7 +201,6 @@ void XembedProtocolHandler::initX11resources()
     values[0] = screen->black_pixel; // draw a solid background so the embedded icon doesn't get garbage in it
     values[1] = true; // bypass wM
     values[2] = XCB_EVENT_MASK_STRUCTURE_NOTIFY | XCB_EVENT_MASK_SUBSTRUCTURE_NOTIFY | XCB_EVENT_MASK_SUBSTRUCTURE_REDIRECT | XCB_EVENT_MASK_LEAVE_WINDOW | XCB_EVENT_MASK_ENTER_WINDOW;
-    const auto ratio = qApp->devicePixelRatio();
     xcb_create_window(c,
                       XCB_COPY_FROM_PARENT,
                       m_containerWid,

--- a/plugins/dde-dock/airplane-mode/airplanemodeplugin.cpp
+++ b/plugins/dde-dock/airplane-mode/airplanemodeplugin.cpp
@@ -185,6 +185,7 @@ void AirplaneModePlugin::refreshAirplaneEnableState()
 
 void AirplaneModePlugin::onAirplaneEnableChanged(bool enable)
 {
+    Q_UNUSED(enable)
     if (!m_proxyInter)
         return;
 
@@ -266,6 +267,8 @@ bool AirplaneModePlugin::getAirplaneDconfig() const
 
 void AirplaneModePlugin::onAirplaneModePropertiesChanged(const QString &interfaceName, const QVariantMap &changedProperties, const QStringList &invalidatedProperties)
 {
+    Q_UNUSED(interfaceName)
+    Q_UNUSED(invalidatedProperties)
     if (changedProperties.contains("HasAirplaneMode")) {
         updatePluginVisible();
     }

--- a/plugins/dde-dock/bluetooth/componments/bluetoothadapteritem.cpp
+++ b/plugins/dde-dock/bluetooth/componments/bluetoothadapteritem.cpp
@@ -24,6 +24,7 @@ BluetoothDeviceItem::BluetoothDeviceItem(QStyle *style, const Device *device, Pl
     : m_style(style)
     , m_device(device)
 {
+    Q_UNUSED(parent)
     m_standardItem = new PluginStandardItem();
 
     m_standardItem->updateIcon(m_device->deviceType().isEmpty() ? QIcon::fromTheme("bluetooth_other")

--- a/plugins/dde-dock/bluetooth/componments/bluetoothadapteritem.h
+++ b/plugins/dde-dock/bluetooth/componments/bluetoothadapteritem.h
@@ -88,7 +88,7 @@ public:
         }
     }
 
-    const bool isExpand() { return m_isExpand; }
+    bool isExpand() { return m_isExpand; }
 
 Q_SIGNALS:
     void expandStateChanged(bool state);
@@ -97,6 +97,7 @@ Q_SIGNALS:
 protected:
     void paintEvent(QPaintEvent *paint) override
     {
+        Q_UNUSED(paint)
         QPainter painter(this);
         painter.setRenderHints(QPainter::Antialiasing | QPainter::SmoothPixmapTransform);
         // 绘制背景

--- a/plugins/dde-dock/brightness/brightnesscontroller.cpp
+++ b/plugins/dde-dock/brightness/brightnesscontroller.cpp
@@ -38,6 +38,7 @@ void BrightnessController::init()
     connect(&m_displayInter, &DisplayInter::BrightnessChanged, this, &BrightnessController::onMonitorsBrightnessChanged);
     connect(&m_displayInter, &DisplayInter::BrightnessChanged, &BrightnessModel::ref(), &BrightnessModel::setBrightnessMap);
     connect(&m_displayInter, &DisplayInter::DisplayModeChanged, this, [this](uchar value) {
+        Q_UNUSED(value)
         // 显示模式以m_displayInter.GetRealDisplayMode()为准
         BrightnessModel::ref().setDisplayMode(m_displayInter.GetRealDisplayMode());
     });

--- a/plugins/dde-dock/brightness/monitor.h
+++ b/plugins/dde-dock/brightness/monitor.h
@@ -32,7 +32,7 @@ public:
     inline bool isPrimary() const { return m_primary == m_name; }
     inline double brightness() const { return m_brightness; }
     inline const QString name() const { return m_name; }
-    inline const bool canBrightness() const { return m_canBrightness; }
+    inline bool canBrightness() const { return m_canBrightness; }
     inline const QString path() const { return m_path; }
     inline bool isEnabled() const { return m_enable; }
     inline bool isBuildin() const { return m_buildin; };

--- a/plugins/dde-dock/common/pluginitemdelegate.h
+++ b/plugins/dde-dock/common/pluginitemdelegate.h
@@ -42,8 +42,8 @@ class PluginItemDelegate : public QStyledItemDelegate
 public:
     explicit PluginItemDelegate(QAbstractItemView* parent = nullptr);
 
-    inline const int itemHeight() const { return m_widgetHeight; }
-    inline const int itemSpacing() const { return m_bottomSpacing; }
+    inline int itemHeight() const { return m_widgetHeight; }
+    inline int itemSpacing() const { return m_bottomSpacing; }
 
     inline void setItemHeight(int height) { m_widgetHeight = height; }
     inline void setItemSpacing(int spacing) { m_bottomSpacing = spacing; }

--- a/plugins/dde-dock/eye-comfort-mode/eyecomfortmodecontroller.cpp
+++ b/plugins/dde-dock/eye-comfort-mode/eyecomfortmodecontroller.cpp
@@ -29,6 +29,8 @@ EyeComfortModeController::EyeComfortModeController()
 
 void EyeComfortModeController::onPropertiesChanged(const QString &interfaceName, const QVariantMap &changedProperties, const QStringList &invalidatedProperties)
 {
+    Q_UNUSED(interfaceName)
+    Q_UNUSED(invalidatedProperties)
     if (changedProperties.contains(COLOR_TEMPERATURE_ENABLED)) {
         m_eyeComfortModeEnabled = changedProperties.value(COLOR_TEMPERATURE_ENABLED, false).toBool();
         Q_EMIT eyeComfortModeChanged(m_eyeComfortModeEnabled);
@@ -60,6 +62,7 @@ QString EyeComfortModeController::globalTheme() const
 
 void EyeComfortModeController::enable(bool enable)
 {
+    Q_UNUSED(enable)
     m_displayInter->setProperty(COLOR_TEMPERATURE_ENABLED, !isEyeComfortModeEnabled());
 }
 

--- a/plugins/dde-dock/keyboard-layout/dbusadaptors.cpp
+++ b/plugins/dde-dock/keyboard-layout/dbusadaptors.cpp
@@ -30,9 +30,9 @@ DBusAdaptors::DBusAdaptors(QObject *parent)
       m_keyboard(new Keyboard("org.deepin.dde.InputDevices1",
                               "/org/deepin/dde/InputDevice1/Keyboard",
                               QDBusConnection::sessionBus(), this)),
-    m_menu(new QMenu()),
     m_fcitxRunning(false),
-    m_inputmethod(nullptr)
+    m_inputmethod(nullptr),
+    m_menu(new QMenu())
 {
     m_keyboard->setSync(false);
 
@@ -275,6 +275,7 @@ void DBusAdaptors::onFcitxDisconnected(const QString &service)
 
 void DBusAdaptors::onPropertyChanged(QString name, QVariantMap map, QStringList list)
 {
+    Q_UNUSED(map)
     // fcitx uniquename start with fcitx-keyboard- which contains keyboard layout.
     QString fcitxUniqueName("fcitx-keyboard-");
     qCDebug(KEYBOARD_LAYOUT) << QString("Properties of interface %1 changed").arg(name);

--- a/plugins/dde-dock/media/mediaplugin.cpp
+++ b/plugins/dde-dock/media/mediaplugin.cpp
@@ -77,27 +77,32 @@ QWidget *MediaPlugin::itemWidget(const QString &itemKey)
 
 QWidget *MediaPlugin::itemTipsWidget(const QString &itemKey)
 {
+    Q_UNUSED(itemKey)
     return nullptr;
 }
 
 QWidget *MediaPlugin::itemPopupApplet(const QString &itemKey)
 {
+    Q_UNUSED(itemKey)
     return nullptr;
 }
 
 void MediaPlugin::refreshIcon(const QString &itemKey)
 {
-
+    Q_UNUSED(itemKey)
 }
 
 const QString MediaPlugin::itemContextMenu(const QString &itemKey)
 {
+    Q_UNUSED(itemKey)
     return QString();
 }
 
 void MediaPlugin::invokedMenuItem(const QString &itemKey, const QString &menuId, const bool checked)
 {
-
+    Q_UNUSED(itemKey)
+    Q_UNUSED(menuId)
+    Q_UNUSED(checked)
 }
 
 int MediaPlugin::itemSortKey(const QString &itemKey)

--- a/plugins/dde-dock/notification/notification.cpp
+++ b/plugins/dde-dock/notification/notification.cpp
@@ -182,6 +182,7 @@ void Notification::setNotificationCount(uint count)
 
 void Notification::onNotificationStateChanged(qint64 id, int processedType)
 {
+    Q_UNUSED(id)
     static const int Processed = 2;
     if (processedType == Processed) {
         if (!m_hasNewNotification && !m_notificationCenterVisible) {

--- a/plugins/dde-dock/notification/notificationplugin.cpp
+++ b/plugins/dde-dock/notification/notificationplugin.cpp
@@ -104,6 +104,7 @@ const QString NotificationPlugin::itemCommand(const QString &itemKey)
 
 const QString NotificationPlugin::itemContextMenu(const QString &itemKey)
 {
+    Q_UNUSED(itemKey)
     QList<QVariant> items;
     QMap<QString, QVariant> toggleDnd;
     toggleDnd["itemId"] = TOGGLE_DND;
@@ -158,6 +159,7 @@ void NotificationPlugin::pluginSettingsChanged()
 
 QIcon NotificationPlugin::icon(Dock::IconType dockPart, Dock::ThemeType themeType) const
 {
+    Q_UNUSED(dockPart)
     Q_UNUSED(themeType)
     /*if (dockPart == DockPart::DCCSetting) {*/
         if (themeType == Dock::ThemeType_Dark) {

--- a/plugins/dde-dock/sound/soundcontroller.cpp
+++ b/plugins/dde-dock/sound/soundcontroller.cpp
@@ -87,6 +87,7 @@ void SoundController::onDefaultSinkChanged(const QDBusObjectPath &path)
 
     // 音量和静音状态变化时手动获取下另外一个的状态，有时候收不到 changed 信号
     connect(m_defaultSinkInter, &DBusSink::MuteChanged, &SoundModel::ref(), [this] (bool value) {
+        Q_UNUSED(value)
         SoundModel::ref().setMute(m_defaultSinkInter->mute());
         SoundModel::ref().setVolume(m_defaultSinkInter->volume());
     });

--- a/plugins/dde-dock/sound/soundquickpanel.cpp
+++ b/plugins/dde-dock/sound/soundquickpanel.cpp
@@ -67,6 +67,7 @@ void SoundQuickPanel::initConnection()
         m_sliderContainer->updateSliderValue(soundVolume());
     });
     connect(&SoundModel::ref(), &SoundModel::volumeChanged, this, [this](int value) {
+        Q_UNUSED(value)
         m_sliderContainer->updateSliderValue(soundVolume());
         refreshWidget();
     });

--- a/plugins/dde-dock/widgets/singlecontentwidget.h
+++ b/plugins/dde-dock/widgets/singlecontentwidget.h
@@ -23,6 +23,7 @@ public:
     explicit SingleContentWidget(QWidget* parent = nullptr)
         : m_mainLayout(new QHBoxLayout(this))
     {
+        Q_UNUSED(parent)
         m_mainLayout->setContentsMargins(0, 0, 0, 0);
         m_mainLayout->setSpacing(0);
     }

--- a/plugins/dde-network-display-ui/plugins/common/wirelesscastingmodel.cpp
+++ b/plugins/dde-network-display-ui/plugins/common/wirelesscastingmodel.cpp
@@ -139,6 +139,7 @@ void WirelessCastingModel::updateSinkList(const QVariant &sinkList)
 
 void WirelessCastingModel::updateWarningInfo(const QVariant &var)
 {
+    Q_UNUSED(var)
     checkState();
 }
 
@@ -239,6 +240,7 @@ void WirelessCastingModel::prepareDbus()
         checkWirelessDev();
     });
     connect(this, &WirelessCastingModel::AllDevicesChanged, this, [=](const QList<QDBusObjectPath> &devList) {
+        Q_UNUSED(devList)
         checkWirelessDev();
     });
     connect(this, &WirelessCastingModel::WirelessEnabledChanged, this, [=](bool) {
@@ -248,6 +250,7 @@ void WirelessCastingModel::prepareDbus()
 
 void WirelessCastingModel::onDBusNameOwnerChanged(const QString &name, const QString &oldOwner, const QString &newOwner)
 {
+    Q_UNUSED(oldOwner)
     if ("com.deepin.Cooperation.NetworkDisplay" == name && !newOwner.isEmpty()) {
         resetNetworkDisplayData();
         checkState();
@@ -303,6 +306,7 @@ void WirelessCastingModel::handleMonitorStateChanged(const Monitor::NdSinkState 
 
 void WirelessCastingModel::timerEvent(QTimerEvent *event)
 {
+    Q_UNUSED(event)
     refresh();
 }
 

--- a/plugins/dde-network-display-ui/plugins/dock-wirelesscasting-plugin/src/displaymodel.cpp
+++ b/plugins/dde-network-display-ui/plugins/dock-wirelesscasting-plugin/src/displaymodel.cpp
@@ -45,6 +45,7 @@ void DisplayModel::setDisplayMode(const uchar &mode)
 
 void DisplayModel::setMonitors(const QList<QDBusObjectPath> &monitors)
 {
+    Q_UNUSED(monitors)
     QDBusPendingCall call = m_displayInter->ListOutputNames();
     QDBusPendingCallWatcher *watcher = new QDBusPendingCallWatcher(call, this);
     connect(watcher, &QDBusPendingCallWatcher::finished, this, [this, watcher] {

--- a/plugins/dde-network-display-ui/plugins/dock-wirelesscasting-plugin/src/widget/monitoritemdelegate.h
+++ b/plugins/dde-network-display-ui/plugins/dock-wirelesscasting-plugin/src/widget/monitoritemdelegate.h
@@ -56,9 +56,9 @@ class MonitorItemDelegate : public QStyledItemDelegate
 public:
     explicit MonitorItemDelegate(QAbstractItemView* parent = nullptr);
 
-    inline const int expandItemHeight() const { return m_expandHeight; }
-    inline const int standardItemHeight() const { return m_standardHeight; }
-    inline const int itemSpacing() const { return m_bottomSpacing; }
+    inline int expandItemHeight() const { return m_expandHeight; }
+    inline int standardItemHeight() const { return m_standardHeight; }
+    inline int itemSpacing() const { return m_bottomSpacing; }
 
     ItemSpacing getItemSpacing(const QModelIndex &index) const;
 
@@ -231,6 +231,7 @@ public:
 protected:
     void paintEvent(QPaintEvent *event) override
     {
+        Q_UNUSED(event)
         QPainter painter(this);
 
         QColor textColor = DPaletteHelper::instance()->palette(this).brush(QPalette::BrightText).color();
@@ -273,6 +274,7 @@ protected:
 
     void paintEvent(QPaintEvent *event) override
     {
+        Q_UNUSED(event)
         QPainter painter(this);
         painter.setRenderHint(QPainter::Antialiasing, true);
 

--- a/plugins/dde-network-display-ui/plugins/dock-wirelesscasting-plugin/src/wirelesscastingapplet.cpp
+++ b/plugins/dde-network-display-ui/plugins/dock-wirelesscasting-plugin/src/wirelesscastingapplet.cpp
@@ -297,6 +297,8 @@ void WirelessCastingApplet::onStateChanged(WirelessCastingModel::CastingState st
 
 void WirelessCastingApplet::onAddMonitor(const QString &path, Monitor *monitor)
 {
+    Q_UNUSED(path)
+    Q_UNUSED(monitor)
 #ifdef WIRELESS_CASTING_ENABLED
     MonitorItem *item = new MonitorItem(monitor);
     m_monitorsModel->appendRow(item);
@@ -307,6 +309,7 @@ void WirelessCastingApplet::onAddMonitor(const QString &path, Monitor *monitor)
 
 void WirelessCastingApplet::onRemoveMonitor(const QString &path)
 {
+    Q_UNUSED(path)
 #ifdef WIRELESS_CASTING_ENABLED
     m_monitorsModel->removeRow(m_monitorsModel->indexFromItem(m_monitors[path].item).row());
     if (m_lastConnMonitor == m_monitors.value(path).monitor)

--- a/plugins/dde-network-display-ui/plugins/dock-wirelesscasting-plugin/src/wirelesscastingitem.cpp
+++ b/plugins/dde-network-display-ui/plugins/dock-wirelesscasting-plugin/src/wirelesscastingitem.cpp
@@ -67,6 +67,7 @@ WirelessCastingItem::WirelessCastingItem(QWidget *parent)
     connect(m_displayMode, &DisplayModel::primaryScreenChanged, this, syncState);
     connect(m_displayMode, &DisplayModel::currentModeChanged, this, syncState);
     connect(m_model, &WirelessCastingModel::stateChanged, this, [=](WirelessCastingModel::CastingState state) {
+        Q_UNUSED(state)
         syncState();
     });
     connect(m_model, &WirelessCastingModel::connectStateChanged, this, syncState);

--- a/plugins/dde-network-display-ui/plugins/dock-wirelesscasting-plugin/src/wirelesscastingplugin.cpp
+++ b/plugins/dde-network-display-ui/plugins/dock-wirelesscasting-plugin/src/wirelesscastingplugin.cpp
@@ -67,11 +67,13 @@ QWidget *WirelessCastingPlugin::itemWidget(const QString &itemKey)
 
 QWidget *WirelessCastingPlugin::itemTipsWidget(const QString &itemKey)
 {
+    Q_UNUSED(itemKey)
     return m_wirelessCastingItem->tips();
 }
 
 QWidget *WirelessCastingPlugin::itemPopupApplet(const QString &itemKey)
 {
+    Q_UNUSED(itemKey)
     return m_wirelessCastingItem->appletWidget();
 }
 
@@ -104,7 +106,7 @@ void WirelessCastingPlugin::setSortKey(const QString &itemKey, const int order)
     m_proxyInter->saveValue(this, key, order);
 }
 
-void WirelessCastingPlugin::refreshIcon(const QString &itemKey) { }
+void WirelessCastingPlugin::refreshIcon(const QString &itemKey) { Q_UNUSED(itemKey) }
 
 void WirelessCastingPlugin::pluginSettingsChanged() { }
 

--- a/src/loader/main.cpp
+++ b/src/loader/main.cpp
@@ -32,6 +32,7 @@ static QString pluginDisplayName;
 
 void sig_crash(int signum)
 {
+    Q_UNUSED(signum)
     DDBusSender()
         .service("org.deepin.dde.Notification1")
         .path("/org/deepin/dde/Notification1")

--- a/src/loader/pluginitem.cpp
+++ b/src/loader/pluginitem.cpp
@@ -16,8 +16,8 @@ const static QString DockQuickPlugins = "Dock_Quick_Plugins";
 
 PluginItem::PluginItem(PluginsItemInterface *pluginItemInterface, const QString &itemKey, QWidget *parent)
     : QWidget(parent)
-    , m_pluginsItemInterface(pluginItemInterface)
     , m_itemKey(itemKey)
+    , m_pluginsItemInterface(pluginItemInterface)
     , m_menu(new DockContextMenu(this))
     , m_tooltipTimer(new QTimer(this))
     , m_tipsWidget(nullptr)
@@ -194,6 +194,7 @@ void PluginItem::moveEvent(QMoveEvent *e)
 
 void PluginItem::leaveEvent(QEvent *event)
 {
+    Q_UNUSED(event)
     closeToolTip();
 }
 

--- a/src/loader/pluginitem.h
+++ b/src/loader/pluginitem.h
@@ -68,11 +68,11 @@ private:
 
 protected:
     QString m_itemKey;
+    PluginsItemInterface *m_pluginsItemInterface;
     QMenu *m_menu;
     QScopedPointer<DockDBusProxy> m_dbusProxy;
 
 private:
-    PluginsItemInterface *m_pluginsItemInterface;
     QTimer* m_tooltipTimer;
     QPointer<QWidget> m_tipsWidget;
 

--- a/src/loader/quickpluginitem.cpp
+++ b/src/loader/quickpluginitem.cpp
@@ -61,8 +61,8 @@ private:
         Q_EMIT m_target->recvMouseEvent(m_accepedEvent);
         m_accepedEvent = QEvent::None;
     }
-    QTimer *m_timer = nullptr;
     PluginItem *m_target = nullptr;
+    QTimer *m_timer = nullptr;
     QEvent::Type m_accepedEvent = {QEvent::None};
 };
 

--- a/src/loader/widgetplugin.cpp
+++ b/src/loader/widgetplugin.cpp
@@ -34,6 +34,7 @@ public:
 public:
     bool eventFilter(QObject *watched, QEvent *event)
     {
+        Q_UNUSED(watched)
         if (event->type() == QEvent::ToolTip) {
             const auto pos = static_cast<QHelpEvent*>(event)->globalPos();
             QMetaObject::invokeMethod(this, [this, pos] () {
@@ -179,6 +180,7 @@ void WidgetPlugin::itemAdded(PluginsItemInterface * const itemInter, const QStri
 
 void WidgetPlugin::itemUpdate(PluginsItemInterface * const itemInter, const QString &itemKey)
 {
+    Q_UNUSED(itemInter)
     if(m_pluginItem) m_pluginItem->update();
 
     auto widget = m_pluginsItemInterface->itemWidget(itemKey);
@@ -197,6 +199,7 @@ void WidgetPlugin::itemUpdate(PluginsItemInterface * const itemInter, const QStr
 
 void WidgetPlugin::itemRemoved(PluginsItemInterface * const itemInter, const QString &itemKey)
 {
+    Q_UNUSED(itemInter)
     auto widget = m_pluginsItemInterface->itemWidget(itemKey);
     if(widget && widget->window() && widget->window()->windowHandle()) {
         widget->window()->windowHandle()->hide();
@@ -216,10 +219,15 @@ void WidgetPlugin::itemRemoved(PluginsItemInterface * const itemInter, const QSt
 
 void WidgetPlugin::requestWindowAutoHide(PluginsItemInterface * const itemInter, const QString &itemKey, const bool autoHide)
 {
+    Q_UNUSED(itemInter)
+    Q_UNUSED(itemKey)
+    Q_UNUSED(autoHide)
 }
 
 void WidgetPlugin::requestRefreshWindowVisible(PluginsItemInterface * const itemInter, const QString &itemKey)
 {
+    Q_UNUSED(itemInter)
+    Q_UNUSED(itemKey)
 }
 
 void WidgetPlugin::requestSetAppletVisible(PluginsItemInterface * const itemInter, const QString &itemKey, const bool visible)
@@ -274,15 +282,22 @@ void WidgetPlugin::requestSetAppletVisible(PluginsItemInterface * const itemInte
 
 void WidgetPlugin::saveValue(PluginsItemInterface * const itemInter, const QString &key, const QVariant &value)
 {
+    Q_UNUSED(itemInter)
+    Q_UNUSED(key)
+    Q_UNUSED(value)
 }
 
 const QVariant WidgetPlugin::getValue(PluginsItemInterface *const itemInter, const QString &key, const QVariant& fallback)
 {
+    Q_UNUSED(itemInter)
+    Q_UNUSED(key)
     return fallback;
 }
 
 void WidgetPlugin::removeValue(PluginsItemInterface *const itemInter, const QStringList &keyList)
 {
+    Q_UNUSED(itemInter)
+    Q_UNUSED(keyList)
 }
 
 void WidgetPlugin::updateDockContainerState(PluginsItemInterface *itemInter, bool onDock)


### PR DESCRIPTION
as titile.

Logs:

## Summary by Sourcery

Add Q_UNUSED macros and remove unnecessary qualifiers to suppress build warnings across loader and plugin modules

Enhancements:
- Suppress compiler warnings by marking unused parameters with Q_UNUSED in various event filters and plugin methods
- Remove redundant const qualifiers from simple inline getters to clean up signatures
- Reorder constructor initializer lists to match member declaration order and resolve initialization warnings

Chores:
- Fix build warnings across multiple components by silencing unused parameters and correcting method signatures