### PR TITLE
build: request Qt CorePrivate/WidgetsPrivate components in application-tray

### DIFF
--- a/plugins/application-tray/CMakeLists.txt
+++ b/plugins/application-tray/CMakeLists.txt
@@ -7,7 +7,10 @@ set(PLUGIN_NAME "application-tray")
 project(${PLUGIN_NAME})
 
 find_package(PkgConfig REQUIRED)
-find_package(Qt${QT_VERSION_MAJOR} ${REQUIRED_QT_VERSION} REQUIRED Core Gui Widgets DBus)
+find_package(Qt${QT_VERSION_MAJOR} ${REQUIRED_QT_VERSION} REQUIRED COMPONENTS Core Gui Widgets DBus)
+if(Qt${QT_VERSION_MAJOR}_VERSION VERSION_GREATER_EQUAL 6.10)
+    find_package(Qt${QT_VERSION_MAJOR} COMPONENTS CorePrivate WidgetsPrivate REQUIRED)
+endif()
 find_package(Dtk${DTK_VERSION_MAJOR} REQUIRED Core Gui Widget Tools)
 find_package(KF6WindowSystem 6.6 REQUIRED) # for x11 tray selection owner
 


### PR DESCRIPTION
`plugins/application-tray/CMakeLists.txt` links against `Qt6::CorePrivate` and `Qt6::WidgetsPrivate`:

```cmake
target_link_libraries(${PLUGIN_NAME} PRIVATE ... Qt6::CorePrivate Qt6::WidgetsPrivate ...)
```

but only requests the public components:

```cmake
find_package(Qt${QT_VERSION_MAJOR} ${REQUIRED_QT_VERSION} REQUIRED Core Gui Widgets DBus)
```

Those imported targets are only defined when the corresponding `*Private` components are requested. On Qt 6.11.1 this fails at generate time:

```
CMake Error at plugins/application-tray/CMakeLists.txt:70 (target_link_libraries):
  Target "application-tray" links to: Qt6::CorePrivate

  but the target was not found.  Possible reasons include:

    * There is a typo in the target name.
    * A find_package call is missing for an IMPORTED target.
    * An ALIAS target is missing.
```

Reproduced on a pristine checkout of `master` @ `b3d4784` (2.0.36) with no other changes, and on `2.0.35`.

## Fix

```diff
-find_package(Qt${QT_VERSION_MAJOR} ${REQUIRED_QT_VERSION} REQUIRED Core Gui Widgets DBus)
+find_package(Qt${QT_VERSION_MAJOR} ${REQUIRED_QT_VERSION} REQUIRED COMPONENTS Core Gui Widgets DBus CorePrivate WidgetsPrivate)
```

## Testing

- Arch Linux, Qt 6.11.1, CMake 4.3.4, Ninja.
- Before: `cmake -S . -B build -GNinja -DCMAKE_BUILD_TYPE=Release` fails at generate time with the error above.
- After: configures and builds cleanly (`cmake --build build --target trayplugin-loader`).
- Build-only change; no runtime behaviour is affected.

## Note

Presumably latent on the Qt version Deepin 25 ships (6.8.0), where these targets may be pulled in transitively. Surfaced on Qt 6.11.1 (Arch Linux).

## Summary by Sourcery

Ensure the application-tray plugin correctly finds and links Qt CorePrivate and WidgetsPrivate components.

Bug Fixes:
- Fix CMake configuration failure when building the application-tray plugin with Qt 6.11.1 due to missing CorePrivate and WidgetsPrivate imported targets.

Build:
- Update application-tray CMake configuration to request Qt CorePrivate and WidgetsPrivate components explicitly via find_package.