### PR TITLE
fix: optimize cursor behavior for bluetooth applet link

### DIFF
--- a/plugins/dde-dock/bluetooth/componments/bluetoothapplet.h
+++ b/plugins/dde-dock/bluetooth/componments/bluetoothapplet.h
@@ -96,6 +96,9 @@ private:
     // 更新蓝牙插件主界面大小
     void updateSize();
 
+protected:
+    bool eventFilter(QObject *watched, QEvent *event) override;
+
 private:
     QScrollArea *m_scrollArea;
     QWidget *m_contentWidget;


### PR DESCRIPTION
Use manual hit detection via QTextDocument in eventFilter to resolve unreliable linkHovered signal issues during vertical movement.

Log: optimize cursor behavior for bluetooth applet link
Pms: BUG-350071

## Summary by Sourcery

Improve hover-based cursor feedback for the Bluetooth applet’s airplane mode link using manual hit detection.

Bug Fixes:
- Fix unreliable cursor changes when hovering vertically over the airplane mode link in the Bluetooth applet.

Enhancements:
- Use an event filter and QTextDocument-based hit testing on the airplane mode label to determine when to show a pointing hand cursor.