### PR TITLE
fix: Optimised the Quick Panel UI

### DIFF
--- a/plugins/dde-dock/bluetooth/quickpanelwidget.cpp
+++ b/plugins/dde-dock/bluetooth/quickpanelwidget.cpp
@@ -7,10 +7,12 @@
 
 #include <DFontSizeManager>
 #include <DStyle>
+#include <DGuiApplicationHelper>
 
 #include <QHBoxLayout>
 #include <QLabel>
 #include <QMouseEvent>
+#include <QEnterEvent>
 #include <QPainter>
 #include <QPainterPath>
 #include <DToolTip>
@@ -25,7 +27,15 @@ class QuickButton : public DFloatingButton
 public:
     QuickButton(QWidget *parent = nullptr)
         : DFloatingButton(parent)
+        , m_parentHover(false)
     {
+    }
+
+    void setParentHover(bool hover) {
+        if (m_parentHover == hover)
+            return;
+        m_parentHover = hover;
+        update();
     }
 
 protected:
@@ -43,10 +53,10 @@ protected:
                 bgColor.setHslF(bgColor.hslHueF(), bgColor.hslSaturationF(), bgColor.lightnessF() * 1.1);
             }
         } else {
-            textColor.setAlphaF(1);
+            textColor.setAlphaF(m_parentHover ? 1.0 : 0.7);
             if (!option->state.testFlag(QStyle::State_Raised)) { // press
                 bgColor.setAlphaF(0.2);
-            } else if (option->state.testFlag(QStyle::State_MouseOver)) { // hover
+            } else if (option->state.testFlag(QStyle::State_MouseOver) || m_parentHover) { // hover
                 bgColor.setAlphaF(0.15);
             } else { // normal
                 bgColor.setAlphaF(0.1);
@@ -58,6 +68,9 @@ protected:
         option->state.setFlag(QStyle::State_Sunken, false);
         option->state.setFlag(QStyle::State_Raised, true);
     }
+
+private:
+    bool m_parentHover;
 };
 
 QuickPanelWidget::QuickPanelWidget(QWidget *parent)
@@ -66,6 +79,7 @@ QuickPanelWidget::QuickPanelWidget(QWidget *parent)
     , m_nameLabel(new DLabel(this))
     , m_stateLabel(new DLabel(this))
     , m_expandLabel(new DIconButton(this))
+    , m_hover(false)
 {
     initUi();
     initConnection();
@@ -170,4 +184,33 @@ void QuickPanelWidget::initUi()
 void QuickPanelWidget::initConnection()
 {
     connect(m_iconWidget, &DFloatingButton::clicked, this, &QuickPanelWidget::iconClicked);
+}
+
+void QuickPanelWidget::enterEvent(QEnterEvent *event)
+{
+    m_hover = true;
+    m_iconWidget->setParentHover(true);
+    updateTextColor(true);
+    QWidget::enterEvent(event);
+}
+
+void QuickPanelWidget::leaveEvent(QEvent *event)
+{
+    m_hover = false;
+    m_iconWidget->setParentHover(false);
+    updateTextColor(false);
+    QWidget::leaveEvent(event);
+}
+
+void QuickPanelWidget::updateTextColor(bool hover)
+{
+    bool isLight = DGuiApplicationHelper::instance()->themeType() == DGuiApplicationHelper::LightType;
+    QColor color = isLight ? QColor(0, 0, 0) : QColor(255, 255, 255);
+    color.setAlphaF(hover ? 1.0 : 0.7);
+
+    QPalette pa = m_nameLabel->palette();
+    pa.setColor(QPalette::BrightText, color);
+    pa.setColor(QPalette::WindowText, color);
+    m_nameLabel->setPalette(pa);
+    m_stateLabel->setPalette(pa);
 }

--- a/plugins/dde-dock/bluetooth/quickpanelwidget.h
+++ b/plugins/dde-dock/bluetooth/quickpanelwidget.h
@@ -35,10 +35,13 @@ Q_SIGNALS:
 protected:
     void mousePressEvent(QMouseEvent *event) override;
     void mouseReleaseEvent(QMouseEvent *event) override;
+    void enterEvent(QEnterEvent *event) override;
+    void leaveEvent(QEvent *event) override;
 
 private:
     void initUi();
     void initConnection();
+    void updateTextColor(bool hover);
 
 private:
     QuickButton *m_iconWidget;
@@ -46,6 +49,7 @@ private:
     Dtk::Widget::DLabel *m_stateLabel;
     Dtk::Widget::DIconButton *m_expandLabel;
     QPoint m_clickPoint;
+    bool m_hover;
 };
 
 #endif // QUICKPANELWIDGET_H

--- a/plugins/dde-dock/common/commoniconbutton.cpp
+++ b/plugins/dde-dock/common/commoniconbutton.cpp
@@ -16,9 +16,10 @@ CommonIconButton::CommonIconButton(QWidget *parent)
     , m_refreshTimer(nullptr)
     , m_clickable(false)
     , m_hover(false)
+    , m_parentHover(false)
     , m_state(Default)
-    , m_lightThemeColor(Qt::black)
-    , m_darkThemeColor(Qt::white)
+    , m_lightThemeColor(QColor(0, 0, 0, 178))
+    , m_darkThemeColor(QColor(255, 255, 255, 178))
     , m_activeState(false)
     , m_hoverEnable(true)
     , m_iconSize(QSize())
@@ -87,6 +88,9 @@ void CommonIconButton::updatePalette()
         if (m_lightThemeColor.isValid() && m_darkThemeColor.isValid()) {
             if (!m_activeState) {
                 QColor color = DGuiApplicationHelper::instance()->themeType() == DGuiApplicationHelper::LightType ? m_lightThemeColor : m_darkThemeColor;
+                if (m_hover || m_parentHover) {
+                    color.setAlpha(255);
+                }
                 auto pa = palette();
                 pa.setColor(QPalette::WindowText, color);
                 setPalette(pa);
@@ -111,6 +115,12 @@ void CommonIconButton::setActiveState(bool state)
 void CommonIconButton::setHoverEnable(bool enable)
 {
     m_hoverEnable = enable;
+}
+
+void CommonIconButton::setParentHover(bool hover)
+{
+    m_parentHover = hover;
+    updatePalette();
 }
 
 void CommonIconButton::setIcon(const QString &icon, const QString &fallback, const QString &suffix)
@@ -162,7 +172,7 @@ bool CommonIconButton::event(QEvent *e)
     case QEvent::Leave:
     case QEvent::Enter:
         m_hover = e->type() == QEvent::Enter;
-        update();
+        updatePalette();
         break;
     default:
         break;

--- a/plugins/dde-dock/common/commoniconbutton.h
+++ b/plugins/dde-dock/common/commoniconbutton.h
@@ -30,6 +30,7 @@ public:
     void setHoverEnable(bool enable);
     void setIconSize(const QSize &size);
     void setAllEnabled(bool enable);
+    void setParentHover(bool hover);
 
     void startRotate();
     void stopRotate();
@@ -64,6 +65,7 @@ private:
     QPoint m_pressPos;
     bool m_clickable;
     bool m_hover;
+    bool m_parentHover;
     QMap<State, QPair<QString, QString>> m_fileMapping;
     State m_state;
     QColor m_lightThemeColor;

--- a/plugins/dde-dock/common/jumpsettingbutton.cpp
+++ b/plugins/dde-dock/common/jumpsettingbutton.cpp
@@ -63,7 +63,7 @@ void JumpSettingButton::initUI()
 
 void JumpSettingButton::setIcon(const QIcon &icon)
 {
-    m_iconButton->setIcon(icon, Qt::black, Qt::white);
+    m_iconButton->setIcon(icon, QColor(0, 0, 0, 178), QColor(255, 255, 255, 178));
 }
 
 void JumpSettingButton::setDescription(const QString& description)
@@ -77,6 +77,7 @@ bool JumpSettingButton::event(QEvent* e)
     case QEvent::Leave:
     case QEvent::Enter:
         m_hover = e->type() == QEvent::Enter;
+        m_iconButton->setParentHover(m_hover);
         update();
         break;
     case QEvent::Hide:
@@ -100,6 +101,7 @@ void JumpSettingButton::paintEvent(QPaintEvent* e)
         bgColor = palette.color(QPalette::Active, QPalette::Highlight);
     } else {
         textColor = palette.brightText().color();
+        textColor.setAlphaF(0.7);
         bgColor = palette.brightText().color();
         bgColor.setAlphaF(0.05);
     }

--- a/plugins/dde-dock/common/pluginitemdelegate.cpp
+++ b/plugins/dde-dock/common/pluginitemdelegate.cpp
@@ -50,6 +50,7 @@ void PluginItemDelegate::paint(QPainter *painter, const QStyleOptionViewItem &op
         }
     } else {
         textColor = boption.dpalette.brightText().color();
+        textColor.setAlphaF(0.7);
         bgColor = boption.dpalette.brightText().color();
         bgColor.setAlphaF(0.05);
     }

--- a/plugins/dde-dock/common/singlequickpanel.cpp
+++ b/plugins/dde-dock/common/singlequickpanel.cpp
@@ -5,6 +5,7 @@
 #include "singlequickpanel.h"
 
 #include <QVBoxLayout>
+#include <QEnterEvent>
 #include <QMargins>
 
 #include <DFontSizeManager>
@@ -20,6 +21,7 @@ SignalQuickPanel::SignalQuickPanel(QWidget *parent)
     , m_icon(new CommonIconButton(this))
     , m_description(new DLabel(this))
     , m_active(false)
+    , m_hover(false)
 {
     initUI();
     connect(DGuiApplicationHelper::instance(), &DGuiApplicationHelper::themeTypeChanged, this, &SignalQuickPanel::refreshBg);
@@ -52,7 +54,7 @@ void SignalQuickPanel::initUI()
 
 void SignalQuickPanel::setIcon(const QIcon &icon)
 {
-    m_icon->setIcon(icon, Qt::black, Qt::white);
+    m_icon->setIcon(icon, QColor(0, 0, 0, 178), QColor(255, 255, 255, 178));
 }
 
 void SignalQuickPanel::setDescription(const QString &description)
@@ -81,5 +83,36 @@ void SignalQuickPanel::mouseReleaseEvent(QMouseEvent *event)
 void SignalQuickPanel::refreshBg()
 {
     m_description->setForegroundRole(m_icon->activeState() ? QPalette::Highlight : QPalette::NoRole);
+    updateTextColor();
     update();
+}
+
+void SignalQuickPanel::enterEvent(QEnterEvent *event)
+{
+    m_hover = true;
+    m_icon->setParentHover(true);
+    updateTextColor();
+    QWidget::enterEvent(event);
+}
+
+void SignalQuickPanel::leaveEvent(QEvent *event)
+{
+    m_hover = false;
+    m_icon->setParentHover(false);
+    updateTextColor();
+    QWidget::leaveEvent(event);
+}
+
+void SignalQuickPanel::updateTextColor()
+{
+    if (m_active)
+        return;
+
+    bool isLight = DGuiApplicationHelper::instance()->themeType() == DGuiApplicationHelper::LightType;
+    QColor color = isLight ? QColor(0, 0, 0) : QColor(255, 255, 255);
+    color.setAlphaF(m_hover ? 1.0 : 0.7);
+
+    QPalette pa = m_description->palette();
+    pa.setColor(QPalette::WindowText, color);
+    m_description->setPalette(pa);
 }

--- a/plugins/dde-dock/common/singlequickpanel.h
+++ b/plugins/dde-dock/common/singlequickpanel.h
@@ -37,9 +37,12 @@ Q_SIGNALS:
 
 protected:
     void mouseReleaseEvent(QMouseEvent *event) override;
+    void enterEvent(QEnterEvent *event) override;
+    void leaveEvent(QEvent *event) override;
 
 private:
     void initUI();
+    void updateTextColor();
 
 private slots:
     void refreshBg();
@@ -48,6 +51,7 @@ private:
     CommonIconButton *m_icon;
     DLabel *m_description;
     bool m_active;
+    bool m_hover;
 };
 
 #endif

--- a/plugins/dde-dock/eye-comfort-mode/quickpanelwidget.cpp
+++ b/plugins/dde-dock/eye-comfort-mode/quickpanelwidget.cpp
@@ -8,10 +8,12 @@
 
 #include <DFontSizeManager>
 #include <DStyle>
+#include <DGuiApplicationHelper>
 
 #include <QHBoxLayout>
 #include <QLabel>
 #include <QMouseEvent>
+#include <QEnterEvent>
 #include <QPainter>
 #include <QPainterPath>
 #include <DToolTip>
@@ -36,10 +38,10 @@ void QuickButton::initStyleOption(DStyleOptionButton *option) const
             bgColor.setHslF(bgColor.hslHueF(), bgColor.hslSaturationF(), bgColor.lightnessF() * 1.1);
         }
     } else {
-        textColor.setAlphaF(1);
+        textColor.setAlphaF(m_parentHover ? 1.0 : 0.7);
         if (!option->state.testFlag(QStyle::State_Raised)) { // press
             bgColor.setAlphaF(0.2);
-        } else if (option->state.testFlag(QStyle::State_MouseOver)) { // hover
+        } else if (option->state.testFlag(QStyle::State_MouseOver) || m_parentHover) { // hover
             bgColor.setAlphaF(0.15);
         } else { // normal
             bgColor.setAlphaF(0.1);
@@ -64,6 +66,7 @@ QuickPanelWidget::QuickPanelWidget(QWidget *parent)
     , m_nameLabel(new DLabel(this))
     , m_stateLabel(new DLabel(this))
     , m_expandLabel(new DIconButton(this))
+    , m_hover(false)
 {
     initUi();
     initConnection();
@@ -172,4 +175,33 @@ void QuickPanelWidget::initUi()
 void QuickPanelWidget::initConnection()
 {
     connect(m_iconWidget, &DFloatingButton::clicked, this, &QuickPanelWidget::iconClicked);
+}
+
+void QuickPanelWidget::enterEvent(QEnterEvent *event)
+{
+    m_hover = true;
+    m_iconWidget->setParentHover(true);
+    updateTextColor(true);
+    QWidget::enterEvent(event);
+}
+
+void QuickPanelWidget::leaveEvent(QEvent *event)
+{
+    m_hover = false;
+    m_iconWidget->setParentHover(false);
+    updateTextColor(false);
+    QWidget::leaveEvent(event);
+}
+
+void QuickPanelWidget::updateTextColor(bool hover)
+{
+    bool isLight = DGuiApplicationHelper::instance()->themeType() == DGuiApplicationHelper::LightType;
+    QColor color = isLight ? QColor(0, 0, 0) : QColor(255, 255, 255);
+    color.setAlphaF(hover ? 1.0 : 0.7);
+
+    QPalette pa = m_nameLabel->palette();
+    pa.setColor(QPalette::BrightText, color);
+    pa.setColor(QPalette::WindowText, color);
+    m_nameLabel->setPalette(pa);
+    m_stateLabel->setPalette(pa);
 }

--- a/plugins/dde-dock/eye-comfort-mode/quickpanelwidget.h
+++ b/plugins/dde-dock/eye-comfort-mode/quickpanelwidget.h
@@ -26,6 +26,7 @@ public:
     QuickButton(QWidget *parent = nullptr)
         : DFloatingButton(parent)
         , m_mode(ButtonMode::ClickButton)
+        , m_parentHover(false)
     {
     }
 
@@ -38,11 +39,19 @@ public:
         initStyleOption(&option);
     }
 
+    void setParentHover(bool hover) {
+        if (m_parentHover == hover)
+            return;
+        m_parentHover = hover;
+        update();
+    }
+
 protected:
     void initStyleOption(DStyleOptionButton *option) const override;
 
 private:
     ButtonMode m_mode;
+    bool m_parentHover;
 };
 
 class QLabel;
@@ -68,10 +77,13 @@ Q_SIGNALS:
 protected:
     void mousePressEvent(QMouseEvent *event) override;
     void mouseReleaseEvent(QMouseEvent *event) override;
+    void enterEvent(QEnterEvent *event) override;
+    void leaveEvent(QEvent *event) override;
 
 private:
     void initUi();
     void initConnection();
+    void updateTextColor(bool hover);
 
 private:
     QuickButton *m_iconWidget;
@@ -80,6 +92,7 @@ private:
     Dtk::Widget::DIconButton *m_expandLabel;
     QPoint m_clickPoint;
     bool m_eyeComfortModeEnabled;
+    bool m_hover;
 };
 
 #endif // QUICKPANELWIDGET_H

--- a/plugins/dde-dock/media/quickpanelwidget.cpp
+++ b/plugins/dde-dock/media/quickpanelwidget.cpp
@@ -8,9 +8,11 @@
 #include "mediamodel.h"
 
 #include <QHBoxLayout>
+#include <QEnterEvent>
 
 #include <DStyleOption>
 #include <DIcon>
+#include <DGuiApplicationHelper>
 
 QuickPanelWidget::QuickPanelWidget(MediaController *controller, QWidget* parent)
     : QWidget(parent)
@@ -20,6 +22,7 @@ QuickPanelWidget::QuickPanelWidget(MediaController *controller, QWidget* parent)
     , m_artistLab(new DLabel(this))
     , m_playButton(new CommonIconButton(this))
     , m_nextButton(new CommonIconButton(this))
+    , m_hover(false)
 {
     init();
 }
@@ -62,9 +65,9 @@ void QuickPanelWidget::init()
     QHBoxLayout *hLayout = new QHBoxLayout(buttonWidget);
 
     m_playButton->setClickable(true);
-    m_playButton->setIcon(QIcon::fromTheme(MediaModel::ref().playState() ? "play-pause" : "play-start"), Qt::black, Qt::white);
+    m_playButton->setIcon(QIcon::fromTheme(MediaModel::ref().playState() ? "play-pause" : "play-start"), QColor(0, 0, 0, 178), QColor(255, 255, 255, 178));
     m_nextButton->setClickable(true);
-    m_nextButton->setIcon(QIcon::fromTheme("play-next"), Qt::black, Qt::white);
+    m_nextButton->setIcon(QIcon::fromTheme("play-next"), QColor(0, 0, 0, 178), QColor(255, 255, 255, 178));
 
     hLayout->setSpacing(0);
     hLayout->setContentsMargins(0, 0, 0, 0);
@@ -79,7 +82,7 @@ void QuickPanelWidget::init()
     connect(m_nextButton, &CommonIconButton::clicked, m_controller, &MediaController::next);
 
     connect(&MediaModel::ref(), &MediaModel::playStateChanged, this, [this] (bool state) {
-        m_playButton->setIcon(QIcon::fromTheme(state ? "play-pause" : "play-start"), Qt::black, Qt::white);
+        m_playButton->setIcon(QIcon::fromTheme(state ? "play-pause" : "play-start"), QColor(0, 0, 0, 178), QColor(255, 255, 255, 178));
     });
     connect(m_playButton, &CommonIconButton::clicked, this, [this] {
         MediaModel::ref().playState() ? m_controller->pause() : m_controller->play();
@@ -125,6 +128,35 @@ void QuickPanelWidget::mouseReleaseEvent(QMouseEvent *event)
         Q_EMIT clicked();
     }
     return QWidget::mouseReleaseEvent(event);
+}
+
+void QuickPanelWidget::enterEvent(QEnterEvent *event)
+{
+    m_hover = true;
+    m_playButton->setParentHover(true);
+    m_nextButton->setParentHover(true);
+    updateTextColor(true);
+    QWidget::enterEvent(event);
+}
+
+void QuickPanelWidget::leaveEvent(QEvent *event)
+{
+    m_hover = false;
+    m_playButton->setParentHover(false);
+    m_nextButton->setParentHover(false);
+    updateTextColor(false);
+    QWidget::leaveEvent(event);
+}
+
+void QuickPanelWidget::updateTextColor(bool hover)
+{
+    bool isLight = DGuiApplicationHelper::instance()->themeType() == DGuiApplicationHelper::LightType;
+    QColor color = isLight ? QColor(0, 0, 0) : QColor(255, 255, 255);
+    color.setAlphaF(hover ? 1.0 : 0.7);
+
+    QPalette pa = m_titleLab->palette();
+    pa.setColor(QPalette::BrightText, color);
+    m_titleLab->setPalette(pa);
 }
 
 QuickPanelWidget::~QuickPanelWidget()

--- a/plugins/dde-dock/media/quickpanelwidget.h
+++ b/plugins/dde-dock/media/quickpanelwidget.h
@@ -22,6 +22,8 @@ public:
 
 protected:
     void mouseReleaseEvent(QMouseEvent *event);
+    void enterEvent(QEnterEvent *event) override;
+    void leaveEvent(QEvent *event) override;
 
 Q_SIGNALS:
     void clicked();
@@ -30,6 +32,7 @@ Q_SIGNALS:
 private:
     void init();
     void updateUI();
+    void updateTextColor(bool hover);
 
 private:
     MediaController *m_controller;
@@ -39,6 +42,7 @@ private:
     DLabel *m_artistLab;
     CommonIconButton *m_playButton;
     CommonIconButton *m_nextButton;
+    bool m_hover;
 };
 
 #endif

--- a/plugins/dde-network-display-ui/plugins/dock-wirelesscasting-plugin/src/quickpanelwidget.cpp
+++ b/plugins/dde-network-display-ui/plugins/dock-wirelesscasting-plugin/src/quickpanelwidget.cpp
@@ -7,10 +7,12 @@
 #include <DFontSizeManager>
 #include <DStyle>
 #include <DToolTip>
+#include <DGuiApplicationHelper>
 
 #include <QHBoxLayout>
 #include <QLabel>
 #include <QMouseEvent>
+#include <QEnterEvent>
 #include <QPainter>
 #include <QPainterPath>
 
@@ -26,7 +28,15 @@ class QuickButton : public DFloatingButton
 public:
     explicit QuickButton(QWidget *parent = nullptr)
         : DFloatingButton(parent)
+        , m_parentHover(false)
     {
+    }
+
+    void setParentHover(bool hover) {
+        if (m_parentHover == hover)
+            return;
+        m_parentHover = hover;
+        update();
     }
 
 protected:
@@ -45,7 +55,7 @@ protected:
             }
         } else {
             bgColor.setAlphaF(0);
-            textColor.setAlphaF(1);
+            textColor.setAlphaF(m_parentHover ? 1.0 : 0.7);
         }
         option->palette.setBrush(QPalette::Button, bgColor);
         option->palette.setBrush(QPalette::ButtonText, textColor);
@@ -53,6 +63,9 @@ protected:
         option->state.setFlag(QStyle::State_Sunken, false);
         option->state.setFlag(QStyle::State_Raised, true);
     }
+
+private:
+    bool m_parentHover;
 };
 
 QuickPanelWidget::QuickPanelWidget(QWidget *parent)
@@ -61,6 +74,7 @@ QuickPanelWidget::QuickPanelWidget(QWidget *parent)
     , m_nameLabel(new DLabel(this))
     , m_stateLabel(new DLabel(this))
     , m_expandLabel(new DIconButton(this))
+    , m_hover(false)
 {
     initUi();
     initConnection();
@@ -164,6 +178,35 @@ void QuickPanelWidget::initUi()
 void QuickPanelWidget::initConnection()
 {
     connect(m_iconWidget, &DFloatingButton::clicked, this, &QuickPanelWidget::iconClicked);
+}
+
+void QuickPanelWidget::enterEvent(QEnterEvent *event)
+{
+    m_hover = true;
+    m_iconWidget->setParentHover(true);
+    updateTextColor(true);
+    QWidget::enterEvent(event);
+}
+
+void QuickPanelWidget::leaveEvent(QEvent *event)
+{
+    m_hover = false;
+    m_iconWidget->setParentHover(false);
+    updateTextColor(false);
+    QWidget::leaveEvent(event);
+}
+
+void QuickPanelWidget::updateTextColor(bool hover)
+{
+    bool isLight = DGuiApplicationHelper::instance()->themeType() == DGuiApplicationHelper::LightType;
+    QColor color = isLight ? QColor(0, 0, 0) : QColor(255, 255, 255);
+    color.setAlphaF(hover ? 1.0 : 0.7);
+
+    QPalette pa = m_nameLabel->palette();
+    pa.setColor(QPalette::BrightText, color);
+    pa.setColor(QPalette::WindowText, color);
+    m_nameLabel->setPalette(pa);
+    m_stateLabel->setPalette(pa);
 }
 
 } // namespace wirelesscasting

--- a/plugins/dde-network-display-ui/plugins/dock-wirelesscasting-plugin/src/quickpanelwidget.h
+++ b/plugins/dde-network-display-ui/plugins/dock-wirelesscasting-plugin/src/quickpanelwidget.h
@@ -37,10 +37,13 @@ Q_SIGNALS:
 protected:
     void mousePressEvent(QMouseEvent *event) override;
     void mouseReleaseEvent(QMouseEvent *event) override;
+    void enterEvent(QEnterEvent *event) override;
+    void leaveEvent(QEvent *event) override;
 
 private:
     void initUi();
     void initConnection();
+    void updateTextColor(bool hover);
 
 private:
     QuickButton *m_iconWidget;
@@ -48,6 +51,7 @@ private:
     Dtk::Widget::DLabel *m_stateLabel;
     Dtk::Widget::DIconButton *m_expandLabel;
     QPoint m_clickPoint;
+    bool m_hover;
 };
 } // namespace wirelesscasting
 } // namespace dde


### PR DESCRIPTION
log: In light mode, icon and text colours are 000000 with 70% opacity; in dark mode, icon and text colours are ffffff with 70% opacity; on hover, icon and text colours are 100% opacity. Furthermore, the text colour of the titles in the secondary panel does not need to be adjusted; only the colours of the icons and text in the list need to be adjusted.

pms: bug-314503

## Summary by Sourcery

Align quick panel list icon and text colors with design requirements across dock plugins, including hover behavior and light/dark theme opacity.

Bug Fixes:
- Correct quick panel list item colors in light and dark themes to use 70% opacity by default and 100% on hover.

Enhancements:
- Unify hover handling for quick panel items and their icons via shared parent hover state.
- Adjust common icon button defaults and plugin delegates to use semi-transparent theme colors for inactive states.