### PR TITLE
fix: disable menu scroll indicator in application tray plugin

### DIFF
--- a/plugins/application-tray/CMakeLists.txt
+++ b/plugins/application-tray/CMakeLists.txt
@@ -72,6 +72,8 @@ target_link_libraries(${PLUGIN_NAME}
         Qt${QT_VERSION_MAJOR}::Core
         Qt${QT_VERSION_MAJOR}::Gui
         Qt${QT_VERSION_MAJOR}::Widgets
+        Qt${QT_VERSION_MAJOR}::CorePrivate
+        Qt${QT_VERSION_MAJOR}::WidgetsPrivate
         Dtk${DTK_VERSION_MAJOR}::Core
         Dtk${DTK_VERSION_MAJOR}::Gui
         Dtk${DTK_VERSION_MAJOR}::Widget

--- a/plugins/application-tray/sniprotocolhandler.cpp
+++ b/plugins/application-tray/sniprotocolhandler.cpp
@@ -17,6 +17,8 @@
 #include <QRunnable>
 
 #include <DGuiApplicationHelper>
+#include <private/qobject_p.h>
+#include <private/qmenu_p.h>
 
 DGUI_USE_NAMESPACE
 
@@ -32,6 +34,12 @@ public:
     {
         QObject::connect(this, &DBusMenuImporter::menuUpdated, this, [this] (QMenu *menu) {
             menu->setFixedSize(menu->sizeHint());
+            // TODO 删除 QMenu 的滚动功能，修复首次子菜单显示滚动指示器问题
+            if (auto dp = static_cast<QMenuPrivate*>(QObjectPrivate::get(menu))) {
+                if (auto scroll = dp->scroll) {
+                    scroll->scrollFlags = QMenuPrivate::QMenuScroller::ScrollNone;
+                }
+            }
         }, Qt::QueuedConnection);
     }
     virtual QMenu *createMenu(QWidget *parent) override


### PR DESCRIPTION
1. Removed scroll indicator functionality in QMenu submenus to prevent
display issues
2. Added private Qt headers to access QMenuPrivate and disable scrolling
3. Adjusted window positioning logic for popup sub-windows

Log: Disabled menu scroll indicator in application tray to fix display
issues

Influence:
1. Test application tray menu display without scroll indicators
2. Verify sub-menu opening behavior and positioning
3. Test popup window positioning for wayland integration
4. Verify menu size and layout correctness
5. Test on different screen resolutions and scaling factors

fix: 禁止托盘菜单滚动指示器功能

1. 移除 QMenu 子菜单的滚动指示器功能，解决显示问题
2. 添加 Qt 私有头文件以访问 QMenuPrivate 并禁用滚动
3. 调整弹出子窗口的定位逻辑

Log: 禁用托盘菜单滚动指示器以修复显示问题

Influence:
1. 测试托盘菜单显示，确认无滚动指示器
2. 验证子菜单打开行为和定位
3. 测试 wayland 集成下的弹出窗口定位
4. 验证菜单尺寸和布局正确性
5. 在不同屏幕分辨率和缩放比例下测试

PMS: BUG-333243

## Summary by Sourcery

Disable scroll indicators in application tray menus and adjust popup positioning for Wayland tray integration.

Bug Fixes:
- Remove QMenu submenu scrolling to prevent initial display issues with scroll indicators in the application tray menu.
- Correct popup sub-window vertical positioning in the Wayland tray integration to align with the parent window.

Build:
- Link the application tray plugin against Qt CorePrivate and WidgetsPrivate to support use of private Qt menu internals.