### PR TITLE
fix: power applet tips need not display when dconfig item was closed

### DIFF
--- a/plugins/dde-dock/power/powerplugin.cpp
+++ b/plugins/dde-dock/power/powerplugin.cpp
@@ -278,8 +278,7 @@ void PowerPlugin::refreshTipsData()
     const int batteryState = m_systemPowerInter->batteryStatus();
 
     if (m_batteryStateChangedTimer->isActive()) {
-        if ((batteryState == BatteryState::CHARGING && m_showTimeToFull)
-        || (batteryState == BatteryState::DIS_CHARGING)) {
+        if (m_showTimeToFull && (batteryState == BatteryState::CHARGING || batteryState == BatteryState::DIS_CHARGING)) {
             // 计算期间
             QString tips = tr("Capacity %1 ...").arg(value);
             m_tipsLabel->setText(tips);


### PR DESCRIPTION
as title

Log: as title
Pms: BUG-301387

## Summary by Sourcery

Bug Fixes:
- Restrict tip display to only when m_showTimeToFull is true for both charging and discharging battery states