### PR TITLE
fix: improve theme compatibility for bluetooth label

### DIFF
--- a/plugins/dde-dock/bluetooth/componments/bluetoothadapteritem.cpp
+++ b/plugins/dde-dock/bluetooth/componments/bluetoothadapteritem.cpp
@@ -16,6 +16,8 @@
 #include <DSwitchButton>
 #include <DListView>
 #include <DSpinner>
+#include <DPaletteHelper>
+#include <DGuiApplicationHelper>
 
 #include <QBoxLayout>
 #include <QStandardItemModel>
@@ -68,7 +70,7 @@ BluetoothAdapterItem::BluetoothAdapterItem(Adapter *adapter, QWidget *parent)
     , m_adapterLayout(new QVBoxLayout)
     , m_adapterStateBtn(new DSwitchButton(this))
     , m_myDeviceWidget(new QWidget(this))
-    , m_myDeviceLabel(new QLabel(tr("My Devices"), this))
+    , m_myDeviceLabel(new DLabel(tr("My Devices"), this))
     , m_myDeviceListView(new PluginListView(this))
     , m_myDeviceModel(new QStandardItemModel(m_myDeviceListView))
     , m_otherDeviceControlWidget(new DeviceControlWidget(this))
@@ -361,8 +363,9 @@ void BluetoothAdapterItem::initUi()
     QVBoxLayout *myDeviceLayout = new QVBoxLayout(m_myDeviceWidget);
     myDeviceLayout->setSpacing(0);
     myDeviceLayout->setContentsMargins(0, 0, 0, 0);
-    m_myDeviceLabel->setContentsMargins(10, 0, 0, 2);
+    m_myDeviceLabel->setContentsMargins(10, 0, 0, 6);
     DFontSizeManager::instance()->bind(m_myDeviceLabel, DFontSizeManager::T10);
+    updateMyDeviceLabelTheme();
     myDeviceLayout->addWidget(m_myDeviceLabel);
     myDeviceLayout->addWidget(m_myDeviceListView);
 
@@ -462,6 +465,10 @@ void BluetoothAdapterItem::initConnect()
     connect(m_otherDeviceControlWidget, &DeviceControlWidget::clicked, this, [this] {
         m_autoFold = false;
     });
+    connect(DGuiApplicationHelper::instance(), &DGuiApplicationHelper::themeTypeChanged, this, [this]{
+        updateMyDeviceLabelTheme();
+        update();
+    });
 }
 
 void BluetoothAdapterItem::setUnnamedDevicesVisible(bool isShow)
@@ -535,4 +542,18 @@ void BluetoothAdapterItem::hideEvent(QHideEvent *event)
     if (m_adapterSwitchEnabled && m_myDeviceModel->rowCount() > 0)
         m_otherDeviceControlWidget->setExpandState(false);
     QWidget::hideEvent(event);
+}
+
+void BluetoothAdapterItem::updateMyDeviceLabelTheme()
+{
+    DPalette palette = DPaletteHelper::instance()->palette(m_myDeviceLabel);
+    QColor textColor;
+    if (DGuiApplicationHelper::instance()->themeType() == DGuiApplicationHelper::LightType) {
+        textColor = Qt::black;
+    } else {
+        textColor = Qt::white;
+    }
+    textColor.setAlphaF(0.60);
+    palette.setColor(QPalette::WindowText, textColor);
+    DPaletteHelper::instance()->setPalette(m_myDeviceLabel, palette);
 }

--- a/plugins/dde-dock/bluetooth/componments/bluetoothadapteritem.h
+++ b/plugins/dde-dock/bluetooth/componments/bluetoothadapteritem.h
@@ -110,7 +110,7 @@ protected:
         // 绘制文字
         QRect textRect = rect().marginsRemoved(QMargins(10, 0, 0, 0));
         QColor textNomal = palette().brightText().color();
-        textNomal.setAlphaF(0.75);
+        textNomal.setAlphaF(0.6);
         QColor textColor = underMouse() ? palette().color(QPalette::HighlightedText) : textNomal;
         painter.setPen(textColor);
         auto pFont = painter.font();
@@ -180,13 +180,14 @@ private:
     void initUi();
     void initConnect();
     void setUnnamedDevicesVisible(bool isShow);
+    void updateMyDeviceLabelTheme();
 
     Adapter *m_adapter;
     SettingLabel *m_adapterLabel;
     QVBoxLayout *m_adapterLayout;
     DSwitchButton *m_adapterStateBtn;
     QWidget *m_myDeviceWidget;
-    QLabel *m_myDeviceLabel;
+    DLabel *m_myDeviceLabel;
     PluginListView *m_myDeviceListView;
     QStandardItemModel *m_myDeviceModel;
 


### PR DESCRIPTION
Changed QLabel to DLabel for better theme integration and added dynamic text color handling
Added DPaletteHelper and DGuiApplicationHelper includes for theme management
Implemented theme change handler to update text color when system theme changes
Adjusted text alpha values from 0.75 to 0.6 for better readability across themes
Modified bottom margin from 2 to 6 for better spacing

These changes ensure consistent text appearance in both light and dark themes
and improve the overall visual experience in the bluetooth dock plugin

fix: 改进蓝牙标签的主题兼容性

将 QLabel 改为 DLabel 以实现更好的主题集成并添加动态文本颜色处理
添加 DPaletteHelper 和 DGuiApplicationHelper 包含以进行主题管理 实现主题变更处理程序，在系统主题更改时更新文本颜色
将文本透明度值从 0.75 调整为 0.6，以在不同主题下获得更好的可读性
将底部边距从 2 修改为 6 以获得更好的间距

这些更改确保在浅色和深色主题下文本外观一致
并改善蓝牙坞站插件的整体视觉体验
Pms: BUG-332553

## Summary by Sourcery

Improve theme compatibility and readability of the Bluetooth dock plugin by integrating labels with the system theme, handling dynamic theme changes, and adjusting text opacity and spacing.

Enhancements:
- Switch the “My Devices” label from QLabel to DLabel and use DPaletteHelper and DGuiApplicationHelper for theme-aware coloring and runtime theme change handling
- Reduce text opacity from 75% to 60% and increase the label’s bottom margin from 2 to 6 to enhance readability and spacing, also applying 60% transparency to DeviceControlWidget text