### PR TITLE
fix: xembed tray icon not updated

### DIFF
--- a/plugins/application-tray/fdoselectionmanager.cpp
+++ b/plugins/application-tray/fdoselectionmanager.cpp
@@ -154,6 +154,10 @@ bool FdoSelectionManager::nativeEventFilter(const QByteArray &eventType, void *m
         }
     } else if (responseType == m_damageEventBase + XCB_DAMAGE_NOTIFY) {
         const auto damagedWId = reinterpret_cast<xcb_damage_notify_event_t *>(ev)->drawable;
+        const xcb_damage_damage_t damageId = m_damageWatches.value(damagedWId);
+        if (damageId) {
+            xcb_damage_subtract(Util::instance()->getX11Connection(), damageId, XCB_NONE, XCB_NONE);
+        }
         m_trayManager->notifyIconChanged(damagedWId);
     } else if (responseType == XCB_CONFIGURE_REQUEST) {
         // const auto event = reinterpret_cast<xcb_configure_request_event_t *>(ev);


### PR DESCRIPTION
修正treeland会话下xembed托盘图标不会更新的问题.

PMS: BUG-369271

## Summary by Sourcery

Bug Fixes:
- Clear X11 DAMAGE regions for damaged tray icon windows before notifying the tray manager so icons refresh properly in Treeland sessions.