### PR TITLE
fix: fix SNI tray context menu style issue on first click

### DIFF
--- a/plugins/application-tray/sniprotocolhandler.cpp
+++ b/plugins/application-tray/sniprotocolhandler.cpp
@@ -161,7 +161,9 @@ SniTrayProtocolHandler::SniTrayProtocolHandler(const QString &sniServicePath, QO
     connect(m_sniInter, &StatusNotifierItem::NewToolTip, this, &SniTrayProtocolHandler::tooltiChanged);
     connect(DGuiApplicationHelper::instance(), &DGuiApplicationHelper::themeTypeChanged, this, [this](DGuiApplicationHelper::ColorType themeType) {
         Q_UNUSED(themeType)
-        menuImporter()->updateMenu(true);
+        if (auto menu = menuImporter()) {
+            menu->updateMenu(true);
+        }
     });
 }
 
@@ -186,6 +188,9 @@ DBusMenuImporter *SniTrayProtocolHandler::menuImporter() const
 {
     if (!m_dbusMenuImporter) {
         auto that = const_cast<SniTrayProtocolHandler *>(this);
+        if (that->m_menuPath == QLatin1String("/NO_DBUSMENU")) {
+            return nullptr;
+        }
         that->m_dbusMenuImporter = new DBusMenu(m_service, m_menuPath, that);
     }
     return m_dbusMenuImporter;
@@ -290,13 +295,12 @@ bool SniTrayProtocolHandler::eventFilter(QObject *watched, QEvent *event)
             if (mouseEvent->button() == Qt::LeftButton) {
                 m_sniInter->Activate(0, 0);
             } else if (mouseEvent->button() == Qt::RightButton) {
-                auto menu = menuImporter()->menu();
-                Q_CHECK_PTR(menu);
-                if (menu->isEmpty()) {
+                if (!menuImporter()) {
                     m_sniInter->ContextMenu(0, 0);
                     return false;
                 }
 
+                auto menu = menuImporter()->menu();
                 menu->setFixedSize(menu->sizeHint());
                 menu->winId();
 


### PR DESCRIPTION
Fixed an issue where the SNI tray context menu displayed incorrect
styling on the first right-click. The problem occurred because
menuImporter() was being called before the DBusMenuImporter was properly
initialized, causing menu()->isEmpty() to return incorrect results. This
led to the fallback ContextMenu() being called, which uses a non-DTK
style menu.

The fix includes:
1. Added null check for menuImporter() before calling updateMenu() in
theme change handler
2. Added early return in menuImporter() when menu path is "/NO_DBUSMENU"
to prevent creating invalid DBusMenuImporter
3. Modified eventFilter to check if menuImporter() returns null before
accessing menu, ensuring ContextMenu() is only called when no valid menu
is available
4. Ensured proper initialization sequence for DBusMenuImporter

Log: Fixed SNI tray context menu styling issue on first right-click

Influence:
1. Test right-click on SNI tray icons to verify context menu displays
with correct DTK styling
2. Verify menu appears immediately on first right-click without style
issues
3. Test theme switching while tray menu is open to ensure menu updates
correctly
4. Verify ContextMenu() fallback still works when no valid menu path
is available
5. Test left-click activation functionality remains unchanged

fix: 修复SNI托盘右键菜单首次点击样式错误

修复了SNI托盘右键菜单首次点击时显示错误样式的问题。问题发生
在DBusMenuImporter未正确初始化时调用了menuImporter()，导致
menu()->isEmpty()返回错误结果。这触发了回退的ContextMenu()调用，该函数使
用非DTK样式的菜单。

修复内容包括：
1. 在主题变更处理程序中添加了对menuImporter()的空指针检查
2. 在menuImporter()中添加了当菜单路径为"/NO_DBUSMENU"时的提前返回，防止
创建无效的DBusMenuImporter
3. 修改了eventFilter，在访问菜单前检查menuImporter()是否返回空值，确保仅
在无有效菜单时调用ContextMenu()
4. 确保DBusMenuImporter的正确初始化顺序

Log: 修复SNI托盘右键菜单首次点击时的样式问题

Influence:
1. 测试SNI托盘图标右键点击，验证上下文菜单以正确的DTK样式显示
2. 验证首次右键点击时菜单立即显示且无样式问题
3. 测试在托盘菜单打开时切换主题，确保菜单正确更新
4. 验证当无有效菜单路径时，ContextMenu()回退功能仍正常工作
5. 测试左键激活功能保持不变

PMS: BUG-357505

## Summary by Sourcery

Fix SNI tray context menu to use the correct styled menu on first right-click by ensuring the DBus menu importer is valid before use.

Bug Fixes:
- Prevent the SNI tray context menu from falling back to a non-DTK styled menu on the first right-click by guarding against uninitialized or invalid DBusMenuImporter instances.

Enhancements:
- Improve robustness of SNI tray menu handling by adding null checks and early returns around the DBus menu importer and its initialization sequence.