### PR TITLE
chore: update changelog to 2.0.35

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-tray-loader (2.0.35) unstable; urgency=medium
+
+  * fix: use 32-bit visual to avoid alpha channel lost
+
+ -- zhangkun <zhangkun2@uniontech.com>  Wed, 17 Jun 2026 16:17:46 +0800
+
 dde-tray-loader (2.0.34) unstable; urgency=medium
 
   * fix: allow xdg activation without window information


### PR DESCRIPTION
## 更新说明

自动更新 changelog 到版本 2.0.35

### 变更内容
- 更新 debian/changelog

### 版本信息
- 新版本: 2.0.35
- 目标分支: master

## Summary by Sourcery

Chores:
- Bump Debian package changelog entry to version 2.0.35 for the master branch.