### PR TITLE
chore: update changelog to 2.0.30

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,12 @@
+dde-tray-loader (2.0.30) unstable; urgency=medium
+
+  * fix: disable menu scroll indicator in application tray plugin
+  * fix: add mutex protection for unique ID generation
+  * fix: fix SNI tray context menu style issue on first click
+  * fix: correct context menu coordinate mapping
+
+ -- zhangkun <zhangkun2@uniontech.com>  Thu, 23 Apr 2026 21:46:15 +0800
+
 dde-tray-loader (2.0.29) unstable; urgency=medium
 
   * fix: resolve popup cursor display incorrect as arrow when hovering


### PR DESCRIPTION
## 更新说明

自动更新 changelog 到版本 2.0.30

### 变更内容
- 更新 debian/changelog

### 版本信息
- 新版本: 2.0.30
- 目标分支: master

## Summary by Sourcery

Documentation:
- Update debian/changelog to document the 2.0.30 release.