### PR TITLE
fix: fix application tray crash due to parent-child ownership and null pointer issues

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+# SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 #
 # SPDX-License-Identifier: CC0-1.0
 
@@ -39,6 +39,9 @@ endif()
 
 include(GNUInstallDirs)
 include(CMakePackageConfigHelpers)
+
+find_package(PkgConfig REQUIRED)
+pkg_get_variable(WAYLAND_PROTOCOLS_DATADIR wayland-protocols pkgdatadir)
 
 add_subdirectory(plugins)
 add_subdirectory(src)

--- a/plugins/application-tray/CMakeLists.txt
+++ b/plugins/application-tray/CMakeLists.txt
@@ -7,11 +7,15 @@ set(PLUGIN_NAME "application-tray")
 project(${PLUGIN_NAME})
 
 find_package(PkgConfig REQUIRED)
-find_package(Qt${QT_VERSION_MAJOR} ${REQUIRED_QT_VERSION} REQUIRED Core Gui Widgets DBus)
+find_package(Qt${QT_VERSION_MAJOR} ${REQUIRED_QT_VERSION} REQUIRED Core Gui Widgets DBus WaylandClient)
+if(Qt${QT_VERSION_MAJOR}_VERSION VERSION_GREATER_EQUAL 6.10)
+  find_package(Qt${QT_VERSION_MAJOR} COMPONENTS GuiPrivate WaylandClientPrivate REQUIRED)
+endif()
 find_package(Dtk${DTK_VERSION_MAJOR} REQUIRED Core Gui Widget Tools)
 find_package(KF6WindowSystem 6.6 REQUIRED) # for x11 tray selection owner
 
 pkg_check_modules(X11 REQUIRED IMPORTED_TARGET x11 xcb xcb-image xcb-damage xcb-composite xcb-xfixes xcb-util xcb-shape xtst xcb-xtest xcb-res xcb-ewmh)
+pkg_check_modules(WaylandClient REQUIRED IMPORTED_TARGET wayland-client)
 
 set(TRAY_SOURCES
     api/types/dbusimagelist.cpp api/types/dbusimagelist.h
@@ -29,6 +33,9 @@ set(TRAY_SOURCES
     c_ptr.h
     traymanager1.cpp traymanager1.h
     fdoselectionmanager.cpp fdoselectionmanager.h
+
+    ${CMAKE_SOURCE_DIR}/src/tray-wayland-integration/xdgactivationclient.h
+    ${CMAKE_SOURCE_DIR}/src/tray-wayland-integration/xdgactivationclient.cpp
 )
 
 set_source_files_properties(
@@ -65,6 +72,12 @@ add_library(${PLUGIN_NAME} SHARED
     application-tray.qrc
 )
 
+qt_generate_wayland_protocol_client_sources(${PLUGIN_NAME}
+NO_INCLUDE_CORE_ONLY
+FILES
+    ${WAYLAND_PROTOCOLS_DATADIR}/staging/xdg-activation/xdg-activation-v1.xml
+)
+
 target_compile_definitions(${PLUGIN_NAME} PRIVATE "QT_PLUGIN")
 
 target_link_libraries(${PLUGIN_NAME}
@@ -74,11 +87,16 @@ target_link_libraries(${PLUGIN_NAME}
         Qt${QT_VERSION_MAJOR}::Widgets
         Qt${QT_VERSION_MAJOR}::CorePrivate
         Qt${QT_VERSION_MAJOR}::WidgetsPrivate
+        Qt${QT_VERSION_MAJOR}::GuiPrivate
+        Qt${QT_VERSION_MAJOR}::WaylandClient
+        Qt${QT_VERSION_MAJOR}::WaylandClientPrivate
+        Wayland::Client
         Dtk${DTK_VERSION_MAJOR}::Core
         Dtk${DTK_VERSION_MAJOR}::Gui
         Dtk${DTK_VERSION_MAJOR}::Widget
         KF6::WindowSystem
         PkgConfig::X11
+        PkgConfig::WaylandClient
         dbusmenuqt
         dockpluginmanager-interface
 )

--- a/plugins/application-tray/api/dbus/org.kde.StatusNotifierItem.xml
+++ b/plugins/application-tray/api/dbus/org.kde.StatusNotifierItem.xml
@@ -41,6 +41,9 @@
         <arg direction="in" type="i" name="x"/>
         <arg direction="in" type="i" name="y"/>
     </method>
+    <method name="ProvideXdgActivationToken">
+        <arg direction="in" type="s" name="token"/>
+    </method>
     <method name="SecondaryActivate">
         <arg direction="in" type="i" name="x"/>
         <arg direction="in" type="i" name="y"/>

--- a/plugins/application-tray/ddeindicatortrayprotocol.cpp
+++ b/plugins/application-tray/ddeindicatortrayprotocol.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024-2026 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -178,7 +178,7 @@ void DDEindicatorProtocolHandlerPrivate::updateContent()
     Q_Q(DDEindicatorProtocolHandler);
     if (!enabled) return;
 
-    auto widget = static_cast<QWidget*>(q->parent());
+    auto widget = q->window();
 
     if (widget) {
         widget->update();
@@ -333,9 +333,12 @@ bool DDEindicatorProtocolHandler::eventFilter(QObject *watched, QEvent *event)
 {
     Q_D(DDEindicatorProtocolHandler);
 
-    if (watched == parent()) {
+    if (watched == window()) {
         if (event->type() == QEvent::Paint) {
-            auto widget = static_cast<QWidget*>(parent());
+            auto widget = window();
+            if (!widget)
+                return false;
+
             QPainter painter(widget);
             QFontMetrics qfm = QFontMetrics(widget->font());
             QRect tightTextRect = qfm.tightBoundingRect(d->m_text);

--- a/plugins/application-tray/sniprotocolhandler.cpp
+++ b/plugins/application-tray/sniprotocolhandler.cpp
@@ -325,10 +325,9 @@ bool SniTrayProtocolHandler::eventFilter(QObject *watched, QEvent *event)
                     auto sniInter = m_sniInter;
                     activationClient->requestToken(win, QString(), [sniInter](const QString &token) {
                         if (!token.isEmpty()) {
-                            qputenv("XDG_ACTIVATION_TOKEN", token.toUtf8());
+                            sniInter->ProvideXdgActivationToken(token);
                         }
                         sniInter->Activate(0, 0);
-                        qunsetenv("XDG_ACTIVATION_TOKEN");
                     });
                 } else {
                     m_sniInter->Activate(0, 0);

--- a/plugins/application-tray/sniprotocolhandler.cpp
+++ b/plugins/application-tray/sniprotocolhandler.cpp
@@ -8,6 +8,7 @@
 
 #include "util.h"
 #include "plugin.h"
+#include "xdgactivationclient.h"
 
 #include "dbusmenuimporter.h"
 
@@ -317,7 +318,21 @@ bool SniTrayProtocolHandler::eventFilter(QObject *watched, QEvent *event)
         if (event->type() == QEvent::MouseButtonRelease) {
             QMouseEvent* mouseEvent = static_cast<QMouseEvent*>(event);
             if (mouseEvent->button() == Qt::LeftButton) {
-                m_sniInter->Activate(0, 0);
+                auto *activationClient = XdgActivationClient::instance();
+                if (activationClient->isActive()) {
+                    auto widget = static_cast<QWidget*>(parent());
+                    auto *win = widget->window()->windowHandle();
+                    auto sniInter = m_sniInter;
+                    activationClient->requestToken(win, QString(), [sniInter](const QString &token) {
+                        if (!token.isEmpty()) {
+                            qputenv("XDG_ACTIVATION_TOKEN", token.toUtf8());
+                        }
+                        sniInter->Activate(0, 0);
+                        qunsetenv("XDG_ACTIVATION_TOKEN");
+                    });
+                } else {
+                    m_sniInter->Activate(0, 0);
+                }
             } else if (mouseEvent->button() == Qt::RightButton) {
                 if (!menuImporter()) {
                     m_sniInter->ContextMenu(0, 0);

--- a/plugins/application-tray/sniprotocolhandler.cpp
+++ b/plugins/application-tray/sniprotocolhandler.cpp
@@ -320,8 +320,10 @@ bool SniTrayProtocolHandler::eventFilter(QObject *watched, QEvent *event)
             if (mouseEvent->button() == Qt::LeftButton) {
                 auto *activationClient = XdgActivationClient::instance();
                 if (activationClient->isActive()) {
-                    auto widget = static_cast<QWidget*>(parent());
-                    auto *win = widget->window()->windowHandle();
+                    auto *win = window()->windowHandle();
+                    if (!win)
+                        return false;
+
                     auto sniInter = m_sniInter;
                     activationClient->requestToken(win, QString(), [sniInter](const QString &token) {
                         if (!token.isEmpty()) {
@@ -342,8 +344,11 @@ bool SniTrayProtocolHandler::eventFilter(QObject *watched, QEvent *event)
                 menu->setFixedSize(menu->sizeHint());
                 menu->winId();
 
-                auto widget = static_cast<QWidget*>(parent());
-                auto plugin = Plugin::EmbedPlugin::get(widget->window()->windowHandle());
+                auto *win = window()->windowHandle();
+                if (!win)
+                    return false;
+
+                auto plugin = Plugin::EmbedPlugin::get(win);
                 auto geometry = plugin->pluginPos();
                 auto pluginPopup = Plugin::PluginPopup::get(menu->windowHandle());
                 pluginPopup->setPluginId("application-tray");

--- a/plugins/application-tray/trayplugin.cpp
+++ b/plugins/application-tray/trayplugin.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024-2026 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -83,14 +83,18 @@ void TrayPlugin::onTrayhandlerCreatd(QPointer<AbstractTrayProtocolHandler> handl
     m_widget.insert(id, new TrayWidget(handler));
 
     auto remove = [this, id]() {
+        // 清理 tooltip 指针，因为 tooltip widget 是 handler 的成员变量，
+        // 当 handler 被销毁时会被删除，所以需要先从 map 中移除悬空指针
+        m_tooltip.remove(id);
+
         m_proyInter->itemRemoved(this, id);
+
         auto widget = m_widget.value(id);
         if (widget) {
             widget->deleteLater();
         }
 
         m_widget.remove(id);
-        m_tooltip.remove(id);
     };
 
     auto showWidget = [this, handler, id](){

--- a/plugins/application-tray/traywidget.cpp
+++ b/plugins/application-tray/traywidget.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -28,7 +28,8 @@ TrayWidget::TrayWidget(QPointer<AbstractTrayProtocolHandler> handler)
     setWindowTitle(m_handler->id());
     setFixedSize(trayIconSize, trayIconSize);
 
-    m_handler->setParent(this);
+    // Note: Do NOT set parent here - handler lifecycle is managed by QSharedPointer
+    // Setting parent would cause double-delete when QSharedPointer destroys the handler
 
     connect(m_handler, &AbstractTrayProtocolHandler::iconChanged, this, [this](){update();});
     connect(m_handler, &AbstractTrayProtocolHandler::overlayIconChanged, this, [this](){update();});
@@ -47,6 +48,9 @@ TrayWidget::~TrayWidget()
 void TrayWidget::showEvent(QShowEvent* event)
 {
     Q_UNUSED(event)
+    if (!m_handler)
+        return;
+
     m_handler->setWindow(window());
     window()->installEventFilter(m_handler);
     window()->setMouseTracking(true);
@@ -55,6 +59,9 @@ void TrayWidget::showEvent(QShowEvent* event)
 void TrayWidget::paintEvent(QPaintEvent* event)
 {
     Q_UNUSED(event)
+
+    if (!m_handler)
+        return;
 
     // TODO: support attentionIcon/overlayIcon
     QPalette palette;

--- a/src/tray-wayland-integration/CMakeLists.txt
+++ b/src/tray-wayland-integration/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+# SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 #
 # SPDX-License-Identifier: CC0-1.0
 
@@ -35,6 +35,8 @@ add_library(dockpluginmanager SHARED
     pluginmanagerintegration.cpp
     pluginsurface_p.h
     pluginsurface.cpp
+    xdgactivationclient.h
+    xdgactivationclient.cpp
     main.cpp
 )
 
@@ -42,6 +44,7 @@ qt_generate_wayland_protocol_client_sources(dockpluginmanager
 NO_INCLUDE_CORE_ONLY
 FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/../protocol/plugin-manager-v1.xml
+    ${WAYLAND_PROTOCOLS_DATADIR}/staging/xdg-activation/xdg-activation-v1.xml
 )
 
 target_link_libraries(dockpluginmanager

--- a/src/tray-wayland-integration/xdgactivationclient.cpp
+++ b/src/tray-wayland-integration/xdgactivationclient.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/src/tray-wayland-integration/xdgactivationclient.cpp
+++ b/src/tray-wayland-integration/xdgactivationclient.cpp
@@ -1,0 +1,138 @@
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "xdgactivationclient.h"
+
+#include <QGuiApplication>
+#include <QLoggingCategory>
+#include <QPointer>
+#include <QWindow>
+#include <QtWaylandClient/QWaylandClientExtension>
+
+#include "qwayland-xdg-activation-v1.h"
+#include <private/qwaylanddisplay_p.h>
+#include <private/qwaylandinputdevice_p.h>
+#include <private/qwaylandwindow_p.h>
+
+Q_LOGGING_CATEGORY(trayXdgActivation, "dde.tray.xdgactivation")
+
+namespace tray {
+
+class XdgActivationTokenV1 : public QObject, public QtWayland::xdg_activation_token_v1
+{
+    Q_OBJECT
+public:
+    ~XdgActivationTokenV1() override { destroy(); }
+
+Q_SIGNALS:
+    void done(const QString &token);
+
+protected:
+    void xdg_activation_token_v1_done(const QString &token) override
+    {
+        Q_EMIT done(token);
+    }
+};
+
+class XdgActivationV1 : public QWaylandClientExtensionTemplate<XdgActivationV1>,
+                        public QtWayland::xdg_activation_v1
+{
+public:
+    XdgActivationV1()
+        : QWaylandClientExtensionTemplate<XdgActivationV1>(1)
+    {
+        initialize();
+    }
+
+    ~XdgActivationV1() override
+    {
+        if (isInitialized())
+            destroy();
+    }
+
+    XdgActivationTokenV1 *createTokenProvider(QWindow *window, const QString &appId)
+    {
+        auto *provider = new XdgActivationTokenV1;
+        provider->init(get_activation_token());
+
+        if (window) {
+            if (auto *waylandWindow = dynamic_cast<QtWaylandClient::QWaylandWindow *>(window->handle())) {
+                if (auto *surface = waylandWindow->wlSurface())
+                    provider->set_surface(surface);
+                if (auto *inputDevice = waylandWindow->display()->lastInputDevice())
+                    provider->set_serial(inputDevice->serial(), inputDevice->wl_seat());
+            }
+        }
+
+        if (!appId.isEmpty())
+            provider->set_app_id(appId);
+
+        provider->commit();
+        return provider;
+    }
+};
+
+XdgActivationClient *XdgActivationClient::instance()
+{
+    static XdgActivationClient *s_instance = nullptr;
+    if (!s_instance) {
+        s_instance = new XdgActivationClient(qApp);
+    }
+    return s_instance;
+}
+
+XdgActivationClient::XdgActivationClient(QObject *parent)
+    : QObject(parent)
+    , m_activation(new XdgActivationV1)
+{
+    m_activation->setParent(this);
+}
+
+XdgActivationClient::~XdgActivationClient() = default;
+
+bool XdgActivationClient::isActive() const
+{
+    return m_activation && m_activation->isActive();
+}
+
+void XdgActivationClient::requestToken(QWindow *window, const QString &appId, TokenCallback callback)
+{
+    if (m_pendingProvider) {
+        qCWarning(trayXdgActivation) << "Token request already in progress";
+        if (callback) callback(QString());
+        return;
+    }
+
+    if (!isActive()) {
+        qCDebug(trayXdgActivation) << "xdg_activation_v1 not active";
+        if (callback) callback(QString());
+        return;
+    }
+
+    auto effectiveWindow = window ? window : QGuiApplication::focusWindow();
+    if (!effectiveWindow) {
+        qCWarning(trayXdgActivation) << "No target window for activation token";
+        if (callback) callback(QString());
+        return;
+    }
+
+    auto *provider = m_activation->createTokenProvider(effectiveWindow, appId);
+    m_pendingProvider = provider;
+
+    connect(provider, &XdgActivationTokenV1::done, this, [this, callback](const QString &token) {
+        m_pendingProvider = nullptr;
+
+        if (token.isEmpty())
+            qCWarning(trayXdgActivation) << "Empty activation token received";
+        else
+            qCDebug(trayXdgActivation) << "Activation token received";
+
+        if (callback) callback(token);
+        sender()->deleteLater();
+    }, Qt::SingleShotConnection);
+}
+
+} // namespace tray
+
+#include "xdgactivationclient.moc"

--- a/src/tray-wayland-integration/xdgactivationclient.cpp
+++ b/src/tray-wayland-integration/xdgactivationclient.cpp
@@ -120,7 +120,7 @@ void XdgActivationClient::requestToken(QWindow *window, const QString &appId, To
     auto *provider = m_activation->createTokenProvider(effectiveWindow, appId);
     m_pendingProvider = provider;
 
-    connect(provider, &XdgActivationTokenV1::done, this, [this, callback](const QString &token) {
+    connect(provider, &XdgActivationTokenV1::done, this, [this, provider, callback](const QString &token) {
         m_pendingProvider = nullptr;
 
         if (token.isEmpty())
@@ -129,7 +129,7 @@ void XdgActivationClient::requestToken(QWindow *window, const QString &appId, To
             qCDebug(trayXdgActivation) << "Activation token received";
 
         if (callback) callback(token);
-        sender()->deleteLater();
+        provider->deleteLater();
     }, Qt::SingleShotConnection);
 }
 

--- a/src/tray-wayland-integration/xdgactivationclient.h
+++ b/src/tray-wayland-integration/xdgactivationclient.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/src/tray-wayland-integration/xdgactivationclient.h
+++ b/src/tray-wayland-integration/xdgactivationclient.h
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#pragma once
+
+#include <QObject>
+#include <QPointer>
+#include <QString>
+#include <functional>
+
+class QWindow;
+
+namespace tray {
+
+class XdgActivationTokenV1;
+
+class XdgActivationClient : public QObject
+{
+    Q_OBJECT
+public:
+    static XdgActivationClient *instance();
+
+    bool isActive() const;
+
+    using TokenCallback = std::function<void(const QString &token)>;
+    void requestToken(QWindow *window, const QString &appId, TokenCallback callback);
+
+private:
+    explicit XdgActivationClient(QObject *parent = nullptr);
+    ~XdgActivationClient() override;
+
+    class XdgActivationV1 *m_activation = nullptr;
+    QPointer<XdgActivationTokenV1> m_pendingProvider;
+};
+
+} // namespace tray


### PR DESCRIPTION
## 问题描述

应用程序托盘在 SNI (StatusNotifierItem) 托盘项注销时崩溃。

## 根本原因

1. **双重生命周期管理**：`SniTrayProtocolHandler` 同时被 `QSharedPointer` 和 QObject 父子关系管理，导致双重删除
2. **悬空指针**：`m_tooltip` 中存储的 widget 指针在 handler 销毁后变成悬空指针
3. **空指针访问**：`eventFilter` 中使用 `parent()` 获取 widget，但移除 `setParent(this)` 后返回错误对象

## 修复内容

### traywidget.cpp
- 移除 `m_handler->setParent(this)` 避免双重生命周期管理
- 在 `showEvent` 和 `paintEvent` 中添加 `m_handler` 空指针检查

### sniprotocolhandler.cpp
- `eventFilter` 中将 `parent()` 替换为 `window()`
- 添加 `windowHandle()` 的空指针检查

### ddeindicatortrayprotocol.cpp
- `updateContent` 中将 `q->parent()` 替换为 `q->window()`
- `eventFilter` 中将 `parent()` 替换为 `window()`，添加空指针检查

### trayplugin.cpp
- 在 `remove` lambda 中，先清理 `m_tooltip`，再调用 `itemRemoved`，避免访问悬空指针

## 测试

修复后需要验证：
1. SNI 托盘项正常显示和移除
2. 右键菜单正常弹出
3. 左键激活功能正常
4. 不再出现崩溃

🤖 Generated with [Claude Code](https://claude.ai/code)

## Summary by Sourcery

Integrate Wayland xdg-activation support into the application tray and harden tray item lifecycle handling to prevent crashes when SNI items are removed.

New Features:
- Add Wayland xdg-activation client for tray, requesting and forwarding activation tokens before activating SNI items.

Bug Fixes:
- Prevent application tray crashes by avoiding double ownership of tray protocol handlers, cleaning up tooltip pointers before handler destruction, and guarding against null windows in event handling.

Enhancements:
- Use window() instead of parent() for tray widgets and indicator handlers, adding null checks to make painting and context menu handling more robust.

Build:
- Extend CMake configuration to locate Wayland protocols via pkg-config, generate xdg-activation client sources, and link against Qt Wayland and Wayland client libraries.