### PR TITLE
fix: disable xembed tray selection manager registeration

### DIFF
--- a/plugins/application-tray/xembedprotocolhandler.cpp
+++ b/plugins/application-tray/xembedprotocolhandler.cpp
@@ -5,7 +5,10 @@
 #include "abstracttrayprotocol.h"
 #include "traymanager1interface.h"
 #include "xembedprotocolhandler.h"
+
+#if _DDE_TRAY_LOADER_HANDLE_XEMBED_SELECTION_MANAGER
 #include "fdoselectionmanager.h"
+#endif // _DDE_TRAY_LOADER_HANDLE_XEMBED_SELECTION_MANAGER
 
 #include "util.h"
 #include "plugin.h"
@@ -41,10 +44,12 @@ XembedProtocol::XembedProtocol(QObject *parent)
 
     QMetaObject::invokeMethod(this, &XembedProtocol::onTrayIconsChanged, Qt::QueuedConnection);
 
+#if _DDE_TRAY_LOADER_HANDLE_XEMBED_SELECTION_MANAGER
     if ((qgetenv("XDG_SESSION_TYPE") == "wayland") && UTIL->isXAvaliable()) {
         qWarning() << "Not running on X11, registering FDO selection manager";
         m_selectionManager = new FdoSelectionManager(this);
     }
+#endif // _DDE_TRAY_LOADER_HANDLE_XEMBED_SELECTION_MANAGER
 
     QTimer::singleShot(0, this, [this](){
         m_trayManager->Manage();

--- a/plugins/application-tray/xembedprotocolhandler.h
+++ b/plugins/application-tray/xembedprotocolhandler.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -15,6 +15,12 @@
 #include <xcb/xproto.h>
 #include <xcb/composite.h>
 #include <xcb/xcb_image.h>
+
+// dde-daemon handles tray selection-manager registeration so we don't (and shouldn't) need this.
+// Also, if we need to register the FDO selection manager, we also need to ensure tray context menu
+// position can be handled correctly. The whole FdoSelectionManager stuff might be worth to move to
+// dde-shell instead.
+#define _DDE_TRAY_LOADER_HANDLE_XEMBED_SELECTION_MANAGER 0
 
 class FdoSelectionManager;
 namespace tray {


### PR DESCRIPTION
The current FdoSelectionManager is for preparing the legacy xembed2sni solution. We currently no longer plans to go with such solution, but the current code will register `_NET_SYSTEM_TRAY_S0`. This patch disabled related code path so it won't gets registered. We should do registeration from dde-daemon instead.

注:此patch并不直接解决下面关联的PMS问题单,只是有相关性,是相关工作的
一部分.

PMS: BUG-360349