### PR TITLE
fix: correct context menu coordinate mapping

### DIFF
--- a/src/loader/pluginitem.cpp
+++ b/src/loader/pluginitem.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2011 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2011 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -19,7 +19,7 @@ PluginItem::PluginItem(PluginsItemInterface *pluginItemInterface, const QString 
     : QWidget(parent)
     , m_itemKey(itemKey)
     , m_pluginsItemInterface(pluginItemInterface)
-    , m_menu(new DockContextMenu(this))
+    , m_menu(new DockContextMenu(nullptr))
     , m_tooltipTimer(new QTimer(this))
     , m_tipsWidget(nullptr)
 {
@@ -44,7 +44,13 @@ PluginItem::PluginItem(PluginsItemInterface *pluginItemInterface, const QString 
     });
 }
 
-PluginItem::~PluginItem() = default;
+PluginItem::~PluginItem()
+{
+    if (m_menu) {
+        delete m_menu;
+        m_menu = nullptr;
+    }
+}
 
 QWidget *PluginItem::itemPopupApplet()
 {


### PR DESCRIPTION
Changed the DockContextMenu parent from 'this' to 'nullptr' in PluginItem constructor to fix coordinate mapping issues when right-click menu is shown. The issue occurred because using 'this' as parent caused the menu's coordinate system to be relative to the PluginItem widget, leading to incorrect position mapping when the menu was displayed. By setting parent to nullptr, the menu becomes a top-level widget with screen coordinates, ensuring proper positioning. Also added explicit cleanup in destructor to safely delete the menu pointer.

Log: Fixed incorrect right-click menu position for dock plugin items

fix: 修复上下文菜单坐标映射问题

将 PluginItem 构造函数中 DockContextMenu 的父对象从 'this' 改为 'nullptr'，以修复显示右键菜单时的坐标映射问题。问题原因是使用 'this' 作
为父对象会导致菜单的坐标系相对于 PluginItem 小部件，从而在显示菜单时产
生错误的位置映射。通过将父对象设置为 nullptr，菜单成为使用屏幕坐标的顶
层小部件，确保正确定位。同时在析构函数中添加了显式清理逻辑以安全删除菜单
指针。

Log: 修复了任务栏插件项右键菜单位置不正确的问题

PMS: BUG-352159

## Summary by Sourcery

Fix context menu positioning for dock plugin items by adjusting the menu’s ownership and lifecycle management.

Bug Fixes:
- Correct right-click context menu coordinate mapping for dock plugin items so menus appear at the correct screen position.

Enhancements:
- Update plugin item source file copyright year range to include 2026.