### PR TITLE
fix: eliminate remaining memory leaks in application-tray

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -1,7 +1,7 @@
 #!/usr/bin/make -f
 DPKG_EXPORT_BUILDFLAGS = 1
 include /usr/share/dpkg/default.mk
-export QT_SELECT = qt5
+export QT_SELECT = qt6
 export DEB_BUILD_MAINT_OPTIONS = hardening=+all
 export DEB_CFLAGS_MAINT_APPEND = -Wall
 export DEB_CXXFLAGS_MAINT_APPEND = -Wall

--- a/plugins/application-tray/sniprotocolhandler.cpp
+++ b/plugins/application-tray/sniprotocolhandler.cpp
@@ -154,16 +154,23 @@ SniTrayProtocolHandler::SniTrayProtocolHandler(const QString &sniServicePath, QO
     init();
 
     connect(m_sniInter, &StatusNotifierItem::NewIcon, this, [this] {
-        m_cachedIcon = dbusImageList2QIcon(m_sniInter->iconPixmap());
+        if (m_sniInter->iconName().isEmpty())
+            m_cachedIcon = dbusImageList2QIcon(m_sniInter->iconPixmap());
         Q_EMIT iconChanged();
     });
-    connect(m_sniInter, &StatusNotifierItem::NewOverlayIcon, this, &SniTrayProtocolHandler::overlayIconChanged);
+    connect(m_sniInter, &StatusNotifierItem::NewOverlayIcon, this, [this] {
+        if (m_sniInter->overlayIconName().isEmpty())
+            m_cachedOverlayIcon = dbusImageList2QIcon(m_sniInter->overlayIconPixmap());
+        Q_EMIT overlayIconChanged();
+    });
     connect(m_sniInter, &StatusNotifierItem::NewAttentionIcon, this, [this] {
         if (m_ignoreFirstAttention) {
             m_ignoreFirstAttention = false;
             return;
         }
 
+        if (m_sniInter->attentionIconName().isEmpty())
+            m_cachedAttentionIcon = dbusImageList2QIcon(m_sniInter->attentionIconPixmap());
         Q_EMIT attentionIconChanged();
     });
 
@@ -193,6 +200,8 @@ void SniTrayProtocolHandler::init()
     generateId();
     m_menuPath = m_sniInter->menu().path();
     m_cachedIcon = dbusImageList2QIcon(m_sniInter->iconPixmap());
+    m_cachedAttentionIcon = dbusImageList2QIcon(m_sniInter->attentionIconPixmap());
+    m_cachedOverlayIcon = dbusImageList2QIcon(m_sniInter->overlayIconPixmap());
 }
 
 void SniTrayProtocolHandler::generateId()
@@ -261,8 +270,7 @@ QIcon SniTrayProtocolHandler::overlayIcon() const
         return QIcon::fromTheme(iconName);
     }
 
-    auto icon = dbusImageList2QIcon(m_sniInter->overlayIconPixmap());
-    return icon;
+    return m_cachedOverlayIcon;
 }
 
 QIcon SniTrayProtocolHandler::attentionIcon() const
@@ -272,8 +280,7 @@ QIcon SniTrayProtocolHandler::attentionIcon() const
         return QIcon::fromTheme(iconName);
     }
 
-    auto icon = dbusImageList2QIcon(m_sniInter->attentionIconPixmap());
-    return icon;
+    return m_cachedAttentionIcon;
 }
 
 QIcon SniTrayProtocolHandler::icon() const
@@ -356,18 +363,19 @@ QPair<QString, QString> SniTrayProtocolHandler::serviceAndPath(const QString &se
 QIcon SniTrayProtocolHandler::dbusImageList2QIcon(const DBusImageList &dbusImageList)
 {
     QIcon res;
-    if (!dbusImageList.isEmpty() && !dbusImageList.first().pixels.isEmpty()) {
-        for (auto image = dbusImageList.begin(); image < dbusImageList.end(); image++) {
-            const char *image_data = image->pixels.data();
-            if (QSysInfo::ByteOrder == QSysInfo::LittleEndian) {
-                for (int i = 0; i < image->pixels.size(); i += 4) {
-                    *(qint32 *)(image_data + i) = qFromBigEndian(*(qint32 *)(image_data + i));
-                }
-            }
+    if (dbusImageList.isEmpty() || dbusImageList.first().pixels.isEmpty())
+        return res;
 
-            QImage qimage((const uchar *)image->pixels.constData(), image->width, image->height, QImage::Format_ARGB32);
-            res.addPixmap(QPixmap::fromImage(qimage));
+    DBusImageList copy = dbusImageList;
+    for (auto &image : copy) {
+        if (QSysInfo::ByteOrder == QSysInfo::LittleEndian) {
+            quint32 *pixels = reinterpret_cast<quint32 *>(image.pixels.data());
+            for (int i = 0; i < image.pixels.size() / 4; i++)
+                pixels[i] = qFromBigEndian(pixels[i]);
         }
+
+        QImage qimage(reinterpret_cast<const uchar *>(image.pixels.constData()), image.width, image.height, QImage::Format_ARGB32);
+        res.addPixmap(QPixmap::fromImage(qimage));
     }
 
     return res;

--- a/plugins/application-tray/sniprotocolhandler.h
+++ b/plugins/application-tray/sniprotocolhandler.h
@@ -88,5 +88,7 @@ private:
     QString m_menuPath;
     bool m_ignoreFirstAttention;
     QIcon m_cachedIcon;
+    QIcon m_cachedAttentionIcon;
+    QIcon m_cachedOverlayIcon;
 };
 }

--- a/plugins/application-tray/util.cpp
+++ b/plugins/application-tray/util.cpp
@@ -204,7 +204,7 @@ void Util::setX11WindowSize(const xcb_window_t& window, const QSize& size)
 QRect Util::getX11WindowGeometry(const xcb_window_t& window) const
 {
     auto cookie = xcb_get_geometry(m_x11connection, window);
-    QSharedPointer<xcb_get_geometry_reply_t> clientGeom(xcb_get_geometry_reply(m_x11connection, cookie, nullptr));
+    QSharedPointer<xcb_get_geometry_reply_t> clientGeom(xcb_get_geometry_reply(m_x11connection, cookie, nullptr), [](xcb_get_geometry_reply_t* ptr){ free(ptr); });
 
     return clientGeom ? QRect(clientGeom->x, clientGeom->y, clientGeom->width, clientGeom->height) : QRect();
 }
@@ -239,12 +239,19 @@ void Util::setX11WindowInputShape(const xcb_window_t& window, const QSize& size)
 QImage Util::getX11WindowImageNonComposite(const xcb_window_t& window)
 {
     QSize size = getX11WindowGeometry(window).size();
+    if (size.isEmpty()) {
+        return QImage();
+    }
+    
     xcb_image_t *image = xcb_image_get(m_x11connection, window, 0, 0, size.width(), size.height(), 0xFFFFFFFF, XCB_IMAGE_FORMAT_Z_PIXMAP);
 
-    QImage naiveConversion;
-    if (image) {
-        naiveConversion = QImage(image->data, image->width, image->height, QImage::Format_ARGB32);
-    } else {
+    if (!image) {
+        return QImage();
+    }
+
+    QImage naiveConversion(image->data, image->width, image->height, QImage::Format_ARGB32);
+    if (naiveConversion.isNull()) {
+        xcb_image_destroy(image);
         return QImage();
     }
 
@@ -252,10 +259,13 @@ QImage Util::getX11WindowImageNonComposite(const xcb_window_t& window)
         QImage elaborateConversion = QImage(convertFromNative(image));
         if (isTransparentImage(elaborateConversion)) {
             return QImage();
-        } else
+        } else {
             return elaborateConversion;
+        }
     } else {
-        return QImage(image->data, image->width, image->height, image->stride, QImage::Format_ARGB32, clean_xcb_image, image);
+        QImage res = naiveConversion.copy();
+        xcb_image_destroy(image);
+        return res;
     }
 }
 
@@ -384,36 +394,41 @@ QImage Util::convertFromNative(xcb_image_t *xcbImage)
         format = QImage::Format_ARGB32_Premultiplied;
         break;
     default:
+        xcb_image_destroy(xcbImage);
         return QImage();
     }
 
-    QImage image(xcbImage->data, xcbImage->width, xcbImage->height, xcbImage->stride, format, clean_xcb_image, xcbImage);
+    QImage image(xcbImage->data, xcbImage->width, xcbImage->height, xcbImage->stride, format);
 
     if (image.isNull()) {
+        xcb_image_destroy(xcbImage);
         return QImage();
     }
+    
+    QImage deepCopy = image.copy();
+    xcb_image_destroy(xcbImage);
 
-    if (format == QImage::Format_RGB32 && xcbImage->bpp == 32) {
-        QImage m = image.createHeuristicMask();
-        QPixmap p = QPixmap::fromImage(std::move(image));
+    if (format == QImage::Format_RGB32 && deepCopy.depth() == 32) {
+        QImage m = deepCopy.createHeuristicMask();
+        QPixmap p = QPixmap::fromImage(std::move(deepCopy));
         p.setMask(QBitmap::fromImage(std::move(m)));
-        image = p.toImage();
+        deepCopy = p.toImage();
     }
 
-    if (image.format() == QImage::Format_MonoLSB) {
-        image.setColorCount(2);
-        image.setColor(0, QColor(Qt::white).rgb());
-        image.setColor(1, QColor(Qt::black).rgb());
+    if (deepCopy.format() == QImage::Format_MonoLSB) {
+        deepCopy.setColorCount(2);
+        deepCopy.setColor(0, QColor(Qt::white).rgb());
+        deepCopy.setColor(1, QColor(Qt::black).rgb());
     }
 
-    return image;
+    return deepCopy;
 }
 
 QPoint Util::getMousePos() const
 {
     QPoint pos;
     xcb_query_pointer_cookie_t cookie = xcb_query_pointer(m_x11connection, m_rootWindow);
-    QScopedPointer<xcb_query_pointer_reply_t> reply(xcb_query_pointer_reply(m_x11connection, cookie, NULL));
+    QSharedPointer<xcb_query_pointer_reply_t> reply(xcb_query_pointer_reply(m_x11connection, cookie, NULL), [](xcb_query_pointer_reply_t* ptr){ free(ptr); });
     if (reply) {
         pos = QPoint(reply->root_x, reply->root_y);
     }

--- a/plugins/application-tray/xembedprotocolhandler.cpp
+++ b/plugins/application-tray/xembedprotocolhandler.cpp
@@ -284,7 +284,7 @@ void XembedProtocolHandler::initX11resources()
     xcb_flush(c);
 
     auto waCookie = xcb_get_window_attributes(c, m_windowId);
-    QSharedPointer<xcb_get_window_attributes_reply_t> windowAttributes(xcb_get_window_attributes_reply(c, waCookie, nullptr));
+    QSharedPointer<xcb_get_window_attributes_reply_t> windowAttributes(xcb_get_window_attributes_reply(c, waCookie, nullptr), [](xcb_get_window_attributes_reply_t* ptr){ free(ptr); });
     if (windowAttributes && !(windowAttributes->all_event_masks & XCB_EVENT_MASK_BUTTON_PRESS)) {
         m_injectMode = XTest;
     }
@@ -399,7 +399,7 @@ void XembedProtocolHandler::sendClick(uint8_t qMouseButton)
     auto dis = UTIL->getDisplay();
 
     auto cookieSize = xcb_get_geometry(c, m_windowId);
-    QSharedPointer<xcb_get_geometry_reply_t> clientGeom(xcb_get_geometry_reply(c, cookieSize, nullptr));
+    QSharedPointer<xcb_get_geometry_reply_t> clientGeom(xcb_get_geometry_reply(c, cookieSize, nullptr), [](xcb_get_geometry_reply_t* ptr){ free(ptr); });
 
     if (!clientGeom) {
         return;


### PR DESCRIPTION
SNI icon handling:
- Add m_cachedAttentionIcon / m_cachedOverlayIcon to cache attention
  and overlay icons, following the same pattern as m_cachedIcon, to
  avoid repeated D-Bus pixmap reads during attention state blinking
- Skip icon pixmap updates on NewIcon / NewOverlayIcon /
  NewAttentionIcon signals when the client provides a theme icon name,
  since the getter already resolves icons from the icon theme in that
  case and the cached pixmap is not needed
- Rework dbusImageList2QIcon: deep-copy the DBusImageList before
  modifying pixel data to fix const-cast undefined behavior with Qt6
  QByteArray; use quint32* for correct type semantics and bounded
  iteration (size/4 instead of raw byte stride)

XCB image lifecycle (XEmbed path):
- Fix xcb_image_t leak in Util::convertFromNative when the pixel depth
  falls into the unsupported default case
- Explicitly call xcb_image_destroy when QImage construction from
  xcb_image_t fails, since Qt's cleanup callback is not invoked in the
  null state
- Replace QSharedPointer/QScopedPointer default delete deleters with
  explicit free() for xcb reply pointers allocated via malloc, fixing
  undefined behavior and potential leaks in both Util and
  XembedProtocolHandler
- Refactor getX11WindowImageNonComposite to deep-copy the image data
  via QImage::copy and immediately destroy the xcb_image_t, bypassing
  Qt's unreliable cleanup callback that can be evaded by std::move and
  heuristic mask operations

Build:
- Fix debian/rules to export QT_SELECT=qt6 instead of qt5 since
  the tray plugin links against Qt6

Together with the corresponding DTK fix (QMetaType::destruct before
construct in DDBusExtendedAbstractInterface::internalPropGet), this
reduces application-tray RSS growth from ~23 KB/s to negligible levels.

SNI 图标处理:
- 新增 m_cachedAttentionIcon / m_cachedOverlayIcon 缓存 attention/overlay
  图标，沿用 m_cachedIcon 的缓存模式，避免闪烁状态期间每次 paint
  重复走 DBus 属性读取
- NewIcon / NewOverlayIcon / NewAttentionIcon 信号处理中，当客户端提供
  主题图标名时跳过 pixmap 更新，因为 getter 已经优先从图标主题加载
- 重写 dbusImageList2QIcon: 修改像素数据前显式深拷贝 DBusImageList，
  修正 Qt6 QByteArray 的 const_cast 未定义行为；使用 quint32* 替代
  qint32* 获得正确的类型语义，循环边界改为 size/4

XCB 图像生命周期:
- convertFromNative 函数 default 分支中释放 xcb_image_t 防止泄漏
- QImage 从 xcb_image_t 构造失败时显式调用 xcb_image_destroy，弥补
  Qt 在 null state 下不触发 cleanup callback 的问题
- QSharedPointer/QScopedPointer 使用 free 替代默认的 delete 释放
  malloc 分配的 xcb reply 指针，修正未定义行为
- getX11WindowImageNonComposite 通过 QImage::copy 深拷贝后直接
  xcb_image_destroy，绕过 Qt cleanup callback 被 std::move 和
  heuristic mask 绕过的风险

构建:
- debian/rules 修正 QT_SELECT=qt6，匹配实际 Qt6 链接

配合 DTK 修复（DDBusExtendedAbstractInterface::internalPropGet 中
construct 前添加 destruct），application-tray RSS 增长从约 23 KB/s
降至可忽略水平。

Log: fix: eliminate remaining memory leaks in application-tray
Pms: BUG-359161