### PR TITLE
fix: fix application tray crash due to parent-child ownership and null pointer issues

### DIFF
--- a/plugins/application-tray/ddeindicatortrayprotocol.cpp
+++ b/plugins/application-tray/ddeindicatortrayprotocol.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024-2026 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -178,7 +178,7 @@ void DDEindicatorProtocolHandlerPrivate::updateContent()
     Q_Q(DDEindicatorProtocolHandler);
     if (!enabled) return;
 
-    auto widget = static_cast<QWidget*>(q->parent());
+    auto widget = q->window();
 
     if (widget) {
         widget->update();
@@ -333,9 +333,12 @@ bool DDEindicatorProtocolHandler::eventFilter(QObject *watched, QEvent *event)
 {
     Q_D(DDEindicatorProtocolHandler);
 
-    if (watched == parent()) {
+    if (watched == window()) {
         if (event->type() == QEvent::Paint) {
-            auto widget = static_cast<QWidget*>(parent());
+            auto widget = window();
+            if (!widget)
+                return false;
+
             QPainter painter(widget);
             QFontMetrics qfm = QFontMetrics(widget->font());
             QRect tightTextRect = qfm.tightBoundingRect(d->m_text);

--- a/plugins/application-tray/sniprotocolhandler.cpp
+++ b/plugins/application-tray/sniprotocolhandler.cpp
@@ -328,8 +328,11 @@ bool SniTrayProtocolHandler::eventFilter(QObject *watched, QEvent *event)
                 menu->setFixedSize(menu->sizeHint());
                 menu->winId();
 
-                auto widget = static_cast<QWidget*>(parent());
-                auto plugin = Plugin::EmbedPlugin::get(widget->window()->windowHandle());
+                auto *win = window()->windowHandle();
+                if (!win)
+                    return false;
+
+                auto plugin = Plugin::EmbedPlugin::get(win);
                 auto geometry = plugin->pluginPos();
                 auto pluginPopup = Plugin::PluginPopup::get(menu->windowHandle());
                 pluginPopup->setPluginId("application-tray");

--- a/plugins/application-tray/trayplugin.cpp
+++ b/plugins/application-tray/trayplugin.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024-2026 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -83,14 +83,18 @@ void TrayPlugin::onTrayhandlerCreatd(QPointer<AbstractTrayProtocolHandler> handl
     m_widget.insert(id, new TrayWidget(handler));
 
     auto remove = [this, id]() {
+        // 清理 tooltip 指针，因为 tooltip widget 是 handler 的成员变量，
+        // 当 handler 被销毁时会被删除，所以需要先从 map 中移除悬空指针
+        m_tooltip.remove(id);
+
         m_proyInter->itemRemoved(this, id);
+
         auto widget = m_widget.value(id);
         if (widget) {
             widget->deleteLater();
         }
 
         m_widget.remove(id);
-        m_tooltip.remove(id);
     };
 
     auto showWidget = [this, handler, id](){

--- a/plugins/application-tray/traywidget.cpp
+++ b/plugins/application-tray/traywidget.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -28,7 +28,8 @@ TrayWidget::TrayWidget(QPointer<AbstractTrayProtocolHandler> handler)
     setWindowTitle(m_handler->id());
     setFixedSize(trayIconSize, trayIconSize);
 
-    m_handler->setParent(this);
+    // Note: Do NOT set parent here - handler lifecycle is managed by QSharedPointer
+    // Setting parent would cause double-delete when QSharedPointer destroys the handler
 
     connect(m_handler, &AbstractTrayProtocolHandler::iconChanged, this, [this](){update();});
     connect(m_handler, &AbstractTrayProtocolHandler::overlayIconChanged, this, [this](){update();});
@@ -47,6 +48,9 @@ TrayWidget::~TrayWidget()
 void TrayWidget::showEvent(QShowEvent* event)
 {
     Q_UNUSED(event)
+    if (!m_handler)
+        return;
+
     m_handler->setWindow(window());
     window()->installEventFilter(m_handler);
     window()->setMouseTracking(true);
@@ -55,6 +59,9 @@ void TrayWidget::showEvent(QShowEvent* event)
 void TrayWidget::paintEvent(QPaintEvent* event)
 {
     Q_UNUSED(event)
+
+    if (!m_handler)
+        return;
 
     // TODO: support attentionIcon/overlayIcon
     QPalette palette;


### PR DESCRIPTION
## 问题描述

应用程序托盘在 SNI (StatusNotifierItem) 托盘项注销时崩溃。

## 根本原因

1. **双重生命周期管理**：`SniTrayProtocolHandler` 同时被 `QSharedPointer` 和 QObject 父子关系管理，导致双重删除
2. **悬空指针**：`m_tooltip` 中存储的 widget 指针在 handler 销毁后变成悬空指针
3. **空指针访问**：`eventFilter` 中使用 `parent()` 获取 widget，但移除 `setParent(this)` 后返回错误对象

## 修复内容

### traywidget.cpp
- 移除 `m_handler->setParent(this)` 避免双重生命周期管理
- 在 `showEvent` 和 `paintEvent` 中添加 `m_handler` 空指针检查

### sniprotocolhandler.cpp
- `eventFilter` 中将 `parent()` 替换为 `window()`
- 添加 `windowHandle()` 的空指针检查

### ddeindicatortrayprotocol.cpp
- `updateContent` 中将 `q->parent()` 替换为 `q->window()`
- `eventFilter` 中将 `parent()` 替换为 `window()`，添加空指针检查

### trayplugin.cpp
- 在 `remove` lambda 中，先清理 `m_tooltip`，再调用 `itemRemoved`，避免访问悬空指针

## 测试

修复后需要验证：
1. SNI 托盘项正常显示和移除
2. 右键菜单正常弹出
3. 左键激活功能正常
4. 不再出现崩溃

🤖 Generated with [Claude Code](https://claude.ai/code)

## Summary by Sourcery

Prevent crashes and dangling pointers in the application tray by aligning tray handler ownership with Qt windowing semantics and cleaning up tooltip references safely.

Bug Fixes:
- Avoid double deletion of tray protocol handlers by relying on shared pointer ownership instead of QObject parent-child relationships.
- Prevent null and dangling pointer access in tray widget show/paint events and tooltip handling when tray items are removed.
- Ensure SNI and indicator tray event filters operate on window objects with proper null checks to avoid crashes when windows or window handles are missing.

Enhancements:
- Update tray-related event handling to use window-based access instead of parent-based casting for more robust widget updates and painting.