### PR TITLE
chore: update changelog to 2.0.29

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,12 @@
+dde-tray-loader (2.0.29) unstable; urgency=medium
+
+  * fix: resolve popup cursor display incorrect as arrow when hovering
+    links
+  * fix: clip item background painting to prevent border overflow in
+    high DPI
+
+ -- zhangkun <zhangkun2@uniontech.com>  Thu, 26 Mar 2026 19:39:56 +0800
+
 dde-tray-loader (2.0.28) unstable; urgency=medium
 
   * i18n: Translate dde-dock.ts in es (#432)


### PR DESCRIPTION
## 更新说明

自动更新 changelog 到版本 2.0.29

### 变更内容
- 更新 debian/changelog

### 版本信息
- 新版本: 2.0.29
- 目标分支: master

## Summary by Sourcery

Chores:
- Bump Debian changelog entry to version 2.0.29 targeting master.