### PR TITLE
chore: port more behaviors from dde-daemon to dde-tray-loader

### DIFF
--- a/plugins/application-tray/fdoselectionmanager.cpp
+++ b/plugins/application-tray/fdoselectionmanager.cpp
@@ -68,10 +68,21 @@ void FdoSelectionManager::init()
     connect(m_selectionOwner, &KSelectionOwner::failedToClaimOwnership, this, &FdoSelectionManager::onFailedToClaimOwnership);
     connect(m_selectionOwner, &KSelectionOwner::lostOwnership, this, &FdoSelectionManager::onLostOwnership);
     m_selectionOwner->claim(true);
+}
 
-    connect(m_trayManager, &TrayManager1::reclainRequested, this, [this](){
-        m_selectionOwner->claim(true);
-    });
+void FdoSelectionManager::checkValid()
+{
+    if (!m_trayManager) {
+        return;
+    }
+
+    const TrayList trayIcons = m_trayManager->trayIcons();
+    for (uint id : trayIcons) {
+        const xcb_window_t window = static_cast<xcb_window_t>(id);
+        if (!UTIL->isValidX11Window(window)) {
+            undock(window);
+        }
+    }
 }
 
 bool FdoSelectionManager::addDamageWatch(xcb_window_t client)
@@ -82,7 +93,6 @@ bool FdoSelectionManager::addDamageWatch(xcb_window_t client)
     const auto attribsCookie = xcb_get_window_attributes_unchecked(c, client);
 
     const auto damageId = xcb_generate_id(c);
-    m_damageWatches[client] = damageId;
     xcb_damage_create(c, damageId, client, XCB_DAMAGE_REPORT_LEVEL_NON_EMPTY);
 
     xcb_generic_error_t *error = nullptr;
@@ -94,6 +104,7 @@ bool FdoSelectionManager::addDamageWatch(xcb_window_t client)
     }
     // if window is already gone, there is no need to handle it.
     if (getAttrError && getAttrError->error_code == XCB_WINDOW) {
+        xcb_damage_destroy(c, damageId);
         return false;
     }
     // the event mask will not be removed again. We cannot track whether another component also needs STRUCTURE_NOTIFY (e.g. KWindowSystem).
@@ -102,8 +113,11 @@ bool FdoSelectionManager::addDamageWatch(xcb_window_t client)
     UniqueCPointer<xcb_generic_error_t> changeAttrError(xcb_request_check(c, changeAttrCookie));
     // if window is gone by this point, it will be caught by eventFilter, so no need to check later errors.
     if (changeAttrError && changeAttrError->error_code == XCB_WINDOW) {
+        xcb_damage_destroy(c, damageId);
         return false;
     }
+
+    m_damageWatches[client] = damageId;
 
     return true;
 }
@@ -160,6 +174,8 @@ void FdoSelectionManager::dock(xcb_window_t winId)
     Q_CHECK_PTR(m_trayManager);
     qCDebug(SELECTIONMGR) << "trying to dock window " << winId;
 
+    checkValid();
+
     if (m_trayManager->haveIcon(winId)) {
         return;
     }
@@ -182,6 +198,12 @@ void FdoSelectionManager::undock(xcb_window_t winId)
 
     // Unregister from TrayManager1 if available
     m_trayManager->unregisterIcon(winId);
+
+    const auto damageId = m_damageWatches.take(winId);
+    if (damageId) {
+        xcb_damage_destroy(Util::instance()->getX11Connection(), damageId);
+        xcb_flush(Util::instance()->getX11Connection());
+    }
     
     // m_proxies[winId]->deleteLater();
     // m_proxies.remove(winId);
@@ -192,7 +214,8 @@ void FdoSelectionManager::onClaimedOwnership()
     qCDebug(SELECTIONMGR) << "Manager selection claimed";
 
     initTrayManager();
-    setSystemTrayVisual();
+    setSystemTrayProperties();
+    m_trayManager->notifyInited();
 }
 
 void FdoSelectionManager::onFailedToClaimOwnership()
@@ -205,7 +228,7 @@ void FdoSelectionManager::onLostOwnership()
     qCWarning(SELECTIONMGR) << "lost ownership of Systray Manager";
 }
 
-void FdoSelectionManager::setSystemTrayVisual()
+void FdoSelectionManager::setSystemTrayProperties()
 {
     xcb_connection_t *c = Util::instance()->getX11Connection();
     auto screen = xcb_setup_roots_iterator(xcb_get_setup(c)).data;
@@ -234,6 +257,11 @@ void FdoSelectionManager::setSystemTrayVisual()
     }
 
     xcb_change_property(c, XCB_PROP_MODE_REPLACE, m_selectionOwner->ownerWindow(), UTIL->getAtomByName("_NET_SYSTEM_TRAY_VISUAL"), XCB_ATOM_VISUALID, 32, 1, &trayVisual);
+
+    const uint32_t orientation = 0;
+    xcb_change_property(c, XCB_PROP_MODE_REPLACE, m_selectionOwner->ownerWindow(), UTIL->getAtomByName("_NET_SYSTEM_TRAY_ORIENTATION"), XCB_ATOM_CARDINAL, 32, 1, &orientation);
+    xcb_change_property(c, XCB_PROP_MODE_REPLACE, m_selectionOwner->ownerWindow(), UTIL->getAtomByName("NET_SYSTEM_TRAY_ORIENTAION"), XCB_ATOM_CARDINAL, 32, 1, &orientation);
+    xcb_flush(c);
 }
 
 void FdoSelectionManager::initTrayManager()
@@ -253,8 +281,11 @@ void FdoSelectionManager::initTrayManager()
         QDBusConnection::sessionBus().registerService(
             QStringLiteral("org.deepin.dde.TrayManager1")
         );
+
+        connect(m_trayManager, &TrayManager1::reclainRequested, this, [this](){
+            m_selectionOwner->claim(true);
+        });
         
         qCDebug(SELECTIONMGR) << "TrayManager1 DBus interface registered";
     }
 }
-

--- a/plugins/application-tray/fdoselectionmanager.h
+++ b/plugins/application-tray/fdoselectionmanager.h
@@ -36,10 +36,11 @@ private Q_SLOTS:
 
 private:
     void init();
+    void checkValid();
     bool addDamageWatch(xcb_window_t client);
     void dock(xcb_window_t embed_win);
     void undock(xcb_window_t client);
-    void setSystemTrayVisual();
+    void setSystemTrayProperties();
     void initTrayManager();
 
     TrayManager1 *m_trayManager = nullptr;

--- a/plugins/application-tray/traymanager1.cpp
+++ b/plugins/application-tray/traymanager1.cpp
@@ -1,6 +1,6 @@
 // Deepin DDE TrayManager1 implementation
 //
-// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2025 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -14,6 +14,8 @@
 #include <QLoggingCategory>
 
 Q_LOGGING_CATEGORY(TRAYMGR, "org.deepin.dde.trayloader.traymgr")
+
+using Util = tray::Util;
 
 TrayManager1::TrayManager1(QObject *parent)
     : QObject(parent)
@@ -34,7 +36,9 @@ void TrayManager1::registerIcon(xcb_window_t win)
         return;
     }
 
-    m_icons[win] = true;
+    IconState state;
+    UTIL->getX11WindowPixmapData(win, &state.pixmapData);
+    m_icons[win] = state;
     qCDebug(TRAYMGR) << "Icon registered:" << win ;//<< "name:" << proxy->name();
 
     Q_EMIT Added(static_cast<uint32_t>(win));
@@ -55,14 +59,27 @@ void TrayManager1::unregisterIcon(xcb_window_t win)
 
 void TrayManager1::notifyIconChanged(xcb_window_t win)
 {
-    if (!m_icons.contains(win)) {
+    auto it = m_icons.find(win);
+    if (it == m_icons.end()) {
         return;
     }
 
-    if (!m_icons[win]) {
+    if (!it->enableNotify) {
         qCDebug(TRAYMGR) << "EnableNotification is false, not sending changed signal for:" << win;
         return;
     }
+
+    QByteArray newPixmapData;
+    if (!UTIL->getX11WindowPixmapData(win, &newPixmapData)) {
+        return;
+    }
+
+    if (it->pixmapData == newPixmapData) {
+        qCDebug(TRAYMGR) << "Icon changed ignored, pixmap unchanged:" << win;
+        return;
+    }
+
+    it->pixmapData = std::move(newPixmapData);
 
     qCDebug(TRAYMGR) << "Icon changed:" << win;
     Q_EMIT Changed(static_cast<uint32_t>(win));
@@ -81,6 +98,16 @@ TrayList TrayManager1::trayIcons() const
 bool TrayManager1::haveIcon(xcb_window_t win) const
 {
     return m_icons.contains(win);
+}
+
+void TrayManager1::notifyInited()
+{
+    if (m_inited) {
+        return;
+    }
+
+    m_inited = true;
+    Q_EMIT Inited();
 }
 
 // DBus method implementations
@@ -103,7 +130,7 @@ void TrayManager1::EnableNotification(uint32_t win, bool enabled)
         return;
     }
 
-    m_icons[win] = enabled;
+    m_icons[win].enableNotify = enabled;
 
     qCDebug(TRAYMGR) << "EnableNotification for" << win << "=" << enabled;
 }

--- a/plugins/application-tray/traymanager1.h
+++ b/plugins/application-tray/traymanager1.h
@@ -1,12 +1,13 @@
 // Deepin DDE TrayManager1 implementation
 //
-// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2025 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 #pragma once
 
 #include <QObject>
+#include <QByteArray>
 #include <QHash>
 #include <QList>
 #include <QString>
@@ -36,6 +37,11 @@ public:
     explicit TrayManager1(QObject *parent = nullptr);
     ~TrayManager1() override;
 
+    struct IconState {
+        bool enableNotify = true;
+        QByteArray pixmapData;
+    };
+
     /**
      * @brief Register a new tray icon with the manager
      * @param win Window ID of the embedded tray icon
@@ -61,6 +67,7 @@ public:
     TrayList trayIcons() const;
 
     bool haveIcon(xcb_window_t win) const;
+    void notifyInited();
 
 public Q_SLOTS:
     // DBus methods
@@ -79,5 +86,6 @@ Q_SIGNALS:
 
 private:
     TrayManager1Adaptor * m_adaptor;
-    QHash<xcb_window_t, bool> m_icons; // <winid, enableNotify>
+    QHash<xcb_window_t, IconState> m_icons;
+    bool m_inited = false;
 };

--- a/plugins/application-tray/util.cpp
+++ b/plugins/application-tray/util.cpp
@@ -16,6 +16,7 @@
 #include <QAbstractEventDispatcher>
 
 #include <X11/Xlib.h>
+#include <X11/Xutil.h>
 
 #include <mutex>
 #include <xcb/res.h>
@@ -218,7 +219,52 @@ QString Util::getX11WindowName(const xcb_window_t& window)
         ret.assign(reply.strings, reply.strings_len);
         xcb_ewmh_get_utf8_strings_reply_wipe(&reply);
     }
+
+    if (!ret.empty()) {
+        return QString::fromUtf8(ret.c_str(), static_cast<int>(ret.size()));
+    }
+
+    if (m_display) {
+        char *windowName = nullptr;
+        if (XFetchName(m_display, window, &windowName) > 0 && windowName) {
+            ret.assign(windowName);
+            XFree(windowName);
+        }
+    }
+
+    if (!ret.empty()) {
+        return QString::fromLocal8Bit(ret.c_str(), static_cast<int>(ret.size()));
+    }
+
+    if (m_display) {
+        XClassHint classHint;
+        if (XGetClassHint(m_display, window, &classHint)) {
+            const QString wmClass = QString::fromLocal8Bit(classHint.res_class ? classHint.res_class : "");
+            const QString wmInstance = QString::fromLocal8Bit(classHint.res_name ? classHint.res_name : "");
+            if (classHint.res_name) {
+                XFree(classHint.res_name);
+            }
+            if (classHint.res_class) {
+                XFree(classHint.res_class);
+            }
+            if (!wmClass.isEmpty() || !wmInstance.isEmpty()) {
+                return QStringLiteral("[%1|%2]").arg(wmClass, wmInstance);
+            }
+        }
+    }
+
     return ret.c_str();
+}
+
+bool Util::isValidX11Window(const xcb_window_t& window) const
+{
+    xcb_generic_error_t *error = nullptr;
+    QSharedPointer<xcb_get_window_attributes_reply_t> reply(
+        xcb_get_window_attributes_reply(m_x11connection, xcb_get_window_attributes(m_x11connection, window), &error),
+        [](xcb_get_window_attributes_reply_t *ptr) { free(ptr); });
+    QSharedPointer<xcb_generic_error_t> replyError(error, [](xcb_generic_error_t *ptr) { free(ptr); });
+
+    return reply && !replyError;
 }
 
 void Util::setX11WindowInputShape(const xcb_window_t& window, const QSize& size)
@@ -267,6 +313,50 @@ QImage Util::getX11WindowImageNonComposite(const xcb_window_t& window)
         xcb_image_destroy(image);
         return res;
     }
+}
+
+bool Util::getX11WindowPixmapData(const xcb_window_t& window, QByteArray *data)
+{
+    if (!data) {
+        return false;
+    }
+
+    data->clear();
+
+    const QRect geometry = getX11WindowGeometry(window);
+    if (geometry.isEmpty()) {
+        return false;
+    }
+
+    xcb_connection_t *connection = m_x11connection;
+    const xcb_pixmap_t pixmap = xcb_generate_id(connection);
+    const auto namePixmapCookie = xcb_composite_name_window_pixmap_checked(connection, window, pixmap);
+    QSharedPointer<xcb_generic_error_t> namePixmapError(xcb_request_check(connection, namePixmapCookie), [](xcb_generic_error_t *ptr) { free(ptr); });
+    if (namePixmapError) {
+        return false;
+    }
+
+    QSharedPointer<xcb_get_image_reply_t> imageReply(
+        xcb_get_image_reply(connection,
+                            xcb_get_image(connection,
+                                          XCB_IMAGE_FORMAT_Z_PIXMAP,
+                                          pixmap,
+                                          0,
+                                          0,
+                                          geometry.width(),
+                                          geometry.height(),
+                                          0xFFFFFFFF),
+                            nullptr),
+        [](xcb_get_image_reply_t *ptr) { free(ptr); });
+    xcb_free_pixmap(connection, pixmap);
+
+    if (!imageReply) {
+        return false;
+    }
+
+    *data = QByteArray(reinterpret_cast<const char *>(xcb_get_image_data(imageReply.get())),
+                       xcb_get_image_data_length(imageReply.get()));
+    return true;
 }
 
 void Util::setX11WindowOpacity(const xcb_window_t& window, const double& opacity)

--- a/plugins/application-tray/util.h
+++ b/plugins/application-tray/util.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <QByteArray>
 #include <QHash>
 #include <QImage>
 #include <QSharedPointer>
@@ -41,8 +42,10 @@ public:
     void setX11WindowSize(const xcb_window_t& window, const QSize& size);
     [[nodiscard]] QRect getX11WindowGeometry(const xcb_window_t& window) const;
     QString getX11WindowName(const xcb_window_t& window);
+    bool isValidX11Window(const xcb_window_t& window) const;
     void setX11WindowInputShape(const xcb_window_t& widnow, const QSize& size);
     QImage getX11WindowImageNonComposite(const xcb_window_t& window);
+    bool getX11WindowPixmapData(const xcb_window_t& window, QByteArray *data);
     void setX11WindowOpacity(const xcb_window_t& window, const double& opacity);
     pid_t getWindowPid(const xcb_window_t& window);
     QString getProcExe(const pid_t& pid);


### PR DESCRIPTION
为 dde-tray-loader 补齐更多与 dde-daemon 提供的 xembed 托盘相关支持的行为差异,包括:

1. 仅当托盘图标实际变化时才发送变化信号
2. 补充 _NET_SYSTEM_TRAY_ORIENTATION 设置(目前写死其值)
3. undock() buchong  xcb_damage_destroy
4. 增加 checkValid 机制
5. 补充 Inited 信号(尽管目前未发现消费者)
6. GetName 增加与 dde-daemon 一致的 fallback 行为
