### PR TITLE
fix: remove shot-start-plugin from wayland blacklist

### DIFF
--- a/src/loader/pluginmanager.cpp
+++ b/src/loader/pluginmanager.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -53,7 +53,6 @@ void PluginManager::loadPlugin(const QString &pluginFilePath)
     if (qgetenv("XDG_SESSION_TYPE") == "wayland") {
         blacklistedPluginPaths.append(QStringList{
             "libshot-start-record-plugin.so",
-            "libshot-start-plugin.so",
             "libdeepin-screen-recorder-plugin.so",
             "libeye-comfort-mode.so",
         });


### PR DESCRIPTION
Remove "libshot-start-plugin.so" from the list of plugins blacklisted
under the Wayland session. The plugin is now compatible with Wayland,
allowing it to load and function properly on Wayland-based systems.

Log: Removed wayland blacklist entry for shot-start-plugin

Influence:
1. Verify the shot-start plugin loads successfully on Wayland systems
2. Test basic functionality of the shot-start plugin under Wayland
3. Ensure no regression on X11 systems

fix: 从 wayland 黑名单中移除 shot-start-plugin

从 Wayland 会话下的插件黑名单中移除 "libshot-start-plugin.so"。该插件现
已兼容 Wayland，允许其在基于 Wayland 的系统上正常加载和运行。

Log: 移除 shot-start-plugin 的 wayland 黑名单配置

Influence:
1. 验证 shot-start 插件在 Wayland 系统上成功加载
2. 在 Wayland 下测试 shot-start 插件的基本功能
3. 确保在 X11 系统上没有回归问题

PMS: BUG-345077

## Summary by Sourcery

Allow the shot-start plugin to load under Wayland by removing it from the Wayland-specific plugin blacklist.

Bug Fixes:
- Fix incorrect Wayland blacklist configuration that prevented the shot-start plugin from loading on Wayland sessions.

Enhancements:
- Update plugin manager file copyright years to cover 2024–2026.