### PR TITLE
chore: bump version to 2.0.8

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+dde-tray-loader (2.0.8) unstable; urgency=medium
+
+  * fix: fix building warnings.
+  * fix: remove redundant palette setup in RoundScrollArea
+
+ -- wujiangyu <wujiangyu@uniontech.com>  Thu, 21 Aug 2025 17:25:25 +0800
+
 dde-tray-loader (2.0.7) unstable; urgency=medium
 
   * feat: improve battery icon loading strategy


### PR DESCRIPTION
update changelog to 2.0.8