### PR TITLE
chore: update changelog to 2.0.31

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-tray-loader (2.0.31) unstable; urgency=medium
+
+  * fix: prevent crash when closing wayland popup surfaces
+
+ -- zhangkun <zhangkun2@uniontech.com>  Fri, 24 Apr 2026 16:48:56 +0800
+
 dde-tray-loader (2.0.30) unstable; urgency=medium
 
   * fix: disable menu scroll indicator in application tray plugin


### PR DESCRIPTION
## 更新说明

自动更新 changelog 到版本 2.0.31

### 变更内容
- 更新 debian/changelog

### 版本信息
- 新版本: 2.0.31
- 目标分支: master

## Summary by Sourcery

Chores:
- Bump Debian changelog version metadata to 2.0.31.