### PR TITLE
fix(sound): avoid muted slider double feedback

### DIFF
--- a/plugins/dde-dock/sound/soundapplet.cpp
+++ b/plugins/dde-dock/sound/soundapplet.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2011 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2011 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -183,7 +183,7 @@ void SoundApplet::onVolumeChanged(int volume)
 
 void SoundApplet::volumeSliderValueChanged()
 {
-    SoundController::ref().SetVolume(m_volumeSlider->value() * 0.01, true);
+    SoundController::ref().SetVolume(m_volumeSlider->value() * 0.01, !SoundModel::ref().isMute());
 }
 
 void SoundApplet::updatePorts()

--- a/plugins/dde-dock/sound/soundquickpanel.cpp
+++ b/plugins/dde-dock/sound/soundquickpanel.cpp
@@ -1,5 +1,5 @@
 // Copyright (C) 2022 ~ 2022 Deepin Technology Co., Ltd.
-// SPDX-FileCopyrightText: 2018 - 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2018 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -78,7 +78,7 @@ void SoundQuickPanel::initConnection()
     });
 
     connect(m_sliderContainer, &SliderContainer::sliderValueChanged, this, [this](int value) {
-        SoundController::ref().SetVolume(value * 0.01, true);
+        SoundController::ref().SetVolume(value * 0.01, !SoundModel::ref().isMute());
     });
     connect(&SoundModel::ref(), &SoundModel::activePortChanged, this, &SoundQuickPanel::refreshWidget);
     connect(&SoundModel::ref(), &SoundModel::cardsInfoChanged, this, &SoundQuickPanel::refreshWidget);


### PR DESCRIPTION
## Summary
- Stop requesting volume feedback from dock sliders while output is muted.
- Apply the behavior to applet and quick panel sliders.

## Issue
PMS: BUG-368463

## Summary by Sourcery

Adjust sound dock and quick panel volume sliders to avoid sending feedback requests while audio output is muted.

Bug Fixes:
- Prevent duplicate or unnecessary volume feedback when adjusting dock and quick panel sliders while muted.

Enhancements:
- Update copyright year ranges for sound applet and quick panel sources.