### PR TITLE
fix(application-tray): Fix submenu display issue

### DIFF
--- a/plugins/application-tray/sniprotocolhandler.cpp
+++ b/plugins/application-tray/sniprotocolhandler.cpp
@@ -29,7 +29,16 @@ public:
         : DBusMenuImporter(service, path, parent)
     {
         QObject::connect(this, &DBusMenuImporter::menuUpdated, this, [this] (QMenu *menu) {
-            menu->setFixedSize(menu->sizeHint());
+            menu->adjustSize();
+            menu->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Preferred);
+            menu->setMinimumHeight(menu->sizeHint().height());
+
+            // hide arrow
+            menu->setStyleSheet(
+                "QMenu::scroller { width: 0px; height: 0px; }"
+                "QMenu::down-arrow { image: none; }"
+                "QMenu::up-arrow { image: none; }"
+            );
         }, Qt::QueuedConnection);
     }
     virtual QMenu *createMenu(QWidget *parent) override
@@ -272,7 +281,7 @@ bool SniTrayProtocolHandler::eventFilter(QObject *watched, QEvent *event)
                 pluginPopup->setItemKey(id());
                 pluginPopup->setPopupType(Plugin::PluginPopup::PopupTypeMenu);
                 const auto offset = mouseEvent->pos();
-                pluginPopup->setX(geometry.x() + offset.x());
+                pluginPopup->setX(geometry.x() + offset.x() + 2); // Add 2 offsets to avoid hovering to the menu
                 pluginPopup->setY(geometry.y() + offset.y());
                 menu->show();
             }

--- a/plugins/libdbusmenuqt/dbusmenuimporter.cpp
+++ b/plugins/libdbusmenuqt/dbusmenuimporter.cpp
@@ -1,4 +1,5 @@
 /* This file is part of the dbusmenu-qt library
+    SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
     SPDX-FileCopyrightText: 2009 Canonical
     SPDX-FileContributor: Aurelien Gateau <aurelien.gateau@canonical.com>
 
@@ -119,6 +120,8 @@ public:
 
         if (map.take(QStringLiteral("children-display")).toString() == QLatin1String("submenu")) {
             QMenu *menu = createMenu(parent);
+            // Set the ID of the menuAction of the submenu so that aboutToShow can correctly obtain the menu ID and refresh it
+            menu->menuAction()->setProperty(DBUSMENU_PROPERTY_ID, id);
             action->setMenu(menu);
         }
 
@@ -522,6 +525,9 @@ void DBusMenuImporter::slotMenuAboutToHide()
 
     int id = action->property(DBUSMENU_PROPERTY_ID).toInt();
     d->sendEvent(id, QStringLiteral("closed"));
+    
+    // Clear id when the menu is closed to ensure that it can be refreshed normally next time hover
+    d->m_idsRefreshedByAboutToShow.remove(id);
 }
 
 void DBusMenuImporter::slotMenuAboutToShow()


### PR DESCRIPTION
Fix submenu display issue and scroll arrows in system tray applications. 修复 clash、中州韵输入法等托盘应用的二级菜单显示问题。

Log: 修复托盘应用二级菜单显示和滚动箭头问题
PMS: BUG-333243
Influence: 托盘应用二级菜单现在能正确显示，不再出现无意义的滚动箭头，提升用户体验。