### PR TITLE
chore: bump version to 2.0.11

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+dde-tray-loader (2.0.11) unstable; urgency=medium
+
+  * fix: When a Bluetooth device is connected, the list of other devices
+    is automatically collapsed
+
+ -- YeShanShan <yeshanshan@uniontech.com>  Thu, 18 Sep 2025 20:40:04 +0800
+
 dde-tray-loader (2.0.10) unstable; urgency=medium
 
   * fix: bluetooth applet widget layout display abnormality


### PR DESCRIPTION
update changelog to 2.0.11

## Summary by Sourcery

Bump project version to 2.0.11 and update changelog accordingly

Documentation:
- Update Debian changelog for version 2.0.11

Chores:
- Bump version to 2.0.11