### PR TITLE
fix: Avoid datetime plugin seconds displayed not same with dcc's date…

### DIFF
--- a/plugins/dde-dock/datetime/datetimeplugin.cpp
+++ b/plugins/dde-dock/datetime/datetimeplugin.cpp
@@ -88,8 +88,12 @@ void DatetimePlugin::loadPlugin()
     m_refershTimer = new QTimer(this);
     m_dateTipsLabel->setObjectName("datetime");
 
-    m_refershTimer->setInterval(1000);
-    m_refershTimer->start();
+    // 整秒启动定时器，并增加更新频率，避免秒显示与控制中心显示不一致（控制中心500ms更新一次）
+    m_refershTimer->setInterval(500);
+    QTimer::singleShot(1000 - QTime::currentTime().msec(), [this]() {
+        updateCurrentTimeString();
+        m_refershTimer->start();
+    });
 
     m_centralWidget.reset(new DatetimeWidget(m_RegionFormatModel));
 


### PR DESCRIPTION
…time

as title

Log: as title
Pms: BUG-289925

## Summary by Sourcery

Ensure datetime plugin’s seconds display stays in sync with the control center by aligning the timer start to whole seconds and increasing its update frequency.

Bug Fixes:
- Adjust the refresh timer to fire every 500ms instead of 1000ms to match the control center’s update frequency.
- Use a singleShot timer to delay the initial update until the next whole second boundary.