### PR TITLE
fix: memory leaks in SNI tooltip and Xembed container window

### DIFF
--- a/plugins/application-tray/ddeindicatortrayprotocol.cpp
+++ b/plugins/application-tray/ddeindicatortrayprotocol.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -22,7 +22,8 @@
 #include <QLoggingCategory>
 
 #include <cmath>
-#include <thread>
+#include <QThreadPool>
+#include <QRunnable>
 
 namespace tray {
 
@@ -150,25 +151,25 @@ void DDEindicatorProtocolHandlerPrivate::initDBus()
         }
 
         const QJsonObject action = config.value("action").toObject();
-        if (!action.isEmpty())
-            q->connect(q, &DDEindicatorProtocolHandler::clicked, q, [ = ](uint8_t button_index, int x, int y) {
-                std::thread t([ = ] ()-> void {
-                    auto triggerConfig = action.value("trigger").toObject();
-                    auto dbusService = triggerConfig.value("dbus_service").toString();
-                    auto dbusPath = triggerConfig.value("dbus_path").toString();
-                    auto dbusInterface = triggerConfig.value("dbus_interface").toString();
-                    auto methodName = triggerConfig.value("dbus_method").toString();
-                    auto isSystemBus = triggerConfig.value("system_dbus").toBool(false);
-                    auto bus = isSystemBus ? QDBusConnection::systemBus() : QDBusConnection::sessionBus();
+        if (!action.isEmpty()) {
+            const auto triggerConfig = action.value("trigger").toObject();
+            const auto dbusService = triggerConfig.value("dbus_service").toString();
+            const auto dbusPath = triggerConfig.value("dbus_path").toString();
+            const auto dbusInterface = triggerConfig.value("dbus_interface").toString();
+            const auto methodName = triggerConfig.value("dbus_method").toString();
+            const auto isSystemBus = triggerConfig.value("system_dbus").toBool(false);
 
+            q->connect(q, &DDEindicatorProtocolHandler::clicked, q, [=](uint8_t button_index, int x, int y) {
+                QThreadPool::globalInstance()->start([=] {
+                    auto bus = isSystemBus ? QDBusConnection::systemBus() : QDBusConnection::sessionBus();
                     QDBusInterface interface(dbusService, dbusPath, dbusInterface, bus);
                     QDBusReply<void> reply = interface.call(methodName, button_index, x, y);
                     if (!reply.isValid()) {
                         interface.call(methodName);
                     }
                 });
-                t.detach();
             });
+        }
     });
 }
 

--- a/plugins/application-tray/sniprotocolhandler.cpp
+++ b/plugins/application-tray/sniprotocolhandler.cpp
@@ -153,7 +153,10 @@ SniTrayProtocolHandler::SniTrayProtocolHandler(const QString &sniServicePath, QO
     m_sniInter->setTimeout(2000);
     init();
 
-    connect(m_sniInter, &StatusNotifierItem::NewIcon, this, &SniTrayProtocolHandler::iconChanged);
+    connect(m_sniInter, &StatusNotifierItem::NewIcon, this, [this] {
+        m_cachedIcon = dbusImageList2QIcon(m_sniInter->iconPixmap());
+        Q_EMIT iconChanged();
+    });
     connect(m_sniInter, &StatusNotifierItem::NewOverlayIcon, this, &SniTrayProtocolHandler::overlayIconChanged);
     connect(m_sniInter, &StatusNotifierItem::NewAttentionIcon, this, [this] {
         if (m_ignoreFirstAttention) {
@@ -177,6 +180,11 @@ SniTrayProtocolHandler::SniTrayProtocolHandler(const QString &sniServicePath, QO
 
 SniTrayProtocolHandler::~SniTrayProtocolHandler()
 {
+    if (m_tooltip) {
+        delete m_tooltip;
+        m_tooltip = nullptr;
+    }
+
     UTIL->removeUniqueId(m_id);
 }
 
@@ -184,6 +192,7 @@ void SniTrayProtocolHandler::init()
 {
     generateId();
     m_menuPath = m_sniInter->menu().path();
+    m_cachedIcon = dbusImageList2QIcon(m_sniInter->iconPixmap());
 }
 
 void SniTrayProtocolHandler::generateId()
@@ -287,7 +296,7 @@ QIcon SniTrayProtocolHandler::icon() const
         }
     }
 
-    return dbusImageList2QIcon(m_sniInter->iconPixmap());
+    return m_cachedIcon;
 }
 
 bool SniTrayProtocolHandler::enabled() const

--- a/plugins/application-tray/sniprotocolhandler.h
+++ b/plugins/application-tray/sniprotocolhandler.h
@@ -87,5 +87,6 @@ private:
     QString m_service;
     QString m_menuPath;
     bool m_ignoreFirstAttention;
+    QIcon m_cachedIcon;
 };
 }

--- a/plugins/application-tray/trayplugin.cpp
+++ b/plugins/application-tray/trayplugin.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -90,6 +90,7 @@ void TrayPlugin::onTrayhandlerCreatd(QPointer<AbstractTrayProtocolHandler> handl
         }
 
         m_widget.remove(id);
+        m_tooltip.remove(id);
     };
 
     auto showWidget = [this, handler, id](){

--- a/plugins/application-tray/xembedprotocolhandler.cpp
+++ b/plugins/application-tray/xembedprotocolhandler.cpp
@@ -127,6 +127,7 @@ XembedProtocolHandler::XembedProtocolHandler(const uint32_t& id, QObject* parent
     : AbstractTrayProtocolHandler(parent)
     , m_enabled(false)
     , m_windowId(id)
+    , m_containerWid(0)
     , m_hoverTimer(new QTimer(this))
     , m_attentionTimer(new QTimer(this))
     , m_iconUpdateTimer(new QTimer(this))
@@ -159,6 +160,9 @@ XembedProtocolHandler::XembedProtocolHandler(const uint32_t& id, QObject* parent
 
 XembedProtocolHandler::~XembedProtocolHandler()
 {
+    if (m_containerWid) {
+        xcb_destroy_window(Util::instance()->getX11Connection(), m_containerWid);
+    }
     UTIL->removeUniqueId(m_id);
 }
 


### PR DESCRIPTION
- Delete m_tooltip QLabel in SniTrayProtocolHandler destructor (parentless QLabel leaked on each handler destruction)
- Remove tooltip entry from TrayPlugin::m_tooltip QHash on handler removal (stale entries accumulated in the map)
- Destroy X11 container window in XembedProtocolHandler destructor (X11 resource leaked on each handler destruction)
- Cache SNI icon to avoid repeated expensive DBus image conversion in frequently-called icon()
- Use QThreadPool instead of std::thread::detach() for DDE indicator DBus trigger (reuse threads, reduce overhead)

- 修复 SniTrayProtocolHandler 析构时未删除无父对象的 m_tooltip QLabel 导致内存泄漏
- 修复 handler 销毁时未清理 TrayPlugin::m_tooltip QHash 条目导致条目累积
- 修复 XembedProtocolHandler 析构时未销毁 X11 container window 导致 X11 资源泄漏
- 缓存 SNI 图标避免高频率调用的 icon() 每次重复转换 DBus 图像数据
- 将 DDE indicator DBus 触发器的线程模型从 std::thread::detach() 改为 QThreadPool 线程复用

Log: fix: memory leaks in SNI tooltip and Xembed container window
Pms: 359161