### PR TITLE
chore: bump version to 2.0.12

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,13 @@
+dde-tray-loader (2.0.12) unstable; urgency=medium
+
+  * i18n: Updates for project Deepin Desktop Environment (#370)
+  * feat: add override icon search path for system tray
+  * chore: convert REUSE config to REUSE.toml
+  * chore: add .tx/config for tx-cli
+  * i18n: Updates for project Deepin Desktop Environment (#368)
+
+ -- zhangkun <zhangkun2@uniontech.com>  Thu, 25 Sep 2025 20:50:20 +0800
+
 dde-tray-loader (2.0.11) unstable; urgency=medium
 
   * fix: When a Bluetooth device is connected, the list of other devices


### PR DESCRIPTION
update changelog to 2.0.12

## Summary by Sourcery

Bump Debian package version to 2.0.12 and update the changelog accordingly

Chores:
- Update Debian changelog for version 2.0.12
- Bump package version to 2.0.12