### PR TITLE
chore: update changelog to 2.0.33

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+dde-tray-loader (2.0.33) unstable; urgency=medium
+
+  * chore: port more behaviors from dde-daemon to dde-tray-loader
+  * i18n: Updates for project Deepin Desktop Environment (#445)
+
+ -- zhangkun <zhangkun2@uniontech.com>  Thu, 04 Jun 2026 19:44:54 +0800
+
 dde-tray-loader (2.0.32) unstable; urgency=medium
 
   * fix: remove shot-start-plugin from wayland blacklist


### PR DESCRIPTION
## 更新说明

自动更新 changelog 到版本 2.0.33

### 变更内容
- 更新 debian/changelog

### 版本信息
- 新版本: 2.0.33
- 目标分支: master

## Summary by Sourcery

Documentation:
- Refresh Debian changelog entries to reflect version 2.0.33.