### PR TITLE
fix: add mutex protection for unique ID generation

### DIFF
--- a/plugins/application-tray/util.cpp
+++ b/plugins/application-tray/util.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -318,6 +318,7 @@ void Util::sendXembedMessage(const xcb_window_t& window, const long& message, co
 
 QString Util::generateUniqueId(const QString &id)
 {
+    QMutexLocker locker(&m_idMutex);
     for (int i = 0; i < 100; i++) {
         QString newId = id + "-" + QString::number(i);
         if (!m_currentIds.contains(newId)) {
@@ -331,6 +332,7 @@ QString Util::generateUniqueId(const QString &id)
 }
 
 void Util::removeUniqueId(const QString &id) {
+    QMutexLocker locker(&m_idMutex);
     m_currentIds.remove(id);
 }
 

--- a/plugins/application-tray/util.h
+++ b/plugins/application-tray/util.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -9,6 +9,7 @@
 #include <QSharedPointer>
 #include <QSet>
 #include <QObject>
+#include <QMutex>
 
 #include <cstdint>
 #include <sys/types.h>
@@ -78,6 +79,7 @@ private:
     _XDisplay *m_display;
 
     QSet<QString> m_currentIds;
+    QMutex m_idMutex;
 };
 
 }


### PR DESCRIPTION
1. Added QMutexLocker to protect the generateUniqueId method from
concurrent access
2. Added QMutexLocker to protect the removeUniqueId method from
concurrent access
3. Added m_idMutex member variable to util.h for thread synchronization
4. This fixes potential race conditions when multiple threads call these
methods simultaneously, ensuring unique IDs remain unique and preventing
data corruption of m_currentIds

Influence:
1. Test generating unique IDs from multiple threads simultaneously
2. Verify that no duplicate IDs are produced under concurrent access
3. Test removing IDs while other threads are generating new ones
4. Verify no crashes or data corruption occurs with heavy multi-threaded
usage
5. Test with stress conditions (100+ concurrent threads)
6. Verify that the application tray plugin works correctly with multi-
threaded operations

fix: 添加互斥锁保护唯一ID生成

1. 为 generateUniqueId 方法添加 QMutexLocker 保护并发访问
2. 为 removeUniqueId 方法添加 QMutexLocker 保护并发访问
3. 在 util.h 中添加 m_idMutex 成员变量用于线程同步
4. 修复了多线程同时调用这些方法时的竞态条件问题，确保唯一ID保持唯一性，
防止 m_currentIds 数据损坏

Influence:
1. 测试多线程同时生成唯一ID
2. 验证并发访问下不会产生重复ID
3. 测试在生成新ID的同时移除其他ID的场景
4. 验证高并发使用下不会出现崩溃或数据损坏
5. 测试压力条件（100+并发线程）
6. 验证应用程序托盘插件在多线程操作下正常工作

## Summary by Sourcery

Add thread-safe protection around application tray unique ID management to prevent race conditions under concurrent access.

Bug Fixes:
- Prevent duplicate or corrupted unique ID entries when generate/remove operations are invoked concurrently from multiple threads.

Enhancements:
- Introduce a mutex to synchronize access to the current ID set in the application tray utility and update SPDX copyright years to cover 2024–2026.