### PR TITLE
Fix power and bluetooth cut in russian

### DIFF
--- a/plugins/dde-dock/bluetooth/bluetoothitem.cpp
+++ b/plugins/dde-dock/bluetooth/bluetoothitem.cpp
@@ -189,6 +189,9 @@ void BluetoothItem::refreshTips()
     }
 
     m_tipsLabel->setText(tipsText);
+    QFontMetrics metrics(m_tipsLabel->font());
+    int textWidth = metrics.boundingRect(m_tipsLabel->text()).width();
+    m_tipsLabel->setMinimumWidth(textWidth);
     m_quickPanel->setDescription(description);
 }
 

--- a/plugins/dde-dock/power/powerplugin.cpp
+++ b/plugins/dde-dock/power/powerplugin.cpp
@@ -216,6 +216,7 @@ void PowerPlugin::loadPlugin()
         }
         refreshTipsData();
     });
+
     connect(m_systemPowerInter, &SystemPowerInter::BatteryTimeToEmptyChanged, this, &PowerPlugin::refreshTipsData);
     connect(m_systemPowerInter, &SystemPowerInter::BatteryTimeToFullChanged, this, &PowerPlugin::refreshTipsData);
     connect(m_systemPowerInter, &SystemPowerInter::BatteryPercentageChanged, this, &PowerPlugin::refreshTipsData);
@@ -226,6 +227,7 @@ void PowerPlugin::loadPlugin()
 
     onDConfigValueChanged("showTimeToFull");
     m_powerStatusWidget->refreshIcon();
+
 }
 
 void PowerPlugin::refreshPluginItemsVisible()
@@ -347,7 +349,10 @@ void PowerPlugin::refreshTipsData()
         }
     }
 
-    m_tipsLabel->setText(tips);
+    m_tipsLabel->setText(tips); 
+    QFontMetrics metrics(m_tipsLabel->font());
+    int textWidth = metrics.boundingRect(m_tipsLabel->text()).width();
+    m_tipsLabel->setMinimumWidth(textWidth);
     m_powerStatusWidget->refreshBatteryPercentage(value, appletTips);
 }
 


### PR DESCRIPTION
https://github.com/linuxdeepin/developer-center/issues/12262

## Summary by Sourcery

Prevent UI text truncation in power and bluetooth plugins by dynamically sizing tip labels to fit rendered text

Bug Fixes:
- Prevent power plugin tips from being truncated by setting the label's minimum width to the rendered text width
- Prevent bluetooth plugin tips from being truncated by setting the label's minimum width to the rendered text width