### PR TITLE
refactor: move XdgActivation to pluginitem and simplify dock plugins

### DIFF
--- a/plugins/dde-dock/airplane-mode/airplanemodeitem.cpp
+++ b/plugins/dde-dock/airplane-mode/airplanemodeitem.cpp
@@ -7,7 +7,6 @@
 #include "constants.h"
 #include "tipswidget.h"
 
-#include "xdgactivation.h"
 
 #include <DGuiApplicationHelper>
 
@@ -119,16 +118,8 @@ void AirplaneModeItem::invokeMenuItem(const QString menuId, const bool checked)
     if (menuId == SHIFT) {
         AMC_PTR->toggle();
     } else if (menuId == SETTINGS) {
-        auto *activation = new tray::XdgActivation(this);
-        connect(activation, &tray::XdgActivation::tokenReady, this, [activation](const QString &token) {
-            QStringList args {"--by-user", "org.deepin.dde.control-center"};
-            if (!token.isEmpty())
-                args << "-e" << "XDG_ACTIVATION_TOKEN=" + token;
-            args << "--" << "-p" << "network/airplaneMode";
-            QProcess::startDetached("dde-am", args);
-            activation->deleteLater();
-        }, Qt::SingleShotConnection);
-        activation->requestToken();
+        QStringList args {"--by-user", "org.deepin.dde.control-center", "--", "-p", "network/airplaneMode"};
+        QProcess::startDetached("dde-am", args);
 
         Q_EMIT requestHideApplet();
     }

--- a/plugins/dde-dock/bluetooth/bluetoothitem.cpp
+++ b/plugins/dde-dock/bluetooth/bluetoothitem.cpp
@@ -10,7 +10,6 @@
 #include "constants.h"
 #include "quickpanelwidget.h"
 
-#include "xdgactivation.h"
 
 #include <DApplication>
 #include <DGuiApplicationHelper>
@@ -128,16 +127,8 @@ void BluetoothItem::invokeMenuItem(const QString menuId, const bool checked)
         }
         m_applet->setAdapterPowered(!m_adapterPowered);
     } else if (menuId == SETTINGS) {
-        auto *activation = new tray::XdgActivation(this);
-        connect(activation, &tray::XdgActivation::tokenReady, this, [activation](const QString &token) {
-            QStringList args {"--by-user", "org.deepin.dde.control-center"};
-            if (!token.isEmpty())
-                args << "-e" << "XDG_ACTIVATION_TOKEN=" + token;
-            args << "--" << "-p" << "device/bluetooth";
-            QProcess::startDetached("dde-am", args);
-            activation->deleteLater();
-        }, Qt::SingleShotConnection);
-        activation->requestToken();
+        QStringList args {"--by-user", "org.deepin.dde.control-center", "--", "-p", "device/bluetooth"};
+        QProcess::startDetached("dde-am", args);
         Q_EMIT requestHideApplet();
     }
 }

--- a/plugins/dde-dock/brightness/brightnessitem.cpp
+++ b/plugins/dde-dock/brightness/brightnessitem.cpp
@@ -6,7 +6,6 @@
 #include "constants.h"
 #include "brightnessmodel.h"
 
-#include "xdgactivation.h"
 
 #include <DFontSizeManager>
 #include <DGuiApplicationHelper>
@@ -81,16 +80,8 @@ void BrightnessItem::invokeMenuItem(const QString menuId, const bool checked)
     Q_UNUSED(checked);
 
     if (menuId == SETTINGS) {
-        auto *activation = new tray::XdgActivation(this);
-        connect(activation, &tray::XdgActivation::tokenReady, this, [activation](const QString &token) {
-            QStringList args {"--by-user", "org.deepin.dde.control-center"};
-            if (!token.isEmpty())
-                args << "-e" << "XDG_ACTIVATION_TOKEN=" + token;
-            args << "--" << "-p" << "display";
-            QProcess::startDetached("dde-am", args);
-            activation->deleteLater();
-        }, Qt::SingleShotConnection);
-        activation->requestToken();
+        QStringList args {"--by-user", "org.deepin.dde.control-center", "--", "-p", "display"};
+        QProcess::startDetached("dde-am", args);
 
         Q_EMIT requestHideApplet();
     }

--- a/plugins/dde-dock/datetime/datetimeplugin.cpp
+++ b/plugins/dde-dock/datetime/datetimeplugin.cpp
@@ -7,7 +7,6 @@
 #include "plugins-logging-category.h"
 #include "regionFormat.h"
 
-#include "xdgactivation.h"
 
 #include <DConfig>
 #include <DDBusSender>
@@ -216,16 +215,8 @@ void DatetimePlugin::invokedMenuItem(const QString &itemKey, const QString &menu
     Q_UNUSED(checked)
 
     if (menuId == "open") {
-        auto *activation = new tray::XdgActivation(this);
-        connect(activation, &tray::XdgActivation::tokenReady, this, [activation](const QString &token) {
-            QStringList args {"--by-user", "org.deepin.dde.control-center"};
-            if (!token.isEmpty())
-                args << "-e" << "XDG_ACTIVATION_TOKEN=" + token;
-            args << "--" << "-p" << "datetime";
-            QProcess::startDetached("dde-am", args);
-            activation->deleteLater();
-        }, Qt::SingleShotConnection);
-        activation->requestToken();
+        QStringList args {"--by-user", "org.deepin.dde.control-center", "--", "-p", "datetime"};
+        QProcess::startDetached("dde-am", args);
     } else if (menuId == "settings") {
         const bool is24HourFormat = m_centralWidget->is24HourFormat();
         m_centralWidget->set24HourFormat(!is24HourFormat);

--- a/plugins/dde-dock/dnd-mode/dndmodeitem.cpp
+++ b/plugins/dde-dock/dnd-mode/dndmodeitem.cpp
@@ -8,8 +8,6 @@
 #include "dndmodecontroller.h"
 #include "tipswidget.h"
 
-#include "xdgactivation.h"
-
 #include <DGuiApplicationHelper>
 
 #include <QDBusConnection>
@@ -112,16 +110,8 @@ void DndModeItem::invokeMenuItem(const QString menuId, const bool checked)
     if (menuId == SHIFT) {
         DndModeController::ref().toggle();
     } else if (menuId == SETTINGS) {
-        auto *activation = new tray::XdgActivation(this);
-        connect(activation, &tray::XdgActivation::tokenReady, this, [activation](const QString &token) {
-            QStringList args {"--by-user", "org.deepin.dde.control-center"};
-            if (!token.isEmpty())
-                args << "-e" << "XDG_ACTIVATION_TOKEN=" + token;
-            args << "--" << "-p" << "notification";
-            QProcess::startDetached("dde-am", args);
-            activation->deleteLater();
-        }, Qt::SingleShotConnection);
-        activation->requestToken();
+        QStringList args {"--by-user", "org.deepin.dde.control-center", "--", "-p", "notification"};
+        QProcess::startDetached("dde-am", args);
 
         Q_EMIT requestHideApplet();
     }

--- a/plugins/dde-dock/eye-comfort-mode/eyecomfortmodeitem.cpp
+++ b/plugins/dde-dock/eye-comfort-mode/eyecomfortmodeitem.cpp
@@ -9,7 +9,6 @@
 #include "tipswidget.h"
 #include "quickpanelwidget.h"
 
-#include "xdgactivation.h"
 
 #include <DGuiApplicationHelper>
 
@@ -187,16 +186,8 @@ void EyeComfortModeItem::invokeMenuItem(const QString menuId, const bool checked
     if (menuId == SHIFT) {
         EyeComfortModeController::ref().toggle();
     } else if (menuId == SETTINGS) {
-        auto *activation = new tray::XdgActivation(this);
-        connect(activation, &tray::XdgActivation::tokenReady, this, [activation](const QString &token) {
-            QStringList args {"--by-user", "org.deepin.dde.control-center"};
-            if (!token.isEmpty())
-                args << "-e" << "XDG_ACTIVATION_TOKEN=" + token;
-            args << "--" << "-p" << "display";
-            QProcess::startDetached("dde-am", args);
-            activation->deleteLater();
-        }, Qt::SingleShotConnection);
-        activation->requestToken();
+        QStringList args {"--by-user", "org.deepin.dde.control-center", "--", "-p", "display"};
+        QProcess::startDetached("dde-am", args);
         Q_EMIT requestHideApplet();
     }
 }

--- a/plugins/dde-dock/keyboard-layout/dbusadaptors.cpp
+++ b/plugins/dde-dock/keyboard-layout/dbusadaptors.cpp
@@ -7,7 +7,6 @@
 #include "fcitxinputmethoditem.h"
 #include "plugins-logging-category.h"
 
-#include "xdgactivation.h"
 
 #include <DSysInfo>
 
@@ -177,16 +176,8 @@ void DBusAdaptors::refreshMenuSelection()
 void DBusAdaptors::handleActionTriggered(QAction *action)
 {
     if (action == m_addLayoutAction) {
-        auto *activation = new tray::XdgActivation(this);
-        connect(activation, &tray::XdgActivation::tokenReady, this, [activation](const QString &token) {
-            QStringList args {"--by-user", "org.deepin.dde.control-center"};
-            if (!token.isEmpty())
-                args << "-e" << "XDG_ACTIVATION_TOKEN=" + token;
-            args << "--" << "-p" << "keyboard/Keyboard Layout/Add Keyboard Layout";
-            QProcess::startDetached("dde-am", args);
-            activation->deleteLater();
-        }, Qt::SingleShotConnection);
-        activation->requestToken();
+        QStringList args {"--by-user", "org.deepin.dde.control-center", "--", "-p", "keyboard/Keyboard Layout/Add Keyboard Layout"};
+        QProcess::startDetached("dde-am", args);
     }
 
     const QString layout = action->objectName();

--- a/plugins/dde-dock/notification/notificationplugin.cpp
+++ b/plugins/dde-dock/notification/notificationplugin.cpp
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
 #include "notificationplugin.h"
 
-#include "xdgactivation.h"
 
 #include <DGuiApplicationHelper>
 
@@ -134,16 +133,8 @@ void NotificationPlugin::invokedMenuItem(const QString &itemKey, const QString &
     if (menuId == TOGGLE_DND) {
         m_notification->setDndMode(!m_notification->dndMode());
     } else if (menuId == NOTIFICATION_SETTINGS) {
-        auto *activation = new tray::XdgActivation(this);
-        connect(activation, &tray::XdgActivation::tokenReady, this, [activation](const QString &token) {
-            QStringList args {"--by-user", "org.deepin.dde.control-center"};
-            if (!token.isEmpty())
-                args << "-e" << "XDG_ACTIVATION_TOKEN=" + token;
-            args << "--" << "-p" << "notification";
-            QProcess::startDetached("dde-am", args);
-            activation->deleteLater();
-        }, Qt::SingleShotConnection);
-        activation->requestToken();
+        QStringList args {"--by-user", "org.deepin.dde.control-center", "--", "-p", "notification"};
+        QProcess::startDetached("dde-am", args);
     }
 }
 

--- a/plugins/dde-dock/power/powerplugin.cpp
+++ b/plugins/dde-dock/power/powerplugin.cpp
@@ -9,7 +9,6 @@
 #include "dbus/dbusaccount.h"
 #include "plugins-logging-category.h"
 
-#include "xdgactivation.h"
 
 #include <DConfig>
 
@@ -143,16 +142,8 @@ void PowerPlugin::invokedMenuItem(const QString &itemKey, const QString &menuId,
     Q_UNUSED(checked)
 
     if (menuId == "power") {
-        auto *activation = new tray::XdgActivation(this);
-        connect(activation, &tray::XdgActivation::tokenReady, this, [activation](const QString &token) {
-            QStringList args {"--by-user", "org.deepin.dde.control-center"};
-            if (!token.isEmpty())
-                args << "-e" << "XDG_ACTIVATION_TOKEN=" + token;
-            args << "--" << "-p" << "power";
-            QProcess::startDetached("dde-am", args);
-            activation->deleteLater();
-        }, Qt::SingleShotConnection);
-        activation->requestToken();
+        QStringList args {"--by-user", "org.deepin.dde.control-center", "--", "-p", "power"};
+        QProcess::startDetached("dde-am", args);
     }
 }
 

--- a/plugins/dde-dock/shutdown/shutdownplugin.cpp
+++ b/plugins/dde-dock/shutdown/shutdownplugin.cpp
@@ -9,7 +9,6 @@
 #include "./dbus/org_deepin_dde_sessionmanager.h"
 #include "plugins-logging-category.h"
 
-#include "xdgactivation.h"
 
 #include <DSysInfo>
 #include <DDBusSender>
@@ -309,16 +308,8 @@ void ShutdownPlugin::invokedMenuItem(const QString &itemKey, const QString &menu
         QCoreApplication::processEvents(QEventLoop::AllEvents, 200);
 
     if (menuId == "power") {
-        auto *activation = new tray::XdgActivation(this);
-        connect(activation, &tray::XdgActivation::tokenReady, this, [activation](const QString &token) {
-            QStringList args {"--by-user", "org.deepin.dde.control-center"};
-            if (!token.isEmpty())
-                args << "-e" << "XDG_ACTIVATION_TOKEN=" + token;
-            args << "--" << "-p" << "power";
-            QProcess::startDetached("dde-am", args);
-            activation->deleteLater();
-        }, Qt::SingleShotConnection);
-        activation->requestToken();
+        QStringList args {"--by-user", "org.deepin.dde.control-center", "--", "-p", "power"};
+        QProcess::startDetached("dde-am", args);
     } else if (menuId == "Lock") {
         if (QFile::exists(ICBC_CONF_FILE)) {
             QDBusMessage send = QDBusMessage::createMethodCall("org.deepin.dde.LockFront1", "/org/deepin/dde/LockFront1", "org.deepin.dde.LockFront1", "SwitchTTYAndShow");

--- a/plugins/dde-dock/sound/soundview.cpp
+++ b/plugins/dde-dock/sound/soundview.cpp
@@ -9,7 +9,6 @@
 #include "utils.h"
 #include "soundmodel.h"
 
-#include "xdgactivation.h"
 
 #include <DApplication>
 #include <DGuiApplicationHelper>
@@ -108,16 +107,8 @@ void SoundView::invokeMenuItem(const QString menuId, const bool checked)
     if (menuId == MUTE) {
         SoundController::ref().SetMuteQueued(!SoundModel::ref().isMute());
     } else if (menuId == SETTINGS) {
-        auto *activation = new tray::XdgActivation(this);
-        connect(activation, &tray::XdgActivation::tokenReady, this, [activation](const QString &token) {
-            QStringList args {"--by-user", "org.deepin.dde.control-center"};
-            if (!token.isEmpty())
-                args << "-e" << "XDG_ACTIVATION_TOKEN=" + token;
-            args << "--" << "-p" << "sound";
-            QProcess::startDetached("dde-am", args);
-            activation->deleteLater();
-        }, Qt::SingleShotConnection);
-        activation->requestToken();
+        QStringList args {"--by-user", "org.deepin.dde.control-center", "--", "-p", "sound"};
+        QProcess::startDetached("dde-am", args);
         Q_EMIT requestHideApplet();
     }
 }

--- a/plugins/dde-network-display-ui/plugins/dock-wirelesscasting-plugin/src/wirelesscastingitem.cpp
+++ b/plugins/dde-network-display-ui/plugins/dock-wirelesscasting-plugin/src/wirelesscastingitem.cpp
@@ -11,7 +11,6 @@
 
 #include <constants.h>
 
-#include "xdgactivation.h"
 
 #include <DGuiApplicationHelper>
 
@@ -221,16 +220,8 @@ void WirelessCastingItem::invokeMenuItem(const QString menuId, const bool checke
 {
     Q_UNUSED(checked);
     if (menuId == SETTINGS) {
-        auto *activation = new tray::XdgActivation(this);
-        connect(activation, &tray::XdgActivation::tokenReady, this, [activation](const QString &token) {
-            QStringList args {"--by-user", "org.deepin.dde.control-center"};
-            if (!token.isEmpty())
-                args << "-e" << "XDG_ACTIVATION_TOKEN=" + token;
-            args << "--" << "-p" << "display";
-            QProcess::startDetached("dde-am", args);
-            activation->deleteLater();
-        }, Qt::SingleShotConnection);
-        activation->requestToken();
+        QStringList args {"--by-user", "org.deepin.dde.control-center", "--", "-p", "display"};
+        QProcess::startDetached("dde-am", args);
 
         Q_EMIT requestHideApplet();
     }

--- a/src/loader/pluginitem.cpp
+++ b/src/loader/pluginitem.cpp
@@ -8,10 +8,14 @@
 #include "widgetplugin.h"
 #include "dockcontextmenu.h"
 
+#include <xdgactivation.h>
+
 #include <QHBoxLayout>
 #include <QMouseEvent>
 #include <QMenu>
 #include <QPainter>
+#include <QProcess>
+#include <QProcessEnvironment>
 
 const static QString DockQuickPlugins = "Dock_Quick_Plugins";
 
@@ -39,7 +43,18 @@ PluginItem::PluginItem(PluginsItemInterface *pluginItemInterface, const QString 
         if (actionStr == Dock::dockMenuItemId || actionStr == Dock::unDockMenuItemId) {
             m_dbusProxy->setItemOnDock(DockQuickPlugins, m_itemKey, actionStr == Dock::dockMenuItemId);
         } else {
-            m_pluginsItemInterface->invokedMenuItem(m_itemKey, action->data().toString(), action->isCheckable() ? action->isChecked() : true);
+            const QString menuId = action->data().toString();
+            const bool checked = action->isCheckable() ? action->isChecked() : true;
+            auto *activation = new tray::XdgActivation(this);
+            connect(activation, &tray::XdgActivation::tokenReady, this, [this, activation, menuId, checked](const QString &token) {
+                if (!token.isEmpty())
+                    qputenv("XDG_ACTIVATION_TOKEN", token.toUtf8());
+                m_pluginsItemInterface->invokedMenuItem(m_itemKey, menuId, checked);
+                if (!token.isEmpty())
+                    qunsetenv("XDG_ACTIVATION_TOKEN");
+                activation->deleteLater();
+            }, Qt::SingleShotConnection);
+            activation->requestToken();
         }
     });
 }
@@ -372,7 +387,17 @@ bool PluginItem::executeCommand()
         QStringList commandList = command.split(" ");
         QString program = commandList.takeFirst(); // 剩下是参数
 
-        QProcess::startDetached(program, commandList);
+        auto *activation = new tray::XdgActivation(this);
+        connect(activation, &tray::XdgActivation::tokenReady, this, [activation, program, commandList](const QString &token) {
+            QProcess process;
+            QProcessEnvironment env = QProcessEnvironment::systemEnvironment();
+            if (!token.isEmpty())
+                env.insert("XDG_ACTIVATION_TOKEN", token);
+            process.setProcessEnvironment(env);
+            process.startDetached(program, commandList);
+            activation->deleteLater();
+        }, Qt::SingleShotConnection);
+        activation->requestToken();
         return true;
     }
     return false;


### PR DESCRIPTION
1. Remove XdgActivation usage from all dock plugins (airplane,
bluetooth, brightness, datetime, dnd, eye-comfort, keyboard,
notification, power, shutdown, sound, wireless-casting)
2. Move XdgActivation request to PluginItem's invokeMenuItem and
executeCommand methods
3. Standardize launching control-center with dde-am command without
XdgActivation token
4. Set XDG_ACTIVATION_TOKEN environment variable in pluginitem before
calling plugin's invokedMenuItem
5. Simplify command execution by using QProcess with environment
variable

Log: Refactored XdgActivation handling for dock plugin system

Influence:
1. Verify all dock plugin settings buttons still open control-center
correctly
2. Test that XDG_ACTIVATION_TOKEN is properly set when invoking plugin
menu items
3. Verify command execution with XdgActivation token works
4. Test that plugins without settings (e.g., airplane mode toggle) still
work
5. Verify no regressions in dock plugin functionality
6. Test keyboard layout add layout action

refactor: 将XdgActivation移到pluginitem并简化dock插件

1. 从所有dock插件中移除XdgActivation使用（飞行模式、蓝牙、亮度、日期时
间、勿扰、护眼、键盘布局、通知、电源、关机、声音、投屏）
2. 将XdgActivation请求移动到PluginItem的invokeMenuItem和executeCommand方
法中
3. 标准化使用dde-am命令启动控制中心，不再传递XdgActivation令牌
4. 在调用插件invokedMenuItem之前，在pluginitem中设置XDG_ACTIVATION_TOKEN
环境变量
5. 通过使用带环境变量的QProcess简化命令执行

Log: 重构了dock插件系统的XdgActivation处理

Influence:
1. 验证所有dock插件设置按钮仍然正确打开控制中心
2. 测试调用插件菜单项时是否正确设置XDG_ACTIVATION_TOKEN
3. 验证带XdgActivation令牌的命令执行是否正常
4. 测试无设置的插件（如飞行模式切换）是否仍然正常工作
5. 验证dock插件功能没有回归问题
6. 测试键盘布局添加布局的操作

## Summary by Sourcery

Centralize XdgActivation handling in the dock plugin framework and standardize how dock plugins launch the control center and external commands.

Enhancements:
- Move XdgActivation token retrieval into PluginItem for both menu invocation and command execution, setting XDG_ACTIVATION_TOKEN only around plugin callbacks.
- Simplify dock plugins by removing per-plugin XdgActivation logic and updating them to launch the control center via a unified dde-am command pattern.