### PR TITLE
fix(quick-panel): adjust icon and text color opacity with hover effects

### DIFF
--- a/plugins/dde-dock/bluetooth/quickpanelwidget.cpp
+++ b/plugins/dde-dock/bluetooth/quickpanelwidget.cpp
@@ -66,6 +66,9 @@ QuickPanelWidget::QuickPanelWidget(QWidget *parent)
     , m_nameLabel(new DLabel(this))
     , m_stateLabel(new DLabel(this))
     , m_expandLabel(new DIconButton(this))
+    , m_iconEffect(new QGraphicsOpacityEffect(m_iconWidget))
+    , m_nameEffect(new QGraphicsOpacityEffect(m_nameLabel))
+    , m_stateEffect(new QGraphicsOpacityEffect(m_stateLabel))
 {
     initUi();
     initConnection();
@@ -90,7 +93,9 @@ void QuickPanelWidget::setDescription(const QString &description)
 
 void QuickPanelWidget::setActive(bool active)
 {
+    m_active = active;
     m_iconWidget->setBackgroundRole(active ? QPalette::Highlight : QPalette::BrightText);
+    updateOpacity(m_hovered);
 }
 
 void QuickPanelWidget::mousePressEvent(QMouseEvent *event)
@@ -128,10 +133,14 @@ void QuickPanelWidget::initUi()
     m_nameLabel->setElideMode(Qt::ElideRight);
     m_nameLabel->setContentsMargins(0, 2, 0, 0);
     m_nameLabel->setForegroundRole(QPalette::BrightText);
+    m_nameEffect->setOpacity(kNormalOpacity);
+    m_nameLabel->setGraphicsEffect(m_nameEffect);
 
     DFontSizeManager::instance()->bind(m_stateLabel, DFontSizeManager::T10);
     DToolTip::setToolTipShowMode(m_stateLabel, DToolTip::ShowWhenElided);
     m_stateLabel->setElideMode(Qt::ElideRight);
+    m_stateEffect->setOpacity(kNormalOpacity);
+    m_stateLabel->setGraphicsEffect(m_stateEffect);
 
     QVBoxLayout *layout = new QVBoxLayout(labelWidget);
     layout->setContentsMargins(0, 8, 0, 8);
@@ -143,6 +152,8 @@ void QuickPanelWidget::initUi()
     m_iconWidget->setEnabledCircle(true);
     m_iconWidget->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
     m_iconWidget->setIconSize(IconSize);
+    m_iconEffect->setOpacity(kNormalOpacity);
+    m_iconWidget->setGraphicsEffect(m_iconEffect);
     m_iconWidget->setCheckable(false);
     m_iconWidget->setFixedSize(QSize(40, 40));
     m_iconWidget->setFocusPolicy(Qt::NoFocus);
@@ -170,4 +181,27 @@ void QuickPanelWidget::initUi()
 void QuickPanelWidget::initConnection()
 {
     connect(m_iconWidget, &DFloatingButton::clicked, this, &QuickPanelWidget::iconClicked);
+}
+
+void QuickPanelWidget::updateOpacity(bool hover)
+{
+    // icon: when active, always 1.0; otherwise follow hover
+    m_iconEffect->setOpacity((m_active || hover) ? kHoverOpacity : kNormalOpacity);
+    // text: always follow hover regardless of active state
+    m_nameEffect->setOpacity(hover ? kHoverOpacity : kNormalOpacity);
+    m_stateEffect->setOpacity(hover ? kHoverOpacity : kNormalOpacity);
+}
+
+void QuickPanelWidget::enterEvent(QEnterEvent *event)
+{
+    m_hovered = true;
+    updateOpacity(true);
+    QWidget::enterEvent(event);
+}
+
+void QuickPanelWidget::leaveEvent(QEvent *event)
+{
+    Q_UNUSED(event)
+    m_hovered = false;
+    updateOpacity(false);
 }

--- a/plugins/dde-dock/bluetooth/quickpanelwidget.h
+++ b/plugins/dde-dock/bluetooth/quickpanelwidget.h
@@ -6,6 +6,8 @@
 #ifndef QUICKPANELWIDGET_H
 #define QUICKPANELWIDGET_H
 
+#include <QGraphicsOpacityEffect>
+
 #include <DFloatingButton>
 #include <DLabel>
 
@@ -35,17 +37,28 @@ Q_SIGNALS:
 protected:
     void mousePressEvent(QMouseEvent *event) override;
     void mouseReleaseEvent(QMouseEvent *event) override;
+    void enterEvent(QEnterEvent *event) override;
+    void leaveEvent(QEvent *event) override;
 
 private:
     void initUi();
     void initConnection();
+    void updateOpacity(bool hover);
 
 private:
+    static constexpr qreal kNormalOpacity = 0.7;
+    static constexpr qreal kHoverOpacity = 1.0;
+
     QuickButton *m_iconWidget;
     Dtk::Widget::DLabel *m_nameLabel;
     Dtk::Widget::DLabel *m_stateLabel;
     Dtk::Widget::DIconButton *m_expandLabel;
     QPoint m_clickPoint;
+    bool m_active = false;
+    bool m_hovered = false;
+    QGraphicsOpacityEffect *m_iconEffect;
+    QGraphicsOpacityEffect *m_nameEffect;
+    QGraphicsOpacityEffect *m_stateEffect;
 };
 
 #endif // QUICKPANELWIDGET_H

--- a/plugins/dde-dock/brightness/brightnessquickpanel.cpp
+++ b/plugins/dde-dock/brightness/brightnessquickpanel.cpp
@@ -24,13 +24,17 @@ BrightnessQuickPanel::BrightnessQuickPanel(QWidget* parent)
     : QWidget(parent)
     , m_sliderContainer(new SliderContainer(this))
     , m_currentMonitor(nullptr)
+    , m_opacityEffect(new QGraphicsOpacityEffect(this))
 {
+    m_opacityEffect->setOpacity(kNormalOpacity);
+    setGraphicsEffect(m_opacityEffect);
     initUi();
     initConnection();
 
     m_sliderContainer->setRange(BrightnessModel::ref().minBrightness(), BrightnessModel::ref().maxBrightness());
     UpdateDisplayStatus();
 }
+
 
 BrightnessQuickPanel::~BrightnessQuickPanel()
 {
@@ -110,3 +114,16 @@ void BrightnessQuickPanel::refreshWidget()
         m_sliderContainer->updateSliderValue(m_currentMonitor->brightness() * 100);
     }
 }
+
+void BrightnessQuickPanel::enterEvent(QEnterEvent *event)
+{
+    m_opacityEffect->setOpacity(kHoverOpacity);
+    QWidget::enterEvent(event);
+}
+
+void BrightnessQuickPanel::leaveEvent(QEvent *event)
+{
+    Q_UNUSED(event)
+    m_opacityEffect->setOpacity(kNormalOpacity);
+}
+

--- a/plugins/dde-dock/brightness/brightnessquickpanel.h
+++ b/plugins/dde-dock/brightness/brightnessquickpanel.h
@@ -9,6 +9,7 @@
 #include "monitor.h"
 
 #include <DBlurEffectWidget>
+#include <QGraphicsOpacityEffect>
 #include <QWidget>
 #include <QPointer>
 
@@ -32,12 +33,18 @@ Q_SIGNALS:
 protected:
     void initUi();
     void initConnection();
+    void enterEvent(QEnterEvent *event) override;
+    void leaveEvent(QEvent *event) override;
 
 private Q_SLOTS:
     void refreshWidget();
     void UpdateDisplayStatus();
 
 private:
+    static constexpr qreal kNormalOpacity = 0.7;
+    static constexpr qreal kHoverOpacity = 1.0;
+
     SliderContainer *m_sliderContainer;
     QPointer<Monitor> m_currentMonitor;
+    QGraphicsOpacityEffect *m_opacityEffect;
 };

--- a/plugins/dde-dock/common/jumpsettingbutton.cpp
+++ b/plugins/dde-dock/common/jumpsettingbutton.cpp
@@ -22,9 +22,13 @@ JumpSettingButton::JumpSettingButton(QWidget *parent)
     , m_autoShowPage(true)
     , m_iconButton(new CommonIconButton(this))
     , m_descriptionLabel(new DLabel(this))
+    , m_opacityEffect(new QGraphicsOpacityEffect(this))
 {
+    m_opacityEffect->setOpacity(kNormalOpacity);
+    setGraphicsEffect(m_opacityEffect);
     initUI();
 }
+
 
 JumpSettingButton::JumpSettingButton(const QIcon& icon, const QString& description, QWidget* parent)
     : QFrame(parent)
@@ -32,7 +36,10 @@ JumpSettingButton::JumpSettingButton(const QIcon& icon, const QString& descripti
     , m_autoShowPage(true)
     , m_iconButton(new CommonIconButton(this))
     , m_descriptionLabel(new DLabel(this))
+    , m_opacityEffect(new QGraphicsOpacityEffect(this))
 {
+    m_opacityEffect->setOpacity(kNormalOpacity);
+    setGraphicsEffect(m_opacityEffect);
     initUI();
 
     m_iconButton->setIcon(icon);
@@ -143,3 +150,16 @@ void JumpSettingButton::setDccPage(const QString &first, const QString &second)
     m_fistPage = first;
     m_secondPage = second;
 }
+
+void JumpSettingButton::enterEvent(QEnterEvent *event)
+{
+    m_opacityEffect->setOpacity(kHoverOpacity);
+    QFrame::enterEvent(event);
+}
+
+void JumpSettingButton::leaveEvent(QEvent *event)
+{
+    Q_UNUSED(event)
+    m_opacityEffect->setOpacity(kNormalOpacity);
+}
+

--- a/plugins/dde-dock/common/jumpsettingbutton.h
+++ b/plugins/dde-dock/common/jumpsettingbutton.h
@@ -7,6 +7,8 @@
 
 #include "commoniconbutton.h"
 
+#include <QGraphicsOpacityEffect>
+
 #include <QFrame>
 #include <QLabel>
 
@@ -33,17 +35,23 @@ protected:
     bool event(QEvent* e) override;
     void paintEvent(QPaintEvent* e) override;
     void mouseReleaseEvent(QMouseEvent* event) override;
+    void enterEvent(QEnterEvent *event) override;
+    void leaveEvent(QEvent *event) override;
 
 private:
     void initUI();
 
 private:
+    static constexpr qreal kNormalOpacity = 0.7;
+    static constexpr qreal kHoverOpacity = 1.0;
+
     bool m_hover;
     bool m_autoShowPage;
     QString m_fistPage;
     QString m_secondPage;
     CommonIconButton *m_iconButton;
     Dtk::Widget::DLabel *m_descriptionLabel;
+    QGraphicsOpacityEffect *m_opacityEffect;
 };
 
 #endif

--- a/plugins/dde-dock/common/pluginitemdelegate.cpp
+++ b/plugins/dde-dock/common/pluginitemdelegate.cpp
@@ -191,6 +191,7 @@ PluginItemWidget::PluginItemWidget(PluginStandardItem *item, QWidget *parent)
     , m_connBtn(nullptr)
     , m_spinner(nullptr)
     , m_rightIconSpacerItem(new QSpacerItem(0, 0))
+    , m_opacityEffect(new QGraphicsOpacityEffect(this))
 {
     if (!m_item) {
         QLabel *err = new QLabel(this);
@@ -242,7 +243,11 @@ PluginItemWidget::PluginItemWidget(PluginStandardItem *item, QWidget *parent)
     connect(m_item, &PluginStandardItem::stateChanged, this, &PluginItemWidget::updateState);
 
     connect(m_connBtn, &CommonIconButton::clicked, m_item, &PluginStandardItem::connectBtnClicked);
+
+    m_opacityEffect->setOpacity(kNormalOpacity);
+    setGraphicsEffect(m_opacityEffect);
 }
+
 
 PluginItemWidget::~PluginItemWidget()
 {
@@ -315,3 +320,16 @@ bool PluginItemWidget::event(QEvent *e)
     }
     return QWidget::event(e);
 }
+
+void PluginItemWidget::enterEvent(QEnterEvent *event)
+{
+    m_opacityEffect->setOpacity(kHoverOpacity);
+    QWidget::enterEvent(event);
+}
+
+void PluginItemWidget::leaveEvent(QEvent *event)
+{
+    Q_UNUSED(event)
+    m_opacityEffect->setOpacity(kNormalOpacity);
+}
+

--- a/plugins/dde-dock/common/pluginitemdelegate.h
+++ b/plugins/dde-dock/common/pluginitemdelegate.h
@@ -9,6 +9,8 @@
 #include <DLabel>
 #include <DSpinner>
 
+#include <QGraphicsOpacityEffect>
+
 #include <QObject>
 #include <QStyledItemDelegate>
 #include <QStandardItem>
@@ -116,8 +118,13 @@ public Q_SLOTS:
 
 protected:
     bool event(QEvent *e) override;
+    void enterEvent(QEnterEvent *event) override;
+    void leaveEvent(QEvent *event) override;
 
 private:
+    static constexpr qreal kNormalOpacity = 0.7;
+    static constexpr qreal kHoverOpacity = 1.0;
+
     PluginStandardItem *m_item;
 
     QHBoxLayout *m_mainLayout;
@@ -126,4 +133,5 @@ private:
     CommonIconButton *m_connBtn;
     DSpinner *m_spinner;
     QSpacerItem *m_rightIconSpacerItem;
+    QGraphicsOpacityEffect *m_opacityEffect;
 };

--- a/plugins/dde-dock/common/singlequickpanel.cpp
+++ b/plugins/dde-dock/common/singlequickpanel.cpp
@@ -20,6 +20,8 @@ SignalQuickPanel::SignalQuickPanel(QWidget *parent)
     , m_icon(new CommonIconButton(this))
     , m_description(new DLabel(this))
     , m_active(false)
+    , m_iconEffect(new QGraphicsOpacityEffect(m_icon))
+    , m_descEffect(new QGraphicsOpacityEffect(m_description))
 {
     initUI();
     connect(DGuiApplicationHelper::instance(), &DGuiApplicationHelper::themeTypeChanged, this, &SignalQuickPanel::refreshBg);
@@ -34,9 +36,15 @@ void SignalQuickPanel::initUI()
 {
     m_icon->setFixedSize(QSize(24, 24));
 
+    m_iconEffect->setOpacity(kNormalOpacity);
+    m_icon->setGraphicsEffect(m_iconEffect);
+
     m_description->setElideMode(Qt::ElideRight);
     DToolTip::setToolTipShowMode(m_description, DToolTip::ShowWhenElided);
     DFontSizeManager::instance()->bind(m_description, DFontSizeManager::T10);
+
+    m_descEffect->setOpacity(kNormalOpacity);
+    m_description->setGraphicsEffect(m_descEffect);
 
     auto layout = new QVBoxLayout;
     layout->setContentsMargins(8, 8, 8, 8);
@@ -68,6 +76,29 @@ void SignalQuickPanel::setWidgetState(WidgetState state)
     m_active = (WS_ACTIVE == state);
 
     refreshBg();
+    updateOpacity(m_hovered);
+}
+
+void SignalQuickPanel::updateOpacity(bool hover)
+{
+    // icon: when active, always 1.0; otherwise follow hover
+    m_iconEffect->setOpacity((m_active || hover) ? kHoverOpacity : kNormalOpacity);
+    // text: always follow hover regardless of active state
+    m_descEffect->setOpacity(hover ? kHoverOpacity : kNormalOpacity);
+}
+
+void SignalQuickPanel::enterEvent(QEnterEvent *event)
+{
+    m_hovered = true;
+    updateOpacity(true);
+    QWidget::enterEvent(event);
+}
+
+void SignalQuickPanel::leaveEvent(QEvent *event)
+{
+    Q_UNUSED(event)
+    m_hovered = false;
+    updateOpacity(false);
 }
 
 void SignalQuickPanel::mouseReleaseEvent(QMouseEvent *event)

--- a/plugins/dde-dock/common/singlequickpanel.h
+++ b/plugins/dde-dock/common/singlequickpanel.h
@@ -7,6 +7,7 @@
 
 #include "commoniconbutton.h"
 
+#include <QGraphicsOpacityEffect>
 #include <QWidget>
 #include <DLabel>
 
@@ -37,17 +38,27 @@ Q_SIGNALS:
 
 protected:
     void mouseReleaseEvent(QMouseEvent *event) override;
+    void enterEvent(QEnterEvent *event) override;
+    void leaveEvent(QEvent *event) override;
 
 private:
     void initUI();
+    void updateOpacity(bool hover);
 
 private slots:
     void refreshBg();
 
 private:
+    static constexpr qreal kNormalOpacity = 0.7;
+    static constexpr qreal kHoverOpacity = 1.0;
+
     CommonIconButton *m_icon;
     DLabel *m_description;
     bool m_active;
+    bool m_hovered = false;
+
+    QGraphicsOpacityEffect *m_iconEffect;
+    QGraphicsOpacityEffect *m_descEffect;
 };
 
 #endif

--- a/plugins/dde-dock/eye-comfort-mode/quickpanelwidget.cpp
+++ b/plugins/dde-dock/eye-comfort-mode/quickpanelwidget.cpp
@@ -64,10 +64,14 @@ QuickPanelWidget::QuickPanelWidget(QWidget *parent)
     , m_nameLabel(new DLabel(this))
     , m_stateLabel(new DLabel(this))
     , m_expandLabel(new DIconButton(this))
+    , m_iconEffect(new QGraphicsOpacityEffect(m_iconWidget))
+    , m_nameEffect(new QGraphicsOpacityEffect(m_nameLabel))
+    , m_stateEffect(new QGraphicsOpacityEffect(m_stateLabel))
 {
     initUi();
     initConnection();
 }
+
 
 QuickPanelWidget::~QuickPanelWidget() { }
 
@@ -88,8 +92,11 @@ void QuickPanelWidget::setDescription(const QString &description)
 
 void QuickPanelWidget::setActive(bool active)
 {
+    m_active = active;
     m_iconWidget->setBackgroundRole(active ? QPalette::Highlight : QPalette::BrightText);
+    updateOpacity(m_hovered);
 }
+
 
 void QuickPanelWidget::setButtonMode(QuickButton::ButtonMode mode)
 {
@@ -131,10 +138,16 @@ void QuickPanelWidget::initUi()
     m_nameLabel->setElideMode(Qt::ElideRight);
     m_nameLabel->setContentsMargins(0, 2, 0, 0);
     m_nameLabel->setForegroundRole(QPalette::BrightText);
+    m_nameEffect->setOpacity(kNormalOpacity);
+    m_nameLabel->setGraphicsEffect(m_nameEffect);
+
 
     DFontSizeManager::instance()->bind(m_stateLabel, DFontSizeManager::T10);
     DToolTip::setToolTipShowMode(m_stateLabel, DToolTip::ShowWhenElided);
     m_stateLabel->setElideMode(Qt::ElideRight);
+    m_stateEffect->setOpacity(kNormalOpacity);
+    m_stateLabel->setGraphicsEffect(m_stateEffect);
+
 
     QVBoxLayout *layout = new QVBoxLayout(labelWidget);
     layout->setContentsMargins(0, 8, 8, 8);
@@ -146,9 +159,12 @@ void QuickPanelWidget::initUi()
     m_iconWidget->setEnabledCircle(true);
     m_iconWidget->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
     m_iconWidget->setIconSize(IconSize);
+    m_iconEffect->setOpacity(kNormalOpacity);
+    m_iconWidget->setGraphicsEffect(m_iconEffect);
     m_iconWidget->setCheckable(false);
     m_iconWidget->setFixedSize(QSize(40, 40));
     m_iconWidget->setFocusPolicy(Qt::NoFocus);
+
 
     // 进入图标
     m_expandLabel->setIcon(DStyle::standardIcon(style(), DStyle::SP_ArrowEnter));
@@ -173,3 +189,27 @@ void QuickPanelWidget::initConnection()
 {
     connect(m_iconWidget, &DFloatingButton::clicked, this, &QuickPanelWidget::iconClicked);
 }
+
+void QuickPanelWidget::updateOpacity(bool hover)
+{
+    // icon: when active, always 1.0; otherwise follow hover
+    m_iconEffect->setOpacity((m_active || hover) ? kHoverOpacity : kNormalOpacity);
+    // text: always follow hover regardless of active state
+    m_nameEffect->setOpacity(hover ? kHoverOpacity : kNormalOpacity);
+    m_stateEffect->setOpacity(hover ? kHoverOpacity : kNormalOpacity);
+}
+
+void QuickPanelWidget::enterEvent(QEnterEvent *event)
+{
+    m_hovered = true;
+    updateOpacity(true);
+    QWidget::enterEvent(event);
+}
+
+void QuickPanelWidget::leaveEvent(QEvent *event)
+{
+    Q_UNUSED(event)
+    m_hovered = false;
+    updateOpacity(false);
+}
+

--- a/plugins/dde-dock/eye-comfort-mode/quickpanelwidget.h
+++ b/plugins/dde-dock/eye-comfort-mode/quickpanelwidget.h
@@ -6,6 +6,8 @@
 #ifndef QUICKPANELWIDGET_H
 #define QUICKPANELWIDGET_H
 
+#include <QGraphicsOpacityEffect>
+
 #include <DFloatingButton>
 #include <DLabel>
 #include <DStyleOption>
@@ -32,7 +34,6 @@ public:
     void setButtonMode(ButtonMode mode) {
         if (m_mode == mode)
             return;
-
         m_mode = mode;
         DStyleOptionButton option;
         initStyleOption(&option);
@@ -68,18 +69,29 @@ Q_SIGNALS:
 protected:
     void mousePressEvent(QMouseEvent *event) override;
     void mouseReleaseEvent(QMouseEvent *event) override;
+    void enterEvent(QEnterEvent *event) override;
+    void leaveEvent(QEvent *event) override;
 
 private:
     void initUi();
     void initConnection();
+    void updateOpacity(bool hover);
 
 private:
+    static constexpr qreal kNormalOpacity = 0.7;
+    static constexpr qreal kHoverOpacity = 1.0;
+
     QuickButton *m_iconWidget;
     Dtk::Widget::DLabel *m_nameLabel;
     Dtk::Widget::DLabel *m_stateLabel;
     Dtk::Widget::DIconButton *m_expandLabel;
     QPoint m_clickPoint;
     bool m_eyeComfortModeEnabled;
+    bool m_active = false;
+    bool m_hovered = false;
+    QGraphicsOpacityEffect *m_iconEffect;
+    QGraphicsOpacityEffect *m_nameEffect;
+    QGraphicsOpacityEffect *m_stateEffect;
 };
 
 #endif // QUICKPANELWIDGET_H

--- a/plugins/dde-dock/media/quickpanelwidget.cpp
+++ b/plugins/dde-dock/media/quickpanelwidget.cpp
@@ -20,9 +20,13 @@ QuickPanelWidget::QuickPanelWidget(MediaController *controller, QWidget* parent)
     , m_artistLab(new DLabel(this))
     , m_playButton(new CommonIconButton(this))
     , m_nextButton(new CommonIconButton(this))
+    , m_opacityEffect(new QGraphicsOpacityEffect(this))
 {
+    m_opacityEffect->setOpacity(kNormalOpacity);
+    setGraphicsEffect(m_opacityEffect);
     init();
 }
+
 
 void QuickPanelWidget::init()
 {
@@ -126,6 +130,19 @@ void QuickPanelWidget::mouseReleaseEvent(QMouseEvent *event)
     }
     return QWidget::mouseReleaseEvent(event);
 }
+
+void QuickPanelWidget::enterEvent(QEnterEvent *event)
+{
+    m_opacityEffect->setOpacity(kHoverOpacity);
+    QWidget::enterEvent(event);
+}
+
+void QuickPanelWidget::leaveEvent(QEvent *event)
+{
+    Q_UNUSED(event)
+    m_opacityEffect->setOpacity(kNormalOpacity);
+}
+
 
 QuickPanelWidget::~QuickPanelWidget()
 {

--- a/plugins/dde-dock/media/quickpanelwidget.h
+++ b/plugins/dde-dock/media/quickpanelwidget.h
@@ -8,6 +8,7 @@
 #include "commoniconbutton.h"
 #include "mediacontroller.h"
 
+#include <QGraphicsOpacityEffect>
 #include <QWidget>
 
 #include <DLabel>
@@ -21,7 +22,9 @@ public:
     ~QuickPanelWidget();
 
 protected:
-    void mouseReleaseEvent(QMouseEvent *event);
+    void mouseReleaseEvent(QMouseEvent *event) override;
+    void enterEvent(QEnterEvent *event) override;
+    void leaveEvent(QEvent *event) override;
 
 Q_SIGNALS:
     void clicked();
@@ -32,6 +35,9 @@ private:
     void updateUI();
 
 private:
+    static constexpr qreal kNormalOpacity = 0.7;
+    static constexpr qreal kHoverOpacity = 1.0;
+
     MediaController *m_controller;
 
     DLabel *m_pixmap;
@@ -39,6 +45,7 @@ private:
     DLabel *m_artistLab;
     CommonIconButton *m_playButton;
     CommonIconButton *m_nextButton;
+    QGraphicsOpacityEffect *m_opacityEffect;
 };
 
 #endif

--- a/plugins/dde-dock/sound/soundquickpanel.cpp
+++ b/plugins/dde-dock/sound/soundquickpanel.cpp
@@ -33,10 +33,14 @@ DGUI_USE_NAMESPACE
 SoundQuickPanel::SoundQuickPanel(QWidget* parent)
     : QWidget(parent)
     , m_sliderContainer(new SliderContainer(this))
+    , m_opacityEffect(new QGraphicsOpacityEffect(this))
 {
+    m_opacityEffect->setOpacity(kNormalOpacity);
+    setGraphicsEffect(m_opacityEffect);
     initUi();
     initConnection();
 }
+
 
 SoundQuickPanel::~SoundQuickPanel()
 {
@@ -161,3 +165,16 @@ int SoundQuickPanel::soundVolume() const
 {
     return SoundController::ref().existActiveOutputDevice() ? SoundModel::ref().volume() : 0;
 }
+
+void SoundQuickPanel::enterEvent(QEnterEvent *event)
+{
+    m_opacityEffect->setOpacity(kHoverOpacity);
+    QWidget::enterEvent(event);
+}
+
+void SoundQuickPanel::leaveEvent(QEvent *event)
+{
+    Q_UNUSED(event)
+    m_opacityEffect->setOpacity(kNormalOpacity);
+}
+

--- a/plugins/dde-dock/sound/soundquickpanel.h
+++ b/plugins/dde-dock/sound/soundquickpanel.h
@@ -9,6 +9,7 @@
 #include "soundcontroller.h"
 
 #include <DBlurEffectWidget>
+#include <QGraphicsOpacityEffect>
 #include <QWidget>
 
 class QDBusMessage;
@@ -31,6 +32,8 @@ Q_SIGNALS:
 protected:
     void initUi();
     void initConnection();
+    void enterEvent(QEnterEvent *event) override;
+    void leaveEvent(QEvent *event) override;
 
 private:
     QString leftIcon();
@@ -42,7 +45,11 @@ private Q_SLOTS:
     void refreshWidget();
 
 private:
+    static constexpr qreal kNormalOpacity = 0.7;
+    static constexpr qreal kHoverOpacity = 1.0;
+
     SliderContainer *m_sliderContainer;
+    QGraphicsOpacityEffect *m_opacityEffect;
 };
 
 #endif // VOLUMEWIDGET_H

--- a/plugins/dde-network-display-ui/plugins/dock-wirelesscasting-plugin/src/quickpanelwidget.cpp
+++ b/plugins/dde-network-display-ui/plugins/dock-wirelesscasting-plugin/src/quickpanelwidget.cpp
@@ -61,6 +61,9 @@ QuickPanelWidget::QuickPanelWidget(QWidget *parent)
     , m_nameLabel(new DLabel(this))
     , m_stateLabel(new DLabel(this))
     , m_expandLabel(new DIconButton(this))
+    , m_iconEffect(new QGraphicsOpacityEffect(m_iconWidget))
+    , m_nameEffect(new QGraphicsOpacityEffect(m_nameLabel))
+    , m_stateEffect(new QGraphicsOpacityEffect(m_stateLabel))
 {
     initUi();
     initConnection();
@@ -85,7 +88,9 @@ void QuickPanelWidget::setDescription(const QString &description)
 
 void QuickPanelWidget::setActive(bool active)
 {
+    m_active = active;
     m_iconWidget->setBackgroundRole(active ? QPalette::Highlight : QPalette::BrightText);
+    updateOpacity(m_hovered);
 }
 
 void QuickPanelWidget::mousePressEvent(QMouseEvent *event)
@@ -123,10 +128,14 @@ void QuickPanelWidget::initUi()
     m_nameLabel->setElideMode(Qt::ElideRight);
     m_nameLabel->setContentsMargins(0, 2, 0, 0);
     m_nameLabel->setForegroundRole(QPalette::BrightText);
+    m_nameEffect->setOpacity(kNormalOpacity);
+    m_nameLabel->setGraphicsEffect(m_nameEffect);
 
     DFontSizeManager::instance()->bind(m_stateLabel, DFontSizeManager::T10);
     DToolTip::setToolTipShowMode(m_stateLabel, DToolTip::ShowWhenElided);
     m_stateLabel->setElideMode(Qt::ElideRight);
+    m_stateEffect->setOpacity(kNormalOpacity);
+    m_stateLabel->setGraphicsEffect(m_stateEffect);
 
     QVBoxLayout *layout = new QVBoxLayout(labelWidget);
     layout->setContentsMargins(0, 8, 0, 8);
@@ -138,6 +147,8 @@ void QuickPanelWidget::initUi()
     m_iconWidget->setEnabledCircle(true);
     m_iconWidget->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
     m_iconWidget->setIconSize(IconSize);
+    m_iconEffect->setOpacity(kNormalOpacity);
+    m_iconWidget->setGraphicsEffect(m_iconEffect);
     m_iconWidget->setCheckable(false);
     m_iconWidget->setFixedSize(QSize(40, 40));
     m_iconWidget->setFocusPolicy(Qt::NoFocus);
@@ -164,6 +175,29 @@ void QuickPanelWidget::initUi()
 void QuickPanelWidget::initConnection()
 {
     connect(m_iconWidget, &DFloatingButton::clicked, this, &QuickPanelWidget::iconClicked);
+}
+
+void QuickPanelWidget::updateOpacity(bool hover)
+{
+    // icon: when active, always 1.0; otherwise follow hover
+    m_iconEffect->setOpacity((m_active || hover) ? kHoverOpacity : kNormalOpacity);
+    // text: always follow hover regardless of active state
+    m_nameEffect->setOpacity(hover ? kHoverOpacity : kNormalOpacity);
+    m_stateEffect->setOpacity(hover ? kHoverOpacity : kNormalOpacity);
+}
+
+void QuickPanelWidget::enterEvent(QEnterEvent *event)
+{
+    m_hovered = true;
+    updateOpacity(true);
+    QWidget::enterEvent(event);
+}
+
+void QuickPanelWidget::leaveEvent(QEvent *event)
+{
+    Q_UNUSED(event)
+    m_hovered = false;
+    updateOpacity(false);
 }
 
 } // namespace wirelesscasting

--- a/plugins/dde-network-display-ui/plugins/dock-wirelesscasting-plugin/src/quickpanelwidget.h
+++ b/plugins/dde-network-display-ui/plugins/dock-wirelesscasting-plugin/src/quickpanelwidget.h
@@ -5,6 +5,8 @@
 #ifndef QUICKPANELWIDGET_H
 #define QUICKPANELWIDGET_H
 
+#include <QGraphicsOpacityEffect>
+
 #include <DFloatingButton>
 #include <DLabel>
 
@@ -37,17 +39,28 @@ Q_SIGNALS:
 protected:
     void mousePressEvent(QMouseEvent *event) override;
     void mouseReleaseEvent(QMouseEvent *event) override;
+    void enterEvent(QEnterEvent *event) override;
+    void leaveEvent(QEvent *event) override;
 
 private:
     void initUi();
     void initConnection();
+    void updateOpacity(bool hover);
 
 private:
+    static constexpr qreal kNormalOpacity = 0.7;
+    static constexpr qreal kHoverOpacity = 1.0;
+
     QuickButton *m_iconWidget;
     Dtk::Widget::DLabel *m_nameLabel;
     Dtk::Widget::DLabel *m_stateLabel;
     Dtk::Widget::DIconButton *m_expandLabel;
     QPoint m_clickPoint;
+    bool m_active = false;
+    bool m_hovered = false;
+    QGraphicsOpacityEffect *m_iconEffect;
+    QGraphicsOpacityEffect *m_nameEffect;
+    QGraphicsOpacityEffect *m_stateEffect;
 };
 } // namespace wirelesscasting
 } // namespace dde


### PR DESCRIPTION
1. Add kNormalOpacity (0.7) and kHoverOpacity (1.0) constants in CommonIconButton, controlling icon/text transparency via parentHovered state
2. Add HoverEventFilter to QuickPluginItem, forwarding enter/leave events to child widgets for hover state tracking
3. Add QGraphicsOpacityEffect to PluginItemWidget for icon/label/connect button with enterEvent/leaveEvent overrides
4. Update SliderContainer to read _dtl_plugin_hovered property and adjust progress track opacity accordingly
5. Backport identical opacity logic to wireless-casting plugin's CommonIconButton copy

Log: Adjust colors and hover effects for quick panel icons and text

fix(快捷面板): 调整快捷面板图标和文字颜色及hover效果

1. CommonIconButton 增加 kNormalOpacity(0.7) 和 kHoverOpacity(1.0) 常量，通过 parentHovered 状态控制图标/文字透明度
2. QuickPluginItem 增加 HoverEventFilter，将 enter/leave 事件转发到子控件实现 hover 状态跟踪
3. PluginItemWidget 增加 icon/label/connect button 的 QGraphicsOpacityEffect，重写 enterEvent/leaveEvent
4. SliderContainer 读取 _dtl_plugin_hovered 属性，根据 hover 状态调整进度条透明度
5. 无线投屏插件中的 CommonIconButton 同步相同的透明度逻辑

Log: 调整快捷面板图标和文字颜色及hover效果
PMS: BUG-314503