### PR TITLE
chore: update changelog to 2.0.34

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+dde-tray-loader (2.0.34) unstable; urgency=medium
+
+  * fix: allow xdg activation without window information
+  * fix: prevent dockHiddenSurfaceIds from being reset to empty
+
+ -- zhangkun <zhangkun2@uniontech.com>  Thu, 11 Jun 2026 19:45:36 +0800
+
 dde-tray-loader (2.0.33) unstable; urgency=medium
 
   * chore: port more behaviors from dde-daemon to dde-tray-loader


### PR DESCRIPTION
## 更新说明

自动更新 changelog 到版本 2.0.34

### 变更内容
- 更新 debian/changelog

### 版本信息
- 新版本: 2.0.34
- 目标分支: master

## Summary by Sourcery

Documentation:
- Document release 2.0.34 in debian/changelog.