### PR TITLE
feat: refactor dock-tray-plugin-dev skill for tray only

### DIFF
--- a/REUSE.toml
+++ b/REUSE.toml
@@ -86,3 +86,9 @@ path = "toolGenerate/**/**"
 precedence = "aggregate"
 SPDX-FileCopyrightText = "None"
 SPDX-License-Identifier = "CC0-1.0"
+
+[[annotations]]
+path = ["dock-tray-plugin-dev/**.md", "dock-tray-plugin-dev/SKILL.md"]
+precedence = "aggregate"
+SPDX-FileCopyrightText = "UnionTech Software Technology Co., Ltd."
+SPDX-License-Identifier = "CC-BY-4.0"

--- a/dock-tray-plugin-dev/SKILL.md
+++ b/dock-tray-plugin-dev/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: dock-tray-plugin-dev
+description: >
+  辅助为 dde-tray-loader 开发托盘（Tray）插件。当需要为 DDE 任务栏编写新的托盘插件、
+  修改现有托盘插件、或理解托盘插件接口时使用此 skill。仅支持 Tray 类型插件，
+  不涉及 Dock/Quick 等其他插件类型。
+---
+
+# dock-tray-plugin-dev
+
+辅助为 dde-tray-loader 开发托盘（Tray）插件。
+
+## 概述
+
+本 skill 辅助开发 DDE 任务栏托盘区插件。托盘插件是遵循 Qt 插件标准的共享库（`.so`），安装路径为 `lib/dde-dock/plugins`，通过实现 `PluginsItemInterfaceV2` 接口与任务栏交互。
+
+## 前置条件
+
+- Qt 6 + C++17 开发环境
+- `dde-tray-loader-dev` 包（提供接口头文件和 CMake 配置）：`sudo apt install dde-tray-loader-dev`
+- DTK 开发库（Dtk6::Widget, Dtk6::Gui）
+
+## 托盘插件核心知识
+
+### 插件类结构
+
+- 必须继承 `QObject` + `PluginsItemInterfaceV2`
+- `flags()` 必须返回含 `Dock::Type_Tray` 的标志
+- `flags()` 典型返回 `Dock::Type_Tray | Dock::Attribute_CanSetting`
+
+### 必须实现的接口
+
+| 接口 | 说明 |
+|------|------|
+| `pluginName()` | 返回插件唯一标识名 |
+| `init(PluginProxyInterface *)` | 初始化入口，保存 proxy 到 `m_proxyInter` |
+| `itemWidget(itemKey)` | 返回托盘区显示的主控件 |
+
+### 推荐实现的接口
+
+| 接口 | 说明 |
+|------|------|
+| `icon(IconType, ThemeType)` | 控制中心插件区域图标（`Attribute_CanSetting` 时必须实现） |
+| `itemTipsWidget(itemKey)` | 鼠标悬浮提示 |
+| `itemContextMenu(itemKey)` / `invokedMenuItem(...)` | 右键菜单 |
+| `pluginIsAllowDisable()` / `pluginIsDisable()` / `pluginStateSwitched()` | 插件禁用/启用 |
+| `setMessageCallback()` / `message()` | 消息通信 |
+
+### JSON 元数据
+
+```json
+{
+    "api": "2.0.0"
+}
+```
+
+## 典型托盘插件结构
+
+```
+my-plugin/
+├── myplugin.h            # 插件类声明
+├── myplugin.cpp          # 插件类实现
+├── mywidget.h            # 主控件声明
+├── mywidget.cpp          # 主控件实现
+├── myplugin.json         # 元数据文件
+├── myplugin.qrc          # Qt 资源文件（图标等）
+├── icons/                # 图标资源目录
+│   ├── myplugin.svg
+│   └── myplugin-dark.svg
+└── CMakeLists.txt        # 构建配置
+```
+
+## 开发流程指引
+
+1. **创建插件类**：继承 `QObject` + `PluginsItemInterfaceV2`，声明 `Q_INTERFACES`、`Q_PLUGIN_METADATA` 宏
+2. **实现 `flags()`**：返回 `Type_Tray | Attribute_CanSetting` 等标志
+3. **实现 `init()`**：保存 proxy，使用延迟加载模式创建主控件
+4. **实现交互功能**：tips / applet / context menu / command
+5. **编写 JSON 元数据和 CMakeLists.txt**
+
+> 快速上手？直接阅读 references/ai-usage-guide.md，按章节逐步生成插件代码。
+
+## 参考实现
+
+notification 插件路径：https://github.com/linuxdeepin/dde-tray-loader/tree/master/plugins/dde-dock/notification
+
+## References 加载指引
+
+按需加载以下参考文档：
+
+1. **`tray-plugin-spec.md`** — 托盘插件接口规范（V1/V2 + flags + proxy 合并文档）。**首次开发时必须阅读。**
+2. **`message-protocol.md`** — 消息协议。当插件需要与任务栏进行消息通信时阅读。
+3. **`context-menu.md`** — 右键菜单协议。当插件需要实现右键菜单时阅读。
+4. **`ai-usage-guide.md`** — AI 使用指南。按章节指导 AI 逐步生成托盘插件代码，每章含 prompt 示例和代码骨架。

--- a/dock-tray-plugin-dev/references/ai-usage-guide.md
+++ b/dock-tray-plugin-dev/references/ai-usage-guide.md
@@ -1,0 +1,937 @@
+# AI 使用指南：托盘插件代码生成
+
+本指南面向 AI 助手，指导其根据用户的功能描述逐步生成 dde-tray-loader 托盘插件代码。每个章节对应一个接口/功能点，包含：接口说明 → 示例 prompt（中文）→ 代码骨架。
+
+> **参考实现**：https://github.com/linuxdeepin/dde-tray-loader/tree/master/plugins/dde-dock/notification 下的 notification 插件是完整的托盘插件示例。
+
+---
+
+## 1. 创建插件骨架
+
+### 接口说明
+
+托盘插件类必须继承 `QObject` + `PluginsItemInterfaceV2`，使用 `Q_INTERFACES` 和 `Q_PLUGIN_METADATA` 宏注册。`flags()` 必须返回包含 `Type_Tray` 的标志。
+
+### Prompt 示例
+
+> 帮我创建一个名为 bluetooth 的托盘插件骨架
+
+### 代码骨架
+
+```cpp
+// bluetoothplugin.h
+#ifndef BLUETOOTHPLUGIN_H
+#define BLUETOOTHPLUGIN_H
+
+#include "pluginsiteminterface.h"
+#include "pluginsiteminterface_v2.h"
+#include <QObject>
+
+class BluetoothPlugin : public QObject, public PluginsItemInterfaceV2
+{
+    Q_OBJECT
+    Q_INTERFACES(PluginsItemInterfaceV2)
+    Q_PLUGIN_METADATA(IID "com.deepin.dock.PluginsItemInterface" FILE "bluetooth.json")
+
+public:
+    explicit BluetoothPlugin(QObject *parent = nullptr);
+
+    const QString pluginName() const override;
+    const QString pluginDisplayName() const override;
+    Dock::PluginFlags flags() const override;
+    void init(PluginProxyInterface *proxyInter) override;
+    QWidget *itemWidget(const QString &itemKey) override;
+};
+
+#endif // BLUETOOTHPLUGIN_H
+```
+
+```cpp
+// bluetoothplugin.cpp
+#include "bluetoothplugin.h"
+
+BluetoothPlugin::BluetoothPlugin(QObject *parent)
+    : QObject(parent)
+{
+}
+
+const QString BluetoothPlugin::pluginName() const
+{
+    return QStringLiteral("bluetooth");
+}
+
+const QString BluetoothPlugin::pluginDisplayName() const
+{
+    return tr("Bluetooth");
+}
+
+Dock::PluginFlags BluetoothPlugin::flags() const
+{
+    return Dock::PluginFlag::Type_Tray | Dock::PluginFlag::Attribute_CanSetting;
+}
+
+void BluetoothPlugin::init(PluginProxyInterface *proxyInter)
+{
+    m_proxyInter = proxyInter;
+}
+
+QWidget *BluetoothPlugin::itemWidget(const QString &itemKey)
+{
+    Q_UNUSED(itemKey)
+    return nullptr;
+}
+```
+
+---
+
+## 2. 实现插件初始化
+
+### 接口说明
+
+`init()` 是插件初始化入口，必须保存 `proxyInter` 到 `m_proxyInter`。推荐使用延迟加载模式（`m_pluginLoaded` 惯用法），仅在插件启用时才创建控件和建立连接。
+
+### Prompt 示例
+
+> 实现这个托盘插件的 init 函数，主控件显示蓝牙图标，使用延迟加载模式
+
+### 代码骨架
+
+```cpp
+// bluetoothplugin.h 新增成员
+private:
+    void loadPlugin();
+    void refreshPluginItemsVisible();
+
+    bool m_pluginLoaded = false;
+    QScopedPointer<QWidget> m_mainWidget;
+```
+
+```cpp
+// bluetoothplugin.cpp
+void BluetoothPlugin::init(PluginProxyInterface *proxyInter)
+{
+    m_proxyInter = proxyInter;
+
+    if (!pluginIsDisable()) {
+        loadPlugin();
+    }
+}
+
+void BluetoothPlugin::loadPlugin()
+{
+    if (m_pluginLoaded) {
+        return;
+    }
+    m_pluginLoaded = true;
+
+    m_mainWidget.reset(new BluetoothWidget);  // Custom widget, see Ch3
+    m_mainWidget->setFixedSize(Dock::TRAY_PLUGIN_ITEM_FIXED_SIZE);
+
+    // Connect signals, init DBus, etc.
+    // connect(...);
+
+    m_proxyInter->itemAdded(this, pluginName());
+}
+
+void BluetoothPlugin::refreshPluginItemsVisible()
+{
+    if (pluginIsDisable()) {
+        m_proxyInter->itemRemoved(this, pluginName());
+    } else {
+        if (!m_pluginLoaded) {
+            loadPlugin();
+            return;
+        }
+        m_proxyInter->itemAdded(this, pluginName());
+    }
+}
+```
+
+---
+
+## 3. 实现主控件（itemWidget）
+
+### 接口说明
+
+`itemWidget()` 返回显示在任务栏托盘区的控件。托盘插件控件固定大小为 `TRAY_PLUGIN_ITEM_FIXED_SIZE (16x16)`。通常自定义 QWidget 子类，在 `paintEvent` 中绘制图标。
+
+### Prompt 示例
+
+> 插件的 itemWidget 显示一个 16x16 的蓝牙图标，根据连接状态变化，使用 paintEvent 绘制
+
+### 代码骨架
+
+```cpp
+// bluetoothwidget.h
+#ifndef BLUETOOTHWIDGET_H
+#define BLUETOOTHWIDGET_H
+
+#include <QWidget>
+#include <QIcon>
+
+class BluetoothWidget : public QWidget
+{
+    Q_OBJECT
+
+public:
+    explicit BluetoothWidget(QWidget *parent = nullptr);
+    void setIcon(const QIcon &icon);
+
+protected:
+    void paintEvent(QPaintEvent *e) override;
+
+private:
+    QIcon m_icon;
+};
+
+#endif // BLUETOOTHWIDGET_H
+```
+
+```cpp
+// bluetoothwidget.cpp
+#include "bluetoothwidget.h"
+#include "constants.h"
+#include <QPainter>
+
+BluetoothWidget::BluetoothWidget(QWidget *parent)
+    : QWidget(parent)
+{
+    setFixedSize(Dock::TRAY_PLUGIN_ITEM_FIXED_SIZE);
+}
+
+void BluetoothWidget::setIcon(const QIcon &icon)
+{
+    m_icon = icon;
+    update();
+}
+
+void BluetoothWidget::paintEvent(QPaintEvent *e)
+{
+    Q_UNUSED(e)
+    QPainter p(this);
+    m_icon.paint(&p, rect());
+}
+```
+
+```cpp
+// bluetoothplugin.cpp 中更新 itemWidget 和 loadPlugin
+QWidget *BluetoothPlugin::itemWidget(const QString &itemKey)
+{
+    Q_UNUSED(itemKey)
+    return m_mainWidget.data();
+}
+
+// In loadPlugin():
+m_mainWidget.reset(new BluetoothWidget);
+m_mainWidget->setIcon(QIcon::fromTheme("bluetooth"));
+```
+
+---
+
+## 4. 实现 Tooltip（itemTipsWidget）
+
+### 接口说明
+
+`itemTipsWidget()` 返回鼠标悬浮时显示的提示控件。推荐使用 `Dock::TipsWidget`，支持单行和多行文本。
+
+> **TipsWidget 依赖说明**：`TipsWidget` 位于 `plugins/dde-dock/widgets/tipswidget.h`。使用时需在 CMakeLists.txt 中添加 `../widgets` 到 `include_directories` 并编译 `tipswidget.cpp`（参见 Ch11 的 CMakeLists.txt 示例）。也可自行实现简单的 QLabel 提示控件替代。
+
+### Prompt 示例
+
+> 鼠标悬停时显示蓝牙连接状态提示文字
+
+### 代码骨架
+
+```cpp
+// bluetoothplugin.h 新增
+#include "tipswidget.h"
+
+public:
+    QWidget *itemTipsWidget(const QString &itemKey) override;
+
+private:
+    QScopedPointer<Dock::TipsWidget> m_tipsLabel;
+    void updateTipsText(bool connected, const QString &deviceName);
+```
+
+```cpp
+// bluetoothplugin.cpp
+
+// Init tips in constructor
+BluetoothPlugin::BluetoothPlugin(QObject *parent)
+    : QObject(parent)
+    , m_pluginLoaded(false)
+    , m_tipsLabel(new Dock::TipsWidget)
+{
+    m_tipsLabel->setText(tr("Bluetooth"));
+    m_tipsLabel->setVisible(false);
+}
+
+QWidget *BluetoothPlugin::itemTipsWidget(const QString &itemKey)
+{
+    Q_UNUSED(itemKey)
+    return m_tipsLabel.data();
+}
+
+void BluetoothPlugin::updateTipsText(bool connected, const QString &deviceName)
+{
+    if (connected) {
+        m_tipsLabel->setText(tr("Connected to %1").arg(deviceName));
+    } else {
+        m_tipsLabel->setText(tr("Not connected"));
+    }
+}
+```
+
+---
+
+## 5. 实现弹窗面板（itemPopupApplet）
+
+### 接口说明
+
+`itemPopupApplet()` 返回左键点击后弹出的面板控件。可包含按钮、列表等交互元素。通过 `m_proxyInter->requestSetAppletVisible()` 控制面板显隐。
+
+### Prompt 示例
+
+> 点击蓝牙图标弹出蓝牙设备列表面板
+
+### 代码骨架
+
+```cpp
+// bluetoothplugin.h 新增
+public:
+    QWidget *itemPopupApplet(const QString &itemKey) override;
+
+private:
+    QScopedPointer<QWidget> m_appletWidget;
+```
+
+```cpp
+// bluetoothplugin.cpp
+
+// 在 loadPlugin() 中创建 applet
+m_appletWidget.reset(new QWidget);
+m_appletWidget->setFixedWidth(Dock::DOCK_POPUP_WIDGET_WIDTH);
+// Add layout and child widgets
+// QVBoxLayout *layout = new QVBoxLayout(m_appletWidget.data());
+// ...
+
+QWidget *BluetoothPlugin::itemPopupApplet(const QString &itemKey)
+{
+    Q_UNUSED(itemKey)
+    return m_appletWidget.data();
+}
+```
+
+> **注意**：如果同时实现了 `itemCommand`，则 `itemCommand` 优先，`itemPopupApplet` 不会被调用。
+
+---
+
+## 6. 实现点击命令（itemCommand）
+
+### 接口说明
+
+`itemCommand()` 返回左键点击时要执行的命令字符串。任务栏会直接执行该命令。返回空字符串则忽略。适用于简单的启动应用场景。
+
+### Prompt 示例
+
+> 左键点击打开蓝牙设置界面
+
+### 代码骨架
+
+```cpp
+// bluetoothplugin.h 新增
+public:
+    const QString itemCommand(const QString &itemKey) override;
+```
+
+```cpp
+// bluetoothplugin.cpp
+const QString BluetoothPlugin::itemCommand(const QString &itemKey)
+{
+    Q_UNUSED(itemKey)
+    return QString("dde-am org.deepin.dde.control-center -- bluetooth");
+}
+```
+
+> **注意**：推荐使用 `dde-am` 打开应用，而非 `dbus-send`。在 Wayland 下需要 xdg-activation token 才能激活窗口，执行命令时框架已设置了所需环境变量，`dde-am` 会正确处理窗口激活。类似 `openControlCenterModule` 的方式：`dde-am org.deepin.dde.control-center -- bluetooth`。
+
+> **注意**：如果同时实现了 `itemCommand` 和 `itemPopupApplet`，`itemCommand` 优先。
+
+---
+
+## 7. 实现右键菜单（itemContextMenu + invokedMenuItem）
+
+### 接口说明
+
+`itemContextMenu()` 返回 JSON 格式的右键菜单数据，`invokedMenuItem()` 处理菜单项点击。详细协议见 `context-menu.md`。
+
+> **翻译说明**：涉及翻译的内容（如菜单文本、面板文字等），需要插件自行加载翻译文件处理，框架不处理翻译问题。使用 Qt 的翻译机制（`tr()` 函数 + `.ts`/`.qm` 文件）。
+
+### Prompt 示例
+
+> 右键菜单包含「打开蓝牙设置」和「开启/关闭蓝牙」两个选项
+
+### 代码骨架
+
+```cpp
+// bluetoothplugin.h 新增
+public:
+    const QString itemContextMenu(const QString &itemKey) override;
+    void invokedMenuItem(const QString &itemKey, const QString &menuId, const bool checked) override;
+```
+
+```cpp
+// bluetoothplugin.cpp
+#define BLUETOOTH_TOGGLE   "bluetooth-toggle"
+#define BLUETOOTH_SETTINGS "bluetooth-settings"
+
+const QString BluetoothPlugin::itemContextMenu(const QString &itemKey)
+{
+    Q_UNUSED(itemKey)
+
+    QList<QVariant> items;
+
+    QMap<QString, QVariant> toggle;
+    toggle["itemId"] = BLUETOOTH_TOGGLE;
+    toggle["itemText"] = isBluetoothOn() ? tr("Turn off Bluetooth") : tr("Turn on Bluetooth");
+    toggle["isCheckable"] = false;
+    toggle["isActive"] = true;
+    items.push_back(toggle);
+
+    QMap<QString, QVariant> settings;
+    settings["itemId"] = BLUETOOTH_SETTINGS;
+    settings["itemText"] = tr("Bluetooth settings");
+    settings["isCheckable"] = false;
+    settings["isActive"] = true;
+    items.push_back(settings);
+
+    QMap<QString, QVariant> menu;
+    menu["items"] = items;
+    menu["checkableMenu"] = false;
+    menu["singleCheck"] = false;
+
+    return QJsonDocument::fromVariant(menu).toJson();
+}
+
+void BluetoothPlugin::invokedMenuItem(const QString &itemKey, const QString &menuId, const bool checked)
+{
+    Q_UNUSED(itemKey)
+    Q_UNUSED(checked)
+
+    if (menuId == BLUETOOTH_TOGGLE) {
+        toggleBluetooth();
+    } else if (menuId == BLUETOOTH_SETTINGS) {
+        QStringList args {"--by-user", "org.deepin.dde.control-center", "--", "-p", "bluetooth"};
+        QProcess::startDetached("dde-am", args);
+    }
+}
+```
+
+---
+
+## 8. 实现 icon() 方法
+
+### 接口说明
+
+当 `flags()` 包含 `Attribute_CanSetting` 时，**必须**实现 `icon()` 方法。返回的图标显示在「控制中心 → 个性化 → 任务栏 → 插件区域」中。需根据 `ThemeType` 参数返回对应主题的图标。
+
+### Prompt 示例
+
+> 在控制中心-个性化-任务栏-插件区域显示蓝牙图标，支持亮暗色主题
+
+### 代码骨架
+
+```cpp
+// bluetoothplugin.h 新增
+public:
+    QIcon icon(Dock::IconType dockPart, Dock::ThemeType themeType) const override;
+```
+
+```cpp
+// bluetoothplugin.cpp
+QIcon BluetoothPlugin::icon(Dock::IconType dockPart, Dock::ThemeType themeType) const
+{
+    Q_UNUSED(dockPart)
+
+    if (themeType == Dock::ThemeType_Dark) {
+        return QIcon(":/dsg/built-in-icons/bluetooth-dark.svg");
+    } else {
+        return QIcon(":/dsg/built-in-icons/bluetooth.svg");
+    }
+}
+```
+
+> **参考 notification 插件**：`icon()` 根据 `dockPart` 参数区分不同场景返回不同图标。当 `dockPart == DockPart::DCCSetting` 时返回控制中心展示图标，否则返回任务栏上的运行时图标。
+
+> **图标使用主题图标**
+
+> **控制中心图标安装**：当 `flags()` 包含 `Attribute_CanSetting` 时，还需安装图标文件（`.dci` 格式）到 `share/dde-dock/icons/dcc-setting/` 目录，供控制中心读取。参考 notification 插件的 CMakeLists.txt：
+> ```cmake
+> install(FILES "icons/dcc-notification.dci" DESTINATION share/dde-dock/icons/dcc-setting)
+> ```
+
+---
+
+## 9. 实现消息通信（message + setMessageCallback）
+
+### 接口说明
+
+`setMessageCallback()` 保存任务栏传入的消息回调函数，`message()` 处理任务栏发来的请求。使用 JSON 格式通信。详见 `message-protocol.md`。
+
+### Prompt 示例
+
+> 插件需要监听蓝牙状态变化，通过消息协议与任务栏交互
+
+### 代码骨架
+
+```cpp
+// bluetoothplugin.h 新增
+public:
+    void setMessageCallback(MessageCallbackFunc cb) override;
+    QString message(const QString &msg) override;
+
+private:
+    MessageCallbackFunc m_messageCallback = nullptr;
+    void notifyActiveState(bool active);
+    void notifySupportFlag(bool supported);
+```
+
+```cpp
+// bluetoothplugin.cpp
+void BluetoothPlugin::setMessageCallback(MessageCallbackFunc cb)
+{
+    m_messageCallback = cb;
+}
+
+QString BluetoothPlugin::message(const QString &msg)
+{
+    QJsonObject msgObj = QJsonDocument::fromJson(msg.toUtf8()).object();
+    QString msgType = msgObj["msgType"].toString();
+
+    if (msgType == Dock::MSG_GET_SUPPORT_FLAG) {
+        QJsonObject data;
+        data["supportFlag"] = isBluetoothAvailable();
+        QJsonObject reply;
+        reply["msgType"] = msgType;
+        reply["data"] = data;
+        return QJsonDocument(reply).toJson();
+    }
+
+    if (msgType == Dock::MSG_WHETHER_WANT_TO_BE_LOADED) {
+        QJsonObject data;
+        data["whetherWantToBeLoaded"] = true;
+        QJsonObject reply;
+        reply["msgType"] = msgType;
+        reply["data"] = data;
+        return QJsonDocument(reply).toJson();
+    }
+
+    if (msgType == Dock::MSG_PLUGIN_PROPERTY) {
+        QJsonObject data;
+        data[Dock::PLUGIN_PROP_NEED_CHAMELEON] = false;
+        QJsonObject reply;
+        reply["msgType"] = msgType;
+        reply["data"] = data;
+        return QJsonDocument(reply).toJson();
+    }
+
+    return "{}";
+}
+
+void BluetoothPlugin::notifyActiveState(bool active)
+{
+    if (!m_messageCallback) return;
+    QJsonObject data;
+    data["itemActiveState"] = active;
+    QJsonObject msg;
+    msg["msgType"] = Dock::MSG_ITEM_ACTIVE_STATE;
+    msg["data"] = data;
+    m_messageCallback(this, QJsonDocument(msg).toJson());
+}
+
+void BluetoothPlugin::notifySupportFlag(bool supported)
+{
+    if (!m_messageCallback) return;
+    QJsonObject data;
+    data["supportFlag"] = supported;
+    QJsonObject msg;
+    msg["msgType"] = Dock::MSG_SUPPORT_FLAG_CHANGED;
+    msg["data"] = data;
+    m_messageCallback(this, QJsonDocument(msg).toJson());
+}
+```
+
+---
+
+## 10. 编写 JSON 元数据
+
+### 接口说明
+
+每个插件必须包含一个 JSON 元数据文件，由 `Q_PLUGIN_METADATA(FILE "...")` 加载。
+
+### Prompt 示例
+
+> 生成这个插件的 JSON 元数据文件，依赖蓝牙 DBus 服务
+
+### 代码骨架
+
+```json
+{
+    "api": "2.0.0"
+}
+```
+
+字段说明：
+- `api`：**必填**，接口版本号，必须为 `"2.0.0"`
+
+---
+
+## 11. 编写 CMakeLists.txt
+
+### 接口说明
+
+插件构建为共享库（`.so`），安装到 `lib/dde-dock/plugins`。需链接 `dockpluginmanager-interface` target 和 DTK 库。
+
+> **依赖说明**：插件依赖 `dde-tray-loader-dev` 包提供的接口头文件和 CMake 配置。安装方式：`sudo apt install dde-tray-loader-dev`。该包提供 `interfaces/` 目录下的头文件和 `dockpluginmanager-interface` CMake target。
+
+### Prompt 示例
+
+> 生成插件的 CMakeLists.txt，项目名为 bluetooth，依赖 Dtk6::Widget 和 Qt6::DBus
+
+### 代码骨架
+
+```cmake
+set(PLUGIN_NAME "bluetooth")
+
+find_package(Qt${QT_VERSION_MAJOR} ${REQUIRED_QT_VERSION} REQUIRED COMPONENTS DBus)
+find_package(Dtk${DTK_VERSION_MAJOR} REQUIRED COMPONENTS Widget Gui)
+
+add_library(${PLUGIN_NAME} SHARED
+    bluetoothplugin.h
+    bluetoothplugin.cpp
+    bluetoothwidget.h
+    bluetoothwidget.cpp
+    bluetooth.qrc
+    ../widgets/tipswidget.h
+    ../widgets/tipswidget.cpp
+)
+
+target_compile_definitions(${PLUGIN_NAME} PRIVATE QT_PLUGIN)
+set_target_properties(${PLUGIN_NAME} PROPERTIES LIBRARY_OUTPUT_DIRECTORY ../)
+
+target_include_directories(${PLUGIN_NAME} PRIVATE
+    "../../../interfaces"
+    "../widgets"
+)
+
+target_link_libraries(${PLUGIN_NAME} PRIVATE
+    Dtk${DTK_VERSION_MAJOR}::Widget
+    Qt${QT_VERSION_MAJOR}::DBus
+    Dtk${DTK_VERSION_MAJOR}::Gui
+    dockpluginmanager-interface
+)
+
+install(TARGETS ${PLUGIN_NAME} LIBRARY DESTINATION lib/dde-dock/plugins)
+install(FILES "icons/dcc-bluetooth.dci" DESTINATION share/dde-dock/icons/dcc-setting)
+```
+
+---
+
+## 12. 调试插件
+
+### 接口说明
+
+开发完成后需要调试插件。由于托盘插件由 `trayplugin-loader` 进程加载，而该进程由 dde-shell 启动，因此需要先找到并退出目标进程，再单独启动调试。
+
+### 调试前提
+
+- dde-shell 进程已启动并加载了 `org.deepin.ds.dock` 插件（如 systemd 中的 `dde-shell@DDE` 服务）
+
+### 调试步骤
+
+1. **查找插件进程**：
+
+```bash
+ps -aux | grep tray
+```
+
+找到加载了目标插件的 `trayplugin-loader` 进程及其 PID。
+
+2. **退出目标进程**：
+
+```bash
+kill <PID>
+```
+
+3. **单独启动调试**：
+
+```bash
+/usr/libexec/trayplugin-loader -p /path/to/your/plugin.so --platform wayland
+```
+
+> **注意**：`-p` 参数指定插件的 `.so` 文件路径。调试时可直接在终端查看插件的日志输出（`qDebug` / `qWarning` 等）。
+
+---
+
+## 13. 完整示例：从描述到插件
+
+本章节展示如何通过一系列 prompt 让 AI 生成一个完整的托盘插件。以 notification 插件为参考蓝本。
+
+### 场景描述
+
+> 我需要为 DDE 任务栏开发一个托盘插件，名为 "vpn"，显示 VPN 连接状态，支持点击打开 VPN 设置，右键菜单可以快速连接/断开，鼠标悬浮显示当前连接信息。
+
+### Prompt 序列
+
+**第 1 步：创建骨架**
+
+> 帮我创建一个名为 vpn 的托盘插件骨架，需要继承 PluginsItemInterfaceV2
+
+**第 2 步：实现初始化**
+
+> 实现这个 VPN 托盘插件的 init 函数，主控件显示 VPN 图标，使用延迟加载模式
+
+**第 3 步：实现主控件**
+
+> 插件的 itemWidget 显示一个 16x16 的 VPN 图标，根据连接状态（已连接/未连接）切换图标，使用 paintEvent 绘制
+
+**第 4 步：实现 Tooltip**
+
+> 鼠标悬停时显示 VPN 连接状态提示文字，已连接时显示服务器名称，未连接时显示"未连接"
+
+**第 5 步：实现右键菜单**
+
+> 右键菜单包含「连接 VPN」和「VPN 设置」两个选项，连接状态时菜单文字变为「断开 VPN」
+
+**第 6 步：实现 icon 方法**
+
+> 在控制中心显示 VPN 图标，支持亮暗色主题
+
+**第 7 步：实现消息通信**
+
+> 插件需要通过消息协议报告 VPN 可用状态和激活状态
+
+**第 8 步：生成构建文件**
+
+> 生成这个插件的 JSON 元数据文件和 CMakeLists.txt
+
+### 完整代码骨架
+
+```cpp
+// vpnplugin.h
+#ifndef VPNPLUGIN_H
+#define VPNPLUGIN_H
+
+#include "pluginsiteminterface.h"
+#include "pluginsiteminterface_v2.h"
+#include "tipswidget.h"
+#include <QObject>
+
+class VpnWidget;
+
+class VpnPlugin : public QObject, public PluginsItemInterfaceV2
+{
+    Q_OBJECT
+    Q_INTERFACES(PluginsItemInterfaceV2)
+    Q_PLUGIN_METADATA(IID "com.deepin.dock.PluginsItemInterface" FILE "vpn.json")
+
+public:
+    explicit VpnPlugin(QObject *parent = nullptr);
+
+    const QString pluginName() const override;
+    const QString pluginDisplayName() const override;
+    Dock::PluginFlags flags() const override;
+    void init(PluginProxyInterface *proxyInter) override;
+
+    QWidget *itemWidget(const QString &itemKey) override;
+    QWidget *itemTipsWidget(const QString &itemKey) override;
+    const QString itemCommand(const QString &itemKey) override;
+    const QString itemContextMenu(const QString &itemKey) override;
+    void invokedMenuItem(const QString &itemKey, const QString &menuId, const bool checked) override;
+
+    bool pluginIsAllowDisable() override;
+    bool pluginIsDisable() override;
+    void pluginStateSwitched() override;
+
+    QIcon icon(Dock::IconType dockPart, Dock::ThemeType themeType) const override;
+
+    void setMessageCallback(MessageCallbackFunc cb) override;
+    QString message(const QString &msg) override;
+
+private:
+    void loadPlugin();
+    void refreshPluginItemsVisible();
+    void updateVpnState(bool connected, const QString &serverName = QString());
+
+    bool m_pluginLoaded = false;
+    QScopedPointer<VpnWidget> m_mainWidget;
+    QScopedPointer<Dock::TipsWidget> m_tipsLabel;
+    MessageCallbackFunc m_messageCallback = nullptr;
+    bool m_vpnConnected = false;
+    QString m_serverName;
+};
+
+#endif // VPNPLUGIN_H
+```
+
+```cpp
+// vpnplugin.cpp
+#include "vpnplugin.h"
+#include "vpnwidget.h"
+#include "constants.h"
+#include <QProcess>
+#include <QJsonDocument>
+
+#define VPN_CONNECT    "vpn-connect"
+#define VPN_DISCONNECT "vpn-disconnect"
+#define VPN_SETTINGS   "vpn-settings"
+#define PLUGIN_STATE_KEY "enable"
+
+VpnPlugin::VpnPlugin(QObject *parent)
+    : QObject(parent)
+    , m_tipsLabel(new Dock::TipsWidget)
+{
+    m_tipsLabel->setText(tr("Not connected"));
+    m_tipsLabel->setVisible(false);
+}
+
+const QString VpnPlugin::pluginName() const { return QStringLiteral("vpn"); }
+const QString VpnPlugin::pluginDisplayName() const { return tr("VPN"); }
+Dock::PluginFlags VpnPlugin::flags() const { return Dock::PluginFlag::Type_Tray | Dock::PluginFlag::Attribute_CanSetting; }
+bool VpnPlugin::pluginIsAllowDisable() { return true; }
+bool VpnPlugin::pluginIsDisable() { return !(m_proxyInter->getValue(this, PLUGIN_STATE_KEY, true).toBool()); }
+
+void VpnPlugin::init(PluginProxyInterface *proxyInter)
+{
+    m_proxyInter = proxyInter;
+    if (!pluginIsDisable()) {
+        loadPlugin();
+    }
+}
+
+void VpnPlugin::loadPlugin()
+{
+    if (m_pluginLoaded) return;
+    m_pluginLoaded = true;
+
+    m_mainWidget.reset(new VpnWidget);
+    // Connect DBus signals, init state, etc.
+    m_proxyInter->itemAdded(this, pluginName());
+}
+
+void VpnPlugin::refreshPluginItemsVisible()
+{
+    if (pluginIsDisable()) {
+        m_proxyInter->itemRemoved(this, pluginName());
+    } else {
+        if (!m_pluginLoaded) { loadPlugin(); return; }
+        m_proxyInter->itemAdded(this, pluginName());
+    }
+}
+
+void VpnPlugin::pluginStateSwitched()
+{
+    m_proxyInter->saveValue(this, PLUGIN_STATE_KEY, pluginIsDisable());
+    refreshPluginItemsVisible();
+}
+
+QWidget *VpnPlugin::itemWidget(const QString &itemKey) { Q_UNUSED(itemKey) return m_mainWidget.data(); }
+QWidget *VpnPlugin::itemTipsWidget(const QString &itemKey) { Q_UNUSED(itemKey) return m_tipsLabel.data(); }
+
+const QString VpnPlugin::itemCommand(const QString &itemKey)
+{
+    Q_UNUSED(itemKey)
+    return QString("dde-am org.deepin.dde.control-center -- vpn");
+}
+
+const QString VpnPlugin::itemContextMenu(const QString &itemKey)
+{
+    Q_UNUSED(itemKey)
+    QList<QVariant> items;
+
+    QMap<QString, QVariant> connectAction;
+    connectAction["itemId"] = m_vpnConnected ? VPN_DISCONNECT : VPN_CONNECT;
+    connectAction["itemText"] = m_vpnConnected ? tr("Disconnect VPN") : tr("Connect VPN");
+    connectAction["isCheckable"] = false;
+    connectAction["isActive"] = true;
+    items.push_back(connectAction);
+
+    QMap<QString, QVariant> settingsAction;
+    settingsAction["itemId"] = VPN_SETTINGS;
+    settingsAction["itemText"] = tr("VPN settings");
+    settingsAction["isCheckable"] = false;
+    settingsAction["isActive"] = true;
+    items.push_back(settingsAction);
+
+    QMap<QString, QVariant> menu;
+    menu["items"] = items;
+    menu["checkableMenu"] = false;
+    menu["singleCheck"] = false;
+    return QJsonDocument::fromVariant(menu).toJson();
+}
+
+void VpnPlugin::invokedMenuItem(const QString &itemKey, const QString &menuId, const bool checked)
+{
+    Q_UNUSED(itemKey) Q_UNUSED(checked)
+    if (menuId == VPN_CONNECT || menuId == VPN_DISCONNECT) {
+        // toggle VPN connection via DBus
+    } else if (menuId == VPN_SETTINGS) {
+        QStringList args {"--by-user", "org.deepin.dde.control-center", "--", "-p", "vpn"};
+        QProcess::startDetached("dde-am", args);
+    }
+}
+
+QIcon VpnPlugin::icon(Dock::IconType dockPart, Dock::ThemeType themeType) const
+{
+    Q_UNUSED(dockPart)
+    if (themeType == Dock::ThemeType_Dark) {
+        return QIcon(":/dsg/built-in-icons/vpn-dark.svg");
+    }
+    return QIcon(":/dsg/built-in-icons/vpn.svg");
+}
+
+void VpnPlugin::setMessageCallback(MessageCallbackFunc cb) { m_messageCallback = cb; }
+
+QString VpnPlugin::message(const QString &msg)
+{
+    QJsonObject msgObj = QJsonDocument::fromJson(msg.toUtf8()).object();
+    QString msgType = msgObj["msgType"].toString();
+
+    if (msgType == Dock::MSG_GET_SUPPORT_FLAG) {
+        QJsonObject data;
+        data["supportFlag"] = true;
+        QJsonObject reply;
+        reply["msgType"] = msgType;
+        reply["data"] = data;
+        return QJsonDocument(reply).toJson();
+    }
+    return "{}";
+}
+
+void VpnPlugin::updateVpnState(bool connected, const QString &serverName)
+{
+    m_vpnConnected = connected;
+    m_serverName = serverName;
+    if (connected) {
+        m_tipsLabel->setText(tr("Connected to %1").arg(serverName));
+    } else {
+        m_tipsLabel->setText(tr("Not connected"));
+    }
+    // Notify dock of active state change
+    if (m_messageCallback) {
+        QJsonObject data;
+        data["itemActiveState"] = connected;
+        QJsonObject msg;
+        msg["msgType"] = Dock::MSG_ITEM_ACTIVE_STATE;
+        msg["data"] = data;
+        m_messageCallback(this, QJsonDocument(msg).toJson());
+    }
+}
+```
+
+```json
+{
+    "api": "2.0.0"
+}
+```

--- a/dock-tray-plugin-dev/references/context-menu.md
+++ b/dock-tray-plugin-dev/references/context-menu.md
@@ -1,0 +1,182 @@
+# 右键菜单协议
+
+本文档描述 dde-tray-loader 托盘插件的右键菜单实现协议。
+
+> **相关文档**：消息通信协议请参考 `message-protocol.md`；完整接口规范请参考 `tray-plugin-spec.md`。
+
+## 1. 概述
+
+托盘插件的右键菜单通过两个接口配合实现：
+
+1. **`itemContextMenu`**：返回菜单数据的 JSON 字符串
+2. **`invokedMenuItem`**：菜单项被点击后的回调
+
+## 2. 菜单数据格式
+
+`itemContextMenu` 返回的 JSON 结构如下：
+
+```json
+{
+    "items": [
+        {
+            "itemId": "menu-id-1",
+            "itemText": "菜单项文本",
+            "isCheckable": false,
+            "isActive": true,
+            "checked": false
+        },
+        {
+            "itemId": "menu-id-2",
+            "itemText": "可勾选项",
+            "isCheckable": true,
+            "isActive": true,
+            "checked": true
+        }
+    ],
+    "checkableMenu": false,
+    "singleCheck": false
+}
+```
+
+### 2.1 顶层字段
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| `items` | `array` | 菜单项列表 |
+| `checkableMenu` | `bool` | 整个菜单是否为可勾选菜单 |
+| `singleCheck` | `bool` | 是否单选模式（仅一个菜单项可被选中） |
+
+### 2.2 菜单项字段
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| `itemId` | `string` | 菜单项唯一标识，用于 `invokedMenuItem` 中区分点击了哪个菜单项 |
+| `itemText` | `string` | 菜单项显示文本 |
+| `isCheckable` | `bool` | 该菜单项是否可勾选 |
+| `isActive` | `bool` | 该菜单项是否激活（灰色不可点击为 `false`） |
+| `checked` | `bool` | 可勾选项的当前选中状态（仅 `isCheckable` 为 `true` 时有效） |
+
+## 3. 预定义菜单项 ID
+
+任务栏保留了以下菜单项 ID，插件不应使用：
+
+| 常量 | 值 | 说明 |
+|------|----|------|
+| `dockMenuItemId` | `"dock-item-id"` | 驻留任务栏 |
+| `unDockMenuItemId` | `"undock-item-id"` | 移除驻留 |
+
+## 4. 实现示例
+
+### 4.1 构建菜单数据
+
+参考 notification 插件的实现：
+
+```cpp
+const QString MyPlugin::itemContextMenu(const QString &itemKey)
+{
+    Q_UNUSED(itemKey)
+
+    QList<QVariant> items;
+
+    // 菜单项 1：普通按钮
+    QMap<QString, QVariant> action1;
+    action1["itemId"] = "toggle-feature";
+    action1["itemText"] = tr("Toggle feature");
+    action1["isCheckable"] = false;
+    action1["isActive"] = true;
+    items.push_back(action1);
+
+    // 菜单项 2：打开设置
+    QMap<QString, QVariant> action2;
+    action2["itemId"] = "open-settings";
+    action2["itemText"] = tr("Settings");
+    action2["isCheckable"] = false;
+    action2["isActive"] = true;
+    items.push_back(action2);
+
+    // 菜单项 3：可勾选项
+    QMap<QString, QVariant> toggleAction;
+    toggleAction["itemId"] = "enable-mode";
+    toggleAction["itemText"] = tr("Enable mode");
+    toggleAction["isCheckable"] = true;
+    toggleAction["isActive"] = true;
+    toggleAction["checked"] = isModeEnabled();
+    items.push_back(toggleAction);
+
+    QMap<QString, QVariant> menu;
+    menu["items"] = items;
+    menu["checkableMenu"] = false;
+    menu["singleCheck"] = false;
+
+    return QJsonDocument::fromVariant(menu).toJson();
+}
+```
+
+### 4.2 处理菜单项点击
+
+```cpp
+void MyPlugin::invokedMenuItem(const QString &itemKey, const QString &menuId, const bool checked)
+{
+    Q_UNUSED(itemKey)
+
+    if (menuId == "toggle-feature") {
+        // 处理功能切换
+        toggleFeature();
+    } else if (menuId == "open-settings") {
+        // 打开设置界面
+        QStringList args {"--by-user", "org.deepin.dde.control-center", "--", "-p", "myplugin"};
+        QProcess::startDetached("dde-am", args);
+    } else if (menuId == "enable-mode") {
+        // 处理可勾选项
+        setModeEnabled(checked);
+    }
+}
+```
+
+## 5. 常见模式
+
+### 5.1 动态菜单文本
+
+菜单文本可以根据状态动态变化：
+
+```cpp
+const QString MyPlugin::itemContextMenu(const QString &itemKey)
+{
+    Q_UNUSED(itemKey)
+
+    QList<QVariant> items;
+
+    QMap<QString, QVariant> toggleDnd;
+    toggleDnd["itemId"] = "toggle-dnd";
+    toggleDnd["itemText"] = dndMode() ? tr("Turn off DND mode") : tr("Turn on DND mode");
+    toggleDnd["isCheckable"] = false;
+    toggleDnd["isActive"] = true;
+    items.push_back(toggleDnd);
+
+    // ...
+}
+```
+
+### 5.2 通过 dde-am 启动控制中心模块
+
+```cpp
+// 打开控制中心的指定模块
+void MyPlugin::openControlCenterModule(const QString &module)
+{
+    QStringList args {"--by-user", "org.deepin.dde.control-center", "--", "-p", module};
+    QProcess::startDetached("dde-am", args);
+}
+```
+
+### 5.3 通过 dde-am 打开应用
+
+> **注意**：推荐使用 `dde-am` 打开应用，而非 `dbus-send`。在 Wayland 下需要 xdg-activation token 才能激活窗口，执行命令时框架已设置了所需环境变量，`dde-am` 会正确处理窗口激活。
+
+```cpp
+// 通过 itemCommand 打开控制中心模块
+const QString MyPlugin::itemCommand(const QString &itemKey)
+{
+    Q_UNUSED(itemKey)
+    return QString("dde-am org.deepin.dde.control-center -- mymodule");
+}
+```

--- a/dock-tray-plugin-dev/references/message-protocol.md
+++ b/dock-tray-plugin-dev/references/message-protocol.md
@@ -1,0 +1,273 @@
+# 消息协议
+
+本文档描述 dde-tray-loader 托盘插件与任务栏之间的消息通信协议。基于 `PluginsItemInterfaceV2` 的 `message()` 和 `setMessageCallback()` 接口，使用 JSON 格式字符串传输数据。
+
+> **相关文档**：右键菜单协议请参考 `context-menu.md`；完整接口规范请参考 `tray-plugin-spec.md`。
+
+## 1. 消息格式
+
+所有消息均使用 JSON 格式，包含两个固定字段：
+
+```json
+{
+    "msgType": "消息类型",
+    "data": { ... }
+}
+```
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| `msgType` | `string` | 消息类型标识，对应常量 `Dock::MSG_TYPE` (`"msgType"`) |
+| `data` | `object` | 消息数据，对应常量 `Dock::MSG_DATA` (`"data"`) |
+
+## 2. MessageCallbackFunc
+
+### 2.1 函数签名
+
+```cpp
+using MessageCallbackFunc = QString (*)(PluginsItemInterfaceV2 *, const QString&);
+```
+
+- **参数 1**：`PluginsItemInterfaceV2 *` — 当前插件实例指针
+- **参数 2**：`const QString&` — 发送给任务栏的 JSON 消息
+- **返回值**：`QString` — 任务栏返回的 JSON 数据
+
+### 2.2 使用模式
+
+插件在 `setMessageCallback` 中保存回调函数，后续通过此回调向任务栏发送请求：
+
+```cpp
+// 声明静态回调函数
+static QString onMessage(PluginsItemInterfaceV2 *plugin, const QString &msg);
+
+// 保存回调
+void MyPlugin::setMessageCallback(MessageCallbackFunc cb) {
+    m_messageCallback = cb;
+}
+
+// 使用回调发送消息
+QString MyPlugin::sendMessage(const QString &msgType, const QJsonObject &data) {
+    if (!m_messageCallback) return "{}";
+    QJsonObject msg;
+    msg["msgType"] = msgType;
+    msg["data"] = data;
+    return m_messageCallback(this, QJsonDocument(msg).toJson());
+}
+```
+
+> **注意**：`MessageCallbackFunc` 是 C 函数指针，不是 `std::function`。不能使用 lambda 捕获，必须使用静态函数或全局函数。
+
+## 3. 托盘插件常用消息类型
+
+### 3.1 MSG_GET_SUPPORT_FLAG — 查询插件是否可用
+
+插件向任务栏报告自身是否可用。
+
+| 字段 | 值 |
+|------|----|
+| 常量 | `Dock::MSG_GET_SUPPORT_FLAG` (`"getSupportFlag"`) |
+| 方向 | 任务栏 → 插件（`message()` 中处理） |
+| data | 无 |
+| 返回 | `{ "supportFlag": true/false }` |
+
+**插件处理示例**：
+
+```cpp
+QString MyPlugin::message(const QString &msg) {
+    QJsonObject msgObj = QJsonDocument::fromJson(msg.toUtf8()).object();
+    QString msgType = msgObj["msgType"].toString();
+
+    if (msgType == Dock::MSG_GET_SUPPORT_FLAG) {
+        QJsonObject data;
+        data["supportFlag"] = isAvailable();
+        QJsonObject reply;
+        reply["msgType"] = msgType;
+        reply["data"] = data;
+        return QJsonDocument(reply).toJson();
+    }
+    return "{}";
+}
+```
+
+### 3.2 MSG_SUPPORT_FLAG_CHANGED — 插件可用状态变化通知
+
+当插件可用状态变化时，主动通知任务栏。
+
+| 字段 | 值 |
+|------|----|
+| 常量 | `Dock::MSG_SUPPORT_FLAG_CHANGED` (`"supportFlagChanged"`) |
+| 方向 | 插件 → 任务栏（通过 `MessageCallbackFunc` 发送） |
+
+**发送示例**：
+
+```cpp
+void MyPlugin::notifySupportChanged(bool supported) {
+    if (!m_messageCallback) return;
+    QJsonObject data;
+    data["supportFlag"] = supported;
+    QJsonObject msg;
+    msg["msgType"] = Dock::MSG_SUPPORT_FLAG_CHANGED;
+    msg["data"] = data;
+    m_messageCallback(this, QJsonDocument(msg).toJson());
+}
+```
+
+### 3.3 MSG_ITEM_ACTIVE_STATE — 插件激活状态
+
+插件向任务栏报告自身是否处于激活状态。
+
+| 字段 | 值 |
+|------|----|
+| 常量 | `Dock::MSG_ITEM_ACTIVE_STATE` (`"itemActiveState"`) |
+| 方向 | 插件 → 任务栏 |
+| data | `{ "itemActiveState": true/false }` |
+
+- `true`：插件处于激活状态（如蓝牙已连接）
+- `false`：插件处于失活状态
+
+### 3.4 MSG_WHETHER_WANT_TO_BE_LOADED — 插件是否希望被加载
+
+插件自行决定是否要被任务栏加载。不发送此消息则默认被加载。
+
+| 字段 | 值 |
+|------|----|
+| 常量 | `Dock::MSG_WHETHER_WANT_TO_BE_LOADED` (`"whetherWantToBeLoaded"`) |
+| 方向 | 任务栏 → 插件（`message()` 中处理） |
+| 返回 | `{ "whetherWantToBeLoaded": true/false }` |
+
+- `true`：希望被加载
+- `false`：不希望被加载
+
+### 3.5 MSG_UPDATE_TOOLTIPS_VISIBLE — 更新 Tooltip 显隐
+
+请求任务栏更新插件的 tooltip 显示状态。一般用于一个插件含多个图标、鼠标 hover 到不同图标时显示不同 tooltip 的场景。
+
+| 字段 | 值 |
+|------|----|
+| 常量 | `Dock::MSG_UPDATE_TOOLTIPS_VISIBLE` (`"updateTooltipsVisible"`) |
+| 方向 | 插件 → 任务栏 |
+
+### 3.6 MSG_UPDATE_OVERFLOW_STATE — 任务栏溢出状态
+
+任务栏通知插件当前的溢出状态。
+
+| 字段 | 值 |
+|------|----|
+| 常量 | `Dock::MSG_UPDATE_OVERFLOW_STATE` (`"updateOverflowState"`) |
+| 方向 | 任务栏 → 插件 |
+| data | `{ "overflowState": 0/1/2 }` |
+
+| 值 | 常量 | 说明 |
+|----|------|------|
+| 0 | `OVERFLOW_STATE_NOT_EXIST` | 没有溢出区 |
+| 1 | `OVERFLOW_STATE_EXIST` | 有溢出区 |
+| 2 | `OVERFLOW_STATE_ALL` | 所有应用都在溢出区 |
+
+### 3.7 MSG_DOCK_PANEL_SIZE_CHANGED — 任务栏面板尺寸变化
+
+任务栏通知插件面板尺寸发生了变化，插件可据此调整自身大小。
+
+| 字段 | 值 |
+|------|----|
+| 常量 | `Dock::MSG_DOCK_PANEL_SIZE_CHANGED` (`"dockPanelSizeChanged"`) |
+| 方向 | 任务栏 → 插件 |
+
+### 3.8 MSG_APPLET_CONTAINER — 弹窗显示位置
+
+告知插件弹窗是在任务栏上直接显示还是在快捷面板的二级页面显示，插件可据此调整样式。
+
+| 字段 | 值 |
+|------|----|
+| 常量 | `Dock::MSG_APPLET_CONTAINER` (`"appletContainer"`) |
+| 方向 | 任务栏 → 插件 |
+| data | `{ "appletContainer": 0/1 }` |
+
+| 值 | 常量 | 说明 |
+|----|------|------|
+| 0 | `APPLET_CONTAINER_DOCK` | 任务栏 |
+| 1 | `APPLET_CONTAINER_QUICK_PANEL` | 快捷面板 |
+
+### 3.9 MSG_PLUGIN_PROPERTY — 插件属性
+
+任务栏获取插件属性，用于确定插件状态（如是否需要变色龙效果）。
+
+| 字段 | 值 |
+|------|----|
+| 常量 | `Dock::MSG_PLUGIN_PROPERTY` (`"pluginProperty"`) |
+| 方向 | 任务栏 → 插件 |
+| 返回 | `QMap<QString, QVariant>` 转为 JSON |
+
+#### 变色龙相关属性
+
+| 属性键 | 说明 |
+|--------|------|
+| `PLUGIN_PROP_NEED_CHAMELEON` (`"needChameleon"`) | 是否需要变色龙效果（hover/press 样式），`true`/`false` |
+| `PLUGIN_PROP_CHAMELEON_MARGIN` (`"chameleonMargin"`) | 变色龙边距，`QMargin` 值 |
+
+## 4. 消息处理完整示例
+
+以下是一个托盘插件处理消息的完整示例：
+
+```cpp
+// myplugin.h
+class MyPlugin : public QObject, public PluginsItemInterfaceV2
+{
+    // ...
+    void setMessageCallback(MessageCallbackFunc cb) override;
+    QString message(const QString &msg) override;
+
+private:
+    MessageCallbackFunc m_messageCallback = nullptr;
+};
+
+// myplugin.cpp
+void MyPlugin::setMessageCallback(MessageCallbackFunc cb) {
+    m_messageCallback = cb;
+}
+
+QString MyPlugin::message(const QString &msg) {
+    QJsonObject msgObj = QJsonDocument::fromJson(msg.toUtf8()).object();
+    QString msgType = msgObj["msgType"].toString();
+
+    if (msgType == Dock::MSG_GET_SUPPORT_FLAG) {
+        return QStringLiteral("{\"msgType\":\"getSupportFlag\",\"data\":{\"supportFlag\":true}}");
+    }
+
+    if (msgType == Dock::MSG_WHETHER_WANT_TO_BE_LOADED) {
+        return QStringLiteral("{\"msgType\":\"whetherWantToBeLoaded\",\"data\":{\"whetherWantToBeLoaded\":true}}");
+    }
+
+    if (msgType == Dock::MSG_PLUGIN_PROPERTY) {
+        QJsonObject data;
+        data[Dock::PLUGIN_PROP_NEED_CHAMELEON] = false;
+        QJsonObject reply;
+        reply["msgType"] = msgType;
+        reply["data"] = data;
+        return QJsonDocument(reply).toJson();
+    }
+
+    return "{}";
+}
+
+// 主动通知状态变化
+void MyPlugin::onAvailabilityChanged(bool available) {
+    if (!m_messageCallback) return;
+    QJsonObject data;
+    data["supportFlag"] = available;
+    QJsonObject msg;
+    msg["msgType"] = Dock::MSG_SUPPORT_FLAG_CHANGED;
+    msg["data"] = data;
+    m_messageCallback(this, QJsonDocument(msg).toJson());
+}
+
+// 通知激活状态
+void MyPlugin::onActiveStateChanged(bool active) {
+    if (!m_messageCallback) return;
+    QJsonObject data;
+    data["itemActiveState"] = active;
+    QJsonObject msg;
+    msg["msgType"] = Dock::MSG_ITEM_ACTIVE_STATE;
+    msg["data"] = data;
+    m_messageCallback(this, QJsonDocument(msg).toJson());
+}
+```

--- a/dock-tray-plugin-dev/references/tray-plugin-spec.md
+++ b/dock-tray-plugin-dev/references/tray-plugin-spec.md
@@ -1,0 +1,300 @@
+# 托盘插件接口规范
+
+本文档合并了 dde-tray-loader 托盘插件开发所需的全部接口定义，包括 V1/V2 接口、PluginFlags、PluginProxyInterface。
+
+## 1. 插件继承关系
+
+托盘插件必须继承 `QObject` + `PluginsItemInterfaceV2`：
+
+```
+PluginsItemInterface          (V1 基类)
+  └── PluginsItemInterfaceV2  (V2 扩展，托盘插件使用此类)
+```
+
+IID 声明：
+- V1 IID: `"com.deepin.dock.PluginsItemInterface"` — 定义为 `ModuleInterface_iid`
+- V2 IID: `"com.deepin.dock.PluginsItemInterface_V2"` — 定义为 `ModuleInterface_iid_V2`
+
+> **注意**：任务栏插件加载器通过 V1 IID `"com.deepin.dock.PluginsItemInterface"` 发现插件。若 `Q_PLUGIN_METADATA` 使用 V2 IID，加载器将无法识别该插件。因此新插件必须使用 V1 IID，并通过 `Q_INTERFACES(PluginsItemInterfaceV2)` 声明 V2 接口支持。
+
+## 2. PluginsItemInterface (V1 基类)
+
+源文件：`interfaces/pluginsiteminterface.h`
+
+### 2.1 必须实现的接口
+
+| 接口 | 签名 | 说明 |
+|------|------|------|
+| `pluginName` | `virtual const QString pluginName() const = 0` | 返回插件唯一标识名，不可与其他插件冲突 |
+| `init` | `virtual void init(PluginProxyInterface *proxyInter) = 0` | 插件初始化入口，必须将 `proxyInter` 保存到 `m_proxyInter`，**不要 delete 此指针** |
+| `itemWidget` | `virtual QWidget *itemWidget(const QString &itemKey) = 0` | 返回插件主控件，用于显示在任务栏托盘区 |
+
+### 2.2 可选实现的接口
+
+| 接口 | 签名 | 说明 |
+|------|------|------|
+| `pluginDisplayName` | `virtual const QString pluginDisplayName() const` | 返回插件显示名称，用于界面展示 |
+| `itemTipsWidget` | `virtual QWidget *itemTipsWidget(const QString &itemKey)` | 返回鼠标悬浮时的提示控件，返回 `nullptr` 则不显示 |
+| `itemPopupApplet` | `virtual QWidget *itemPopupApplet(const QString &itemKey)` | 返回左键点击后弹出的面板控件 |
+| `itemCommand` | `virtual const QString itemCommand(const QString &itemKey)` | 返回左键点击后要执行的命令字符串，空字符串则忽略 |
+| `itemContextMenu` | `virtual const QString itemContextMenu(const QString &itemKey)` | 返回右键菜单的 JSON 数据，详见 `context-menu.md` |
+| `invokedMenuItem` | `virtual void invokedMenuItem(const QString &itemKey, const QString &menuId, const bool checked)` | 右键菜单项被点击的回调 |
+
+> **翻译说明**：涉及翻译的内容（如菜单文本、面板文字等），需要插件自行加载翻译文件处理，框架不处理翻译问题。使用 Qt 的翻译机制（`tr()` 函数 + `.ts`/`.qm` 文件）。
+| `itemSortKey` | `virtual int itemSortKey(const QString &itemKey)` | 返回控件排序位置，1 为默认，0 为左侧，-1 为右侧 |
+| `setSortKey` | `virtual void setSortKey(const QString &itemKey, const int order)` | 用户拖拽后保存新的排序位置 |
+| `pluginIsAllowDisable` | `virtual bool pluginIsAllowDisable()` | 插件是否允许被禁用，默认 `false` |
+| `pluginIsDisable` | `virtual bool pluginIsDisable()` | 插件当前是否被禁用，默认 `false` |
+| `pluginStateSwitched` | `virtual void pluginStateSwitched()` | 插件启用/禁用状态被切换时调用 |
+| `displayModeChanged` | `virtual void displayModeChanged(const Dock::DisplayMode displayMode)` | 任务栏显示模式变化时调用 |
+| `positionChanged` | `virtual void positionChanged(const Dock::Position position)` | 任务栏位置变化时调用 |
+| `refreshIcon` | `virtual void refreshIcon(const QString &itemKey)` | 系统图标主题变化时调用，用于刷新图标 |
+| `pluginSettingsChanged` | `virtual void pluginSettingsChanged()` | 插件设置变化时调用 |
+| `itemAllowContainer` | `virtual bool itemAllowContainer(const QString &itemKey)` | 是否允许收纳，默认 `false` |
+| `itemIsInContainer` | `virtual bool itemIsInContainer(const QString &itemKey)` | 是否处于收纳模式 |
+| `setItemIsInContainer` | `virtual void setItemIsInContainer(const QString &itemKey, const bool container)` | 更新收纳模式状态 |
+| `pluginSizePolicy` | `virtual PluginSizePolicy pluginSizePolicy() const` | 返回插件尺寸策略，默认 `System`。`Custom` 时需自行处理控件大小 |
+
+### 2.3 辅助方法
+
+| 方法 | 说明 |
+|------|------|
+| `displayMode()` | 获取当前任务栏显示模式（Fashion/Efficient） |
+| `position()` | 获取当前任务栏位置（Top/Right/Bottom/Left） |
+
+### 2.4 PluginSizePolicy 枚举
+
+| 值 | 含义 |
+|----|------|
+| `System = 1 << 0` | 跟随系统 |
+| `Custom = 1 << 1` | 自定义 |
+
+### 2.5 保护成员
+
+```cpp
+PluginProxyInterface *m_proxyInter = nullptr;  // 永远不要 delete
+```
+
+## 3. PluginsItemInterfaceV2 (V2 扩展)
+
+源文件：`interfaces/pluginsiteminterface_v2.h`
+
+V2 继承自 V1，新增以下接口：
+
+### 3.1 flags — 插件标识（必须覆写）
+
+```cpp
+virtual Dock::PluginFlags flags() const { return Dock::Type_System | Dock::Attribute_Normal; }
+```
+
+**托盘插件必须覆写**，典型返回值：
+
+```cpp
+Dock::PluginFlags flags() const override {
+    return Dock::PluginFlag::Type_Tray | Dock::PluginFlag::Attribute_CanSetting;
+}
+```
+
+- `Type_Tray (0x10)`：标识插件类型为托盘区
+- `Attribute_CanSetting (0x800)`：允许在控制中心设置显示/隐藏，设置此属性时**必须**实现 `icon()` 方法
+
+### 3.2 icon — 控制中心图标
+
+```cpp
+virtual QIcon icon(Dock::IconType, Dock::ThemeType) const { return QIcon(); }
+```
+
+当 `flags()` 包含 `Attribute_CanSetting` 时，此方法**必须实现**。返回的图标显示在「控制中心 → 个性化 → 任务栏 → 插件区域」中。
+
+参数说明：
+- `Dock::IconType`：图标类型，当前仅有 `IconType_None`
+- `Dock::ThemeType`：主题类型，`ThemeType_Light`（亮色）/ `ThemeType_Dark`（暗色）
+
+示例（参考 notification 插件）：
+
+```cpp
+QIcon icon(Dock::IconType dockPart, Dock::ThemeType themeType) const override {
+    if (themeType == Dock::ThemeType_Dark) {
+        return QIcon(":/dsg/built-in-icons/myplugin-dark.svg");
+    } else {
+        return QIcon(":/dsg/built-in-icons/myplugin.svg");
+    }
+}
+```
+
+> **图标使用主题图标**
+
+> **控制中心图标安装**：当 `flags()` 包含 `Attribute_CanSetting` 时，还需安装图标文件（`.dci` 格式）到 `share/dde-dock/icons/dcc-setting/` 目录，供控制中心读取。参考 notification 插件的 CMakeLists.txt：
+> ```cmake
+> install(FILES "icons/dcc-notification.dci" DESTINATION share/dde-dock/icons/dcc-setting)
+> ```
+
+### 3.3 setMessageCallback — 设置消息回调
+
+```cpp
+virtual void setMessageCallback(MessageCallbackFunc) {}
+```
+
+设置消息回调函数，插件通过此回调向任务栏发送请求。详见 `message-protocol.md`。
+
+### 3.4 message — 处理任务栏消息
+
+```cpp
+virtual QString message(const QString &) { return "{}"; }
+```
+
+任务栏向插件发送请求，使用 JSON 格式字符串传输数据。详见 `message-protocol.md`。
+
+### 3.5 addPlugin — 承载子插件指针
+
+```cpp
+virtual void addPlugin(QPluginLoader*) {}
+```
+
+用于托盘容器插件接收子插件指针，实现一个托盘区容纳多个子插件的场景。单个托盘插件无需实现此接口。
+
+## 4. MessageCallbackFunc 类型定义
+
+```cpp
+using MessageCallbackFunc = QString (*)(PluginsItemInterfaceV2 *, const QString&);
+```
+
+- 参数 1：`PluginsItemInterfaceV2 *` — 插件实例指针
+- 参数 2：`const QString&` — 发送给任务栏的 JSON 数据
+- 返回值：`QString` — 任务栏返回的 JSON 数据
+
+## 5. PluginFlags 详解
+
+源文件：`interfaces/constants.h`
+
+### 5.1 类型标志（Type）
+
+| 标志 | 值 | 说明 |
+|------|----|------|
+| `Type_None` | `0x00` | 默认值 |
+| `Type_Unadapted` | `0x01` | 未适配，请勿使用 |
+| `Type_Quick` | `0x02` | 快捷插件区 |
+| `Type_Tool` | `0x04` | 工具插件（如回收站） |
+| `Type_System` | `0x08` | 系统插件（如关机） |
+| **`Type_Tray`** | **`0x10`** | **托盘区插件（本 skill 关注的类型）** |
+| `Type_Fixed` | `0x20` | 固定区域插件 |
+
+### 5.2 快捷面板布局（仅 Quick 类型使用）
+
+| 标志 | 值 | 说明 |
+|------|----|------|
+| `Quick_Panel_Single` | `0x40` | 单列快捷插件 |
+| `Quick_Panel_Multi` | `0x80` | 双列快捷插件 |
+| `Quick_Panel_Full` | `0x100` | 四列整行快捷插件 |
+
+### 5.3 属性标志（Attribute）
+
+| 标志 | 值 | 说明 |
+|------|----|------|
+| `Attribute_CanDrag` | `0x200` | 支持拖动 |
+| `Attribute_CanInsert` | `0x400` | 支持在前方插入其他插件 |
+| **`Attribute_CanSetting`** | **`0x800`** | **允许在控制中心设置显隐，设置时必须实现 `icon()`** |
+| `Attribute_ForceDock` | `0x1000` | 强制显示在任务栏 |
+| `Attribute_Normal` | `CanDrag \| CanInsert \| CanSetting` | 普通插件属性组合 |
+
+### 5.4 托盘插件常用 flags 组合
+
+| 组合 | 适用场景 |
+|------|----------|
+| `Type_Tray \| Attribute_CanSetting` | 可在控制中心显隐的托盘插件（**最常见**） |
+| `Type_Tray \| Attribute_CanDrag \| Attribute_CanInsert \| Attribute_CanSetting` | 完整属性的可拖拽托盘插件 |
+| `Type_Tray \| Attribute_ForceDock` | 强制显示的托盘插件 |
+
+## 6. PluginProxyInterface 详解
+
+源文件：`interfaces/pluginproxyinterface.h`
+
+插件通过 `m_proxyInter` 调用以下方法主动与任务栏交互：
+
+> **简化说明**：以下方法签名省略了部分 `const` 限定符，完整签名请参考 `interfaces/pluginproxyinterface.h` 源文件。
+
+### 6.1 控件管理
+
+| 方法 | 签名 | 说明 |
+|------|------|------|
+| `itemAdded` | `void itemAdded(PluginsItemInterface *itemInter, const QString &itemKey)` | 向任务栏添加控件，`itemKey` 需在本插件内唯一 |
+| `itemUpdate` | `void itemUpdate(PluginsItemInterface *itemInter, const QString &itemKey)` | 通知任务栏刷新指定控件 |
+| `itemRemoved` | `void itemRemoved(PluginsItemInterface *itemInter, const QString &itemKey)` | 从任务栏移除控件，不会删除控件对象 |
+
+### 6.2 窗口控制
+
+| 方法 | 签名 | 说明 |
+|------|------|------|
+| `requestWindowAutoHide` | `void requestWindowAutoHide(PluginsItemInterface *itemInter, const QString &itemKey, const bool autoHide)` | 设置任务栏是否允许自动隐藏 |
+| `requestRefreshWindowVisible` | `void requestRefreshWindowVisible(PluginsItemInterface *itemInter, const QString &itemKey)` | 通知任务栏刷新隐藏状态 |
+| `requestSetAppletVisible` | `void requestSetAppletVisible(PluginsItemInterface *itemInter, const QString &itemKey, const bool visible)` | 控制弹出面板的显隐 |
+
+### 6.3 配置存储
+
+| 方法 | 签名 | 说明 |
+|------|------|------|
+| `saveValue` | `void saveValue(PluginsItemInterface *itemInter, const QString &key, const QVariant &value)` | 保存配置到 `.config/deepin/dde-dock.conf`，按 `pluginName()` 分组 |
+| `getValue` | `const QVariant getValue(PluginsItemInterface *itemInter, const QString &key, const QVariant &fallback = QVariant())` | 读取配置值 |
+| `removeValue` | `void removeValue(PluginsItemInterface *itemInter, const QStringList &keyList)` | 删除指定 key 的配置，空列表则删除该插件所有配置 |
+
+## 7. 常量与尺寸
+
+源文件：`interfaces/constants.h`
+
+### 7.1 托盘插件关键尺寸
+
+| 常量 | 值 | 说明 |
+|------|----|------|
+| `TRAY_PLUGIN_ITEM_FIXED_WIDTH` | `16` | 托盘插件固定宽度 |
+| `TRAY_PLUGIN_ITEM_FIXED_HEIGHT` | `16` | 托盘插件固定高度 |
+| `TRAY_PLUGIN_ITEM_FIXED_SIZE` | `QSize(16, 16)` | 托盘插件固定大小 |
+| `DOCK_PLUGIN_ITEM_FIXED_SIZE` | `QSize(16, 16)` | 任务栏插件固定大小 |
+
+### 7.2 API 版本
+
+| 常量 | 值 |
+|------|----|
+| `DOCK_PLUGIN_API_VERSION` | `"2.0.0"` |
+| `DOCK_API_VERSION_MAJOR` | `2` |
+| `DOCK_API_VERSION_MINOR` | `0` |
+| `DOCK_API_VERSION_PATCH` | `0` |
+
+### 7.3 其他常量
+
+| 常量 | 说明 |
+|------|------|
+| `DOCK_PLUGIN_MIME` | `"dock/plugin"` |
+| `PROP_DISPLAY_MODE` | `"DisplayMode"` |
+| `PROP_POSITION` | `"Position"` |
+| `PLUGIN_MIN_ICON_NAME` | `"-dark"` — 最小尺寸图标的后缀 |
+
+## 8. JSON 元数据格式
+
+插件必须包含一个 JSON 元数据文件，通过 `Q_PLUGIN_METADATA(FILE "...")` 宏加载：
+
+```json
+{
+    "api": "2.0.0"
+}
+```
+
+字段说明：
+- `api`：**必填**，接口版本号，必须为 `"2.0.0"`
+
+## 9. DisplayMode 与 Position 枚举
+
+### DisplayMode
+
+| 值 | 名称 | 说明 |
+|----|------|------|
+| 0 | `Fashion` | 时尚模式 |
+| 1 | `Efficient` | 高效模式 |
+
+### Position
+
+| 值 | 名称 | 说明 |
+|----|------|------|
+| 0 | `Top` | 顶部 |
+| 1 | `Right` | 右侧 |
+| 2 | `Bottom` | 底部 |
+| 3 | `Left` | 左侧 |


### PR DESCRIPTION
## Summary

Refactor the `dock-tray-plugin-dev` skill to focus exclusively on tray plugin development.

## Changes

1. Rewrite `SKILL.md` to focus exclusively on tray plugin development
2. Merge V1/V2 interface, flags, and proxy into `tray-plugin-spec.md`
3. Preserve `message-protocol.md` for message/callback documentation
4. Preserve `context-menu.md` for context menu protocol documentation
5. Add `ai-usage-guide.md` with step-by-step AI usage instructions

## Related Issue

Fixes #57