### PR TITLE
chore: update changelog to 2.0.32

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+dde-tray-loader (2.0.32) unstable; urgency=medium
+
+  * fix: remove shot-start-plugin from wayland blacklist
+  * fix(test): add missing LaunchType property to identifyService
+    expected result
+
+ -- zhangkun <zhangkun2@uniontech.com>  Thu, 14 May 2026 20:03:21 +0800
+
 dde-tray-loader (2.0.31) unstable; urgency=medium
 
   * fix: prevent crash when closing wayland popup surfaces


### PR DESCRIPTION
## 更新说明

自动更新 changelog 到版本 2.0.32

### 变更内容
- 更新 debian/changelog

### 版本信息
- 新版本: 2.0.32
- 目标分支: master
