### PR TITLE
feat: add override icon search path for system tray

### DIFF
--- a/plugins/application-tray/application-tray.qrc
+++ b/plugins/application-tray/application-tray.qrc
@@ -1,5 +1,5 @@
 <RCC>
-    <qresource prefix="/dsg/built-in-icons">
+    <qresource prefix="/dsg-icon/override">
         <file alias="fcitx-anthy.dci">icons/fcitx-anthy.dci</file>
         <file alias="fcitx-bopomofo.dci">icons/fcitx-bopomofo.dci</file>
         <file alias="fcitx-cangjie.dci">icons/fcitx-cangjie.dci</file>

--- a/plugins/application-tray/trayplugin.cpp
+++ b/plugins/application-tray/trayplugin.cpp
@@ -11,6 +11,7 @@
 #include "ddeindicatortrayprotocol.h"
 #include "pluginproxyinterface.h"
 
+#include <DIconTheme>
 #include <QDebug>
 
 namespace tray {
@@ -46,6 +47,10 @@ QWidget *TrayPlugin::itemTipsWidget(const QString &itemKey)
 void TrayPlugin::init(PluginProxyInterface *proxyInter)
 {
     m_proyInter = proxyInter;
+
+    auto dciPaths = Dtk::Gui::DIconTheme::dciThemeSearchPaths();
+    dciPaths.prepend(":/dsg-icon/override");
+    Dtk::Gui::DIconTheme::setDciThemeSearchPaths(dciPaths);
 
     auto sniProtocol = new SniTrayProtocol();
     auto xembedProtocol = new XembedProtocol();


### PR DESCRIPTION
1. Changed resource prefix from /dsg/built-in-icons to /dsg-icon/ override in application-tray.qrc
2. Added DIconTheme include and modified DCI theme search paths in trayplugin.cpp
3. Prepended the override path to ensure system icons take precedence over theme icons
4. This allows system icons to remain consistent regardless of theme changes

feat: 为系统托盘添加图标覆盖搜索路径

1. 将 application-tray.qrc 中的资源前缀从 /dsg/built-in-icons 改为 /dsg- icon/override
2. 在 trayplugin.cpp 中添加 DIconTheme 包含并修改 DCI 主题搜索路径
3. 将覆盖路径前置以确保系统图标优先于主题图标
4. 这使得系统图标在不同主题下保持一致性

pms: BUG-332583

## Summary by Sourcery

New Features:
- Add override resource prefix `/dsg-icon/override` in application-tray.qrc and prepend it to the DIconTheme search paths for system tray icons