### PR TITLE
feat(dock-plugin): add disconnect button on hover for plugin items

### DIFF
--- a/plugins/dde-dock/common/commontextbutton.cpp
+++ b/plugins/dde-dock/common/commontextbutton.cpp
@@ -1,0 +1,51 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include "commontextbutton.h"
+
+#include <DStyleOption>
+#include <QPainter>
+
+CommonTextButton::CommonTextButton(QWidget *parent, const QString &text)
+: QAbstractButton(parent)
+{
+    setCursor(Qt::PointingHandCursor);
+    setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
+    Dtk::Widget::DFontSizeManager::instance()->bind(this, Dtk::Widget::DFontSizeManager::T8);
+}
+
+void CommonTextButton::paintEvent(QPaintEvent *event)
+{
+    Q_UNUSED(event);
+
+    QPainter p(this);
+    p.setRenderHint(QPainter::Antialiasing);
+
+    QRectF rect = this->rect();
+
+    if (isDown()) {
+        p.setBrush(QColor(0,0,0,255 * 0.2));
+    } else if (underMouse()) {
+        p.setBrush(QColor(0, 0, 0, 255 * 0.15));
+    } else {
+        p.setBrush(QColor(0, 0, 0, 255 * 0.1));
+    }
+        
+    p.setPen(Qt::NoPen);
+    p.drawRoundedRect(rect, 8, 8);
+
+    p.setPen(QColor(255, 255, 255, 255));
+    p.drawText(rect, Qt::AlignCenter, text());
+}
+
+QSize CommonTextButton::sizeHint() const
+{
+    const QFontMetrics metrics(font());
+    return QSize(metrics.horizontalAdvance(text()) + 24, metrics.height() + 6);
+}
+
+QSize CommonTextButton::minimumSizeHint() const
+{
+    return sizeHint();
+}

--- a/plugins/dde-dock/common/commontextbutton.h
+++ b/plugins/dde-dock/common/commontextbutton.h
@@ -1,0 +1,18 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#pragma once
+
+#include <QAbstractButton>
+
+class CommonTextButton : public QAbstractButton
+{
+public:
+    explicit CommonTextButton(QWidget *parent = nullptr, const QString &text = "");
+    QSize sizeHint() const override;
+    QSize minimumSizeHint() const override;
+
+protected:
+    void paintEvent(QPaintEvent *event) override;
+};

--- a/plugins/dde-dock/common/pluginitemdelegate.cpp
+++ b/plugins/dde-dock/common/pluginitemdelegate.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
 #include "pluginitemdelegate.h"
+#include "commontextbutton.h"
 
 #include <DStyleOption>
 #include <DPalette>
@@ -189,6 +190,8 @@ PluginItemWidget::PluginItemWidget(PluginStandardItem *item, QWidget *parent)
     , m_iconBtn(nullptr)
     , m_nameLabel(nullptr)
     , m_connBtn(nullptr)
+    , m_disConnectBtn(nullptr)
+    , m_state(NoState)
     , m_spinner(nullptr)
     , m_rightIconSpacerItem(new QSpacerItem(0, 0))
 {
@@ -213,10 +216,13 @@ PluginItemWidget::PluginItemWidget(PluginStandardItem *item, QWidget *parent)
 
     m_connBtn = new CommonIconButton(this);
     m_connBtn->setIcon(QIcon::fromTheme("plugin_item_select"));
-    m_connBtn->setHoverIcon(QIcon::fromTheme("plugin_item_disconnect"));
     m_connBtn->setFixedSize(16, 16);
     m_connBtn->setClickable(true);
     m_connBtn->hide();
+
+    m_disConnectBtn = new CommonTextButton(this);
+    m_disConnectBtn->setText(tr("Disconnect"));
+    m_disConnectBtn->setVisible(false);
 
     m_spinner = new DSpinner(this);
     m_spinner->setFixedSize(16, 16);
@@ -231,6 +237,7 @@ PluginItemWidget::PluginItemWidget(PluginStandardItem *item, QWidget *parent)
     m_mainLayout->addStretch();
     m_mainLayout->addSpacerItem(m_rightIconSpacerItem);
     m_mainLayout->addWidget(m_connBtn, 0, Qt::AlignRight | Qt::AlignVCenter);
+    m_mainLayout->addWidget(m_disConnectBtn, 0, Qt::AlignRight | Qt::AlignVCenter);
     m_mainLayout->addWidget(m_spinner, 0, Qt::AlignRight | Qt::AlignVCenter);
     updateState(item->state());
 
@@ -241,7 +248,7 @@ PluginItemWidget::PluginItemWidget(PluginStandardItem *item, QWidget *parent)
     connect(m_item, &PluginStandardItem::nameChanged, this, &PluginItemWidget::updateName);
     connect(m_item, &PluginStandardItem::stateChanged, this, &PluginItemWidget::updateState);
 
-    connect(m_connBtn, &CommonIconButton::clicked, m_item, &PluginStandardItem::connectBtnClicked);
+    connect(m_disConnectBtn, &CommonTextButton::clicked, m_item, &PluginStandardItem::connectBtnClicked);
 }
 
 PluginItemWidget::~PluginItemWidget()
@@ -261,6 +268,7 @@ void PluginItemWidget::updateName(const QString &name)
 void PluginItemWidget::updateState(const PluginItemState state)
 {
     m_rightIconSpacerItem->changeSize(10, 0);
+    m_state = state;
     switch (state) {
     case PluginItemState::NoState:
         m_connBtn->setVisible(false);
@@ -314,4 +322,22 @@ bool PluginItemWidget::event(QEvent *e)
         break;
     }
     return QWidget::event(e);
+}
+
+void PluginItemWidget::enterEvent(QEnterEvent *event)
+{
+    if (m_state == PluginItemState::Connected) {
+        m_disConnectBtn->setVisible(true);
+        m_connBtn->setVisible(false);
+    }
+    QWidget::enterEvent(event);
+}
+
+void PluginItemWidget::leaveEvent(QEvent *event)
+{
+    m_disConnectBtn->setVisible(false);
+    if (m_state == PluginItemState::Connected) {
+        m_connBtn->setVisible(true);
+    };
+    QWidget::leaveEvent(event);
 }

--- a/plugins/dde-dock/common/pluginitemdelegate.h
+++ b/plugins/dde-dock/common/pluginitemdelegate.h
@@ -1,10 +1,11 @@
-// SPDX-FileCopyrightText: 2016 - 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2016 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
 #pragma once
 
 #include "commoniconbutton.h"
+#include "commontextbutton.h"
 
 #include <DLabel>
 #include <DSpinner>
@@ -116,14 +117,18 @@ public Q_SLOTS:
 
 protected:
     bool event(QEvent *e) override;
+    void enterEvent(QEnterEvent *event) override;
+    void leaveEvent(QEvent *event) override;
 
 private:
     PluginStandardItem *m_item;
 
     QHBoxLayout *m_mainLayout;
     CommonIconButton *m_iconBtn;
+    CommonTextButton *m_disConnectBtn;
     DLabel *m_nameLabel;
     CommonIconButton *m_connBtn;
     DSpinner *m_spinner;
     QSpacerItem *m_rightIconSpacerItem;
+    PluginItemState m_state;
 };

--- a/plugins/dde-dock/translations/dde-dock.ts
+++ b/plugins/dde-dock/translations/dde-dock.ts
@@ -194,65 +194,6 @@
     </message>
 </context>
 <context>
-    <name>DatetimeWidget</name>
-    <message>
-        <source>Monday</source>
-        <translation>Monday</translation>
-    </message>
-    <message>
-        <source>Tuesday</source>
-        <translation>Tuesday</translation>
-    </message>
-    <message>
-        <source>Wednesday</source>
-        <translation>Wednesday</translation>
-    </message>
-    <message>
-        <source>Thursday</source>
-        <translation>Thursday</translation>
-    </message>
-    <message>
-        <source>Friday</source>
-        <translation>Friday</translation>
-    </message>
-    <message>
-        <source>Saturday</source>
-        <translation>Saturday</translation>
-    </message>
-    <message>
-        <source>Sunday</source>
-        <translation>Sunday</translation>
-    </message>
-    <message>
-        <source>monday</source>
-        <translation>monday</translation>
-    </message>
-    <message>
-        <source>tuesday</source>
-        <translation>tuesday</translation>
-    </message>
-    <message>
-        <source>wednesday</source>
-        <translation>wednesday</translation>
-    </message>
-    <message>
-        <source>thursday</source>
-        <translation>thursday</translation>
-    </message>
-    <message>
-        <source>friday</source>
-        <translation>friday</translation>
-    </message>
-    <message>
-        <source>saturday</source>
-        <translation>saturday</translation>
-    </message>
-    <message>
-        <source>sunday</source>
-        <translation>sunday</translation>
-    </message>
-</context>
-<context>
     <name>DeviceControlWidget</name>
     <message>
         <source>Other Devices</source>
@@ -441,6 +382,13 @@
     </message>
     <message>
         <source>Balance Performance</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PluginItemWidget</name>
+    <message>
+        <source>Disconnect</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/plugins/dde-dock/translations/dde-dock_ady.ts
+++ b/plugins/dde-dock/translations/dde-dock_ady.ts
@@ -194,65 +194,6 @@
     </message>
 </context>
 <context>
-    <name>DatetimeWidget</name>
-    <message>
-        <source>Monday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Tuesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Wednesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Thursday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Friday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Saturday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sunday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>monday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>tuesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>wednesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>thursday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>friday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>saturday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>sunday</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>DeviceControlWidget</name>
     <message>
         <source>Other Devices</source>
@@ -445,6 +386,13 @@
     </message>
 </context>
 <context>
+    <name>PluginItemWidget</name>
+    <message>
+        <source>Disconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PowerApplet</name>
     <message>
         <source>Power</source>
@@ -543,6 +491,14 @@
     </message>
     <message>
         <source>Charging, %1 hr until full</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Capacity %1, charging protection active</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Charging protection active</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/plugins/dde-dock/translations/dde-dock_af.ts
+++ b/plugins/dde-dock/translations/dde-dock_af.ts
@@ -194,65 +194,6 @@
     </message>
 </context>
 <context>
-    <name>DatetimeWidget</name>
-    <message>
-        <source>Monday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Tuesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Wednesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Thursday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Friday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Saturday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sunday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>monday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>tuesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>wednesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>thursday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>friday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>saturday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>sunday</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>DeviceControlWidget</name>
     <message>
         <source>Other Devices</source>
@@ -445,6 +386,13 @@
     </message>
 </context>
 <context>
+    <name>PluginItemWidget</name>
+    <message>
+        <source>Disconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PowerApplet</name>
     <message>
         <source>Power</source>
@@ -543,6 +491,14 @@
     </message>
     <message>
         <source>Charging, %1 hr until full</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Capacity %1, charging protection active</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Charging protection active</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/plugins/dde-dock/translations/dde-dock_af_ZA.ts
+++ b/plugins/dde-dock/translations/dde-dock_af_ZA.ts
@@ -194,65 +194,6 @@
     </message>
 </context>
 <context>
-    <name>DatetimeWidget</name>
-    <message>
-        <source>Monday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Tuesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Wednesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Thursday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Friday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Saturday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sunday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>monday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>tuesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>wednesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>thursday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>friday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>saturday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>sunday</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>DeviceControlWidget</name>
     <message>
         <source>Other Devices</source>
@@ -445,6 +386,13 @@
     </message>
 </context>
 <context>
+    <name>PluginItemWidget</name>
+    <message>
+        <source>Disconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PowerApplet</name>
     <message>
         <source>Power</source>
@@ -543,6 +491,14 @@
     </message>
     <message>
         <source>Charging, %1 hr until full</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Capacity %1, charging protection active</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Charging protection active</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/plugins/dde-dock/translations/dde-dock_am.ts
+++ b/plugins/dde-dock/translations/dde-dock_am.ts
@@ -194,65 +194,6 @@
     </message>
 </context>
 <context>
-    <name>DatetimeWidget</name>
-    <message>
-        <source>Monday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Tuesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Wednesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Thursday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Friday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Saturday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sunday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>monday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>tuesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>wednesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>thursday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>friday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>saturday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>sunday</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>DeviceControlWidget</name>
     <message>
         <source>Other Devices</source>
@@ -445,6 +386,13 @@
     </message>
 </context>
 <context>
+    <name>PluginItemWidget</name>
+    <message>
+        <source>Disconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PowerApplet</name>
     <message>
         <source>Power</source>
@@ -543,6 +491,14 @@
     </message>
     <message>
         <source>Charging, %1 hr until full</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Capacity %1, charging protection active</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Charging protection active</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/plugins/dde-dock/translations/dde-dock_am_ET.ts
+++ b/plugins/dde-dock/translations/dde-dock_am_ET.ts
@@ -194,65 +194,6 @@
     </message>
 </context>
 <context>
-    <name>DatetimeWidget</name>
-    <message>
-        <source>Monday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Tuesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Wednesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Thursday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Friday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Saturday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sunday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>monday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>tuesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>wednesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>thursday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>friday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>saturday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>sunday</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>DeviceControlWidget</name>
     <message>
         <source>Other Devices</source>
@@ -445,6 +386,13 @@
     </message>
 </context>
 <context>
+    <name>PluginItemWidget</name>
+    <message>
+        <source>Disconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PowerApplet</name>
     <message>
         <source>Power</source>
@@ -543,6 +491,14 @@
     </message>
     <message>
         <source>Charging, %1 hr until full</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Capacity %1, charging protection active</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Charging protection active</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/plugins/dde-dock/translations/dde-dock_ar.ts
+++ b/plugins/dde-dock/translations/dde-dock_ar.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="ar">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ar">
 <context>
     <name>AirplaneModeItem</name>
     <message>
@@ -52,7 +54,7 @@
     </message>
     <message>
         <source>Disable [Airplane Mode](#) first if you want to connect to a Bluetooth</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -189,65 +191,6 @@
     <message>
         <source>Open the calendar</source>
         <translation>افتح التقويم</translation>
-    </message>
-</context>
-<context>
-    <name>DatetimeWidget</name>
-    <message>
-        <source>Monday</source>
-        <translation>الاثنين</translation>
-    </message>
-    <message>
-        <source>Tuesday</source>
-        <translation>الثلاثاء</translation>
-    </message>
-    <message>
-        <source>Wednesday</source>
-        <translation>الأربعاء</translation>
-    </message>
-    <message>
-        <source>Thursday</source>
-        <translation>الخميس</translation>
-    </message>
-    <message>
-        <source>Friday</source>
-        <translation>الجمعة</translation>
-    </message>
-    <message>
-        <source>Saturday</source>
-        <translation>السبت</translation>
-    </message>
-    <message>
-        <source>Sunday</source>
-        <translation>الأحد</translation>
-    </message>
-    <message>
-        <source>monday</source>
-        <translation>الاثنين</translation>
-    </message>
-    <message>
-        <source>tuesday</source>
-        <translation>الثلاثاء</translation>
-    </message>
-    <message>
-        <source>wednesday</source>
-        <translation>الأربعاء</translation>
-    </message>
-    <message>
-        <source>thursday</source>
-        <translation>الخميس</translation>
-    </message>
-    <message>
-        <source>friday</source>
-        <translation>جمعة</translation>
-    </message>
-    <message>
-        <source>saturday</source>
-        <translation>سبت</translation>
-    </message>
-    <message>
-        <source>sunday</source>
-        <translation>أحد</translation>
     </message>
 </context>
 <context>
@@ -443,6 +386,13 @@
     </message>
 </context>
 <context>
+    <name>PluginItemWidget</name>
+    <message>
+        <source>Disconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PowerApplet</name>
     <message>
         <source>Power</source>
@@ -545,11 +495,11 @@
     </message>
     <message>
         <source>Capacity %1, charging protection active</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Charging protection active</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/plugins/dde-dock/translations/dde-dock_ar_EG.ts
+++ b/plugins/dde-dock/translations/dde-dock_ar_EG.ts
@@ -194,65 +194,6 @@
     </message>
 </context>
 <context>
-    <name>DatetimeWidget</name>
-    <message>
-        <source>Monday</source>
-        <translation>الإثنين</translation>
-    </message>
-    <message>
-        <source>Tuesday</source>
-        <translation>الثلاثاء</translation>
-    </message>
-    <message>
-        <source>Wednesday</source>
-        <translation>ء</translation>
-    </message>
-    <message>
-        <source>Thursday</source>
-        <translation>الخميس</translation>
-    </message>
-    <message>
-        <source>Friday</source>
-        <translation>الجمعة</translation>
-    </message>
-    <message>
-        <source>Saturday</source>
-        <translation>السبت</translation>
-    </message>
-    <message>
-        <source>Sunday</source>
-        <translation>الأحد</translation>
-    </message>
-    <message>
-        <source>monday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>tuesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>wednesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>thursday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>friday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>saturday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>sunday</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>DeviceControlWidget</name>
     <message>
         <source>Other Devices</source>
@@ -445,6 +386,13 @@
     </message>
 </context>
 <context>
+    <name>PluginItemWidget</name>
+    <message>
+        <source>Disconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PowerApplet</name>
     <message>
         <source>Power</source>
@@ -543,6 +491,14 @@
     </message>
     <message>
         <source>Charging, %1 hr until full</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Capacity %1, charging protection active</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Charging protection active</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/plugins/dde-dock/translations/dde-dock_az.ts
+++ b/plugins/dde-dock/translations/dde-dock_az.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="az">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="az">
 <context>
     <name>AirplaneModeItem</name>
     <message>
@@ -52,7 +54,7 @@
     </message>
     <message>
         <source>Disable [Airplane Mode](#) first if you want to connect to a Bluetooth</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -189,65 +191,6 @@
     <message>
         <source>Open the calendar</source>
         <translation>Təqvimi açın</translation>
-    </message>
-</context>
-<context>
-    <name>DatetimeWidget</name>
-    <message>
-        <source>Monday</source>
-        <translation>Bazar ertəsi</translation>
-    </message>
-    <message>
-        <source>Tuesday</source>
-        <translation>Çərşənbə axşamı</translation>
-    </message>
-    <message>
-        <source>Wednesday</source>
-        <translation>Çərşənbə</translation>
-    </message>
-    <message>
-        <source>Thursday</source>
-        <translation>Cümə axşamı</translation>
-    </message>
-    <message>
-        <source>Friday</source>
-        <translation>Cümə</translation>
-    </message>
-    <message>
-        <source>Saturday</source>
-        <translation>Şənbə</translation>
-    </message>
-    <message>
-        <source>Sunday</source>
-        <translation>Bazar</translation>
-    </message>
-    <message>
-        <source>monday</source>
-        <translation>bazar ertəsi</translation>
-    </message>
-    <message>
-        <source>tuesday</source>
-        <translation>çərşənbə axşamı</translation>
-    </message>
-    <message>
-        <source>wednesday</source>
-        <translation>çərşənbə</translation>
-    </message>
-    <message>
-        <source>thursday</source>
-        <translation>cümə axşamı</translation>
-    </message>
-    <message>
-        <source>friday</source>
-        <translation>cümə</translation>
-    </message>
-    <message>
-        <source>saturday</source>
-        <translation>şənbə</translation>
-    </message>
-    <message>
-        <source>sunday</source>
-        <translation>bazar</translation>
     </message>
 </context>
 <context>
@@ -443,6 +386,13 @@
     </message>
 </context>
 <context>
+    <name>PluginItemWidget</name>
+    <message>
+        <source>Disconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PowerApplet</name>
     <message>
         <source>Power</source>
@@ -545,11 +495,11 @@
     </message>
     <message>
         <source>Capacity %1, charging protection active</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Charging protection active</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/plugins/dde-dock/translations/dde-dock_bg.ts
+++ b/plugins/dde-dock/translations/dde-dock_bg.ts
@@ -194,65 +194,6 @@
     </message>
 </context>
 <context>
-    <name>DatetimeWidget</name>
-    <message>
-        <source>Monday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Tuesday</source>
-        <translation>Вторник</translation>
-    </message>
-    <message>
-        <source>Wednesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Thursday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Friday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Saturday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sunday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>monday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>tuesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>wednesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>thursday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>friday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>saturday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>sunday</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>DeviceControlWidget</name>
     <message>
         <source>Other Devices</source>
@@ -445,6 +386,13 @@
     </message>
 </context>
 <context>
+    <name>PluginItemWidget</name>
+    <message>
+        <source>Disconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PowerApplet</name>
     <message>
         <source>Power</source>
@@ -543,6 +491,14 @@
     </message>
     <message>
         <source>Charging, %1 hr until full</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Capacity %1, charging protection active</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Charging protection active</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/plugins/dde-dock/translations/dde-dock_bn.ts
+++ b/plugins/dde-dock/translations/dde-dock_bn.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="bn">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="bn">
 <context>
     <name>AirplaneModeItem</name>
     <message>
@@ -52,7 +54,7 @@
     </message>
     <message>
         <source>Disable [Airplane Mode](#) first if you want to connect to a Bluetooth</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -189,65 +191,6 @@
     <message>
         <source>Open the calendar</source>
         <translation>ক্যালেনダー খুলুন</translation>
-    </message>
-</context>
-<context>
-    <name>DatetimeWidget</name>
-    <message>
-        <source>Monday</source>
-        <translation>মঙ্গলবার</translation>
-    </message>
-    <message>
-        <source>Tuesday</source>
-        <translation>বুধবার</translation>
-    </message>
-    <message>
-        <source>Wednesday</source>
-        <translation>বৃহস্পতিবার</translation>
-    </message>
-    <message>
-        <source>Thursday</source>
-        <translation>শুক্রবার</translation>
-    </message>
-    <message>
-        <source>Friday</source>
-        <translation>শনিবার</translation>
-    </message>
-    <message>
-        <source>Saturday</source>
-        <translation>শনিবার</translation>
-    </message>
-    <message>
-        <source>Sunday</source>
-        <translation>রবিবার</translation>
-    </message>
-    <message>
-        <source>monday</source>
-        <translation>মঙ্গলবার</translation>
-    </message>
-    <message>
-        <source>tuesday</source>
-        <translation>বুধবার</translation>
-    </message>
-    <message>
-        <source>wednesday</source>
-        <translation>বৃহস্পতিবার</translation>
-    </message>
-    <message>
-        <source>thursday</source>
-        <translation>শুক্রবার</translation>
-    </message>
-    <message>
-        <source>friday</source>
-        <translation>শনিবার</translation>
-    </message>
-    <message>
-        <source>saturday</source>
-        <translation>শনিবার</translation>
-    </message>
-    <message>
-        <source>sunday</source>
-        <translation>রবিবার</translation>
     </message>
 </context>
 <context>
@@ -443,6 +386,13 @@
     </message>
 </context>
 <context>
+    <name>PluginItemWidget</name>
+    <message>
+        <source>Disconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PowerApplet</name>
     <message>
         <source>Power</source>
@@ -545,18 +495,18 @@
     </message>
     <message>
         <source>Capacity %1, charging protection active</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Charging protection active</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>PowerStatusWidget</name>
     <message>
         <source>Power settings</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">পাওয়ার সেটিংস</translation>
     </message>
 </context>
 <context>

--- a/plugins/dde-dock/translations/dde-dock_bo.ts
+++ b/plugins/dde-dock/translations/dde-dock_bo.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="bo">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="bo">
 <context>
     <name>AirplaneModeItem</name>
     <message>
@@ -52,7 +54,7 @@
     </message>
     <message>
         <source>Disable [Airplane Mode](#) first if you want to connect to a Bluetooth</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -189,65 +191,6 @@
     <message>
         <source>Open the calendar</source>
         <translation>ལོ་ཐོ་ལྟ་བ།</translation>
-    </message>
-</context>
-<context>
-    <name>DatetimeWidget</name>
-    <message>
-        <source>Monday</source>
-        <translation>གཟའ་ཟླ་བ།</translation>
-    </message>
-    <message>
-        <source>Tuesday</source>
-        <translation>གཟའ་མིག་དམར།</translation>
-    </message>
-    <message>
-        <source>Wednesday</source>
-        <translation>གཟའ་ལྷག་པ།</translation>
-    </message>
-    <message>
-        <source>Thursday</source>
-        <translation>གཟའ་ཕུར་བུ།</translation>
-    </message>
-    <message>
-        <source>Friday</source>
-        <translation>གཟའ་པ་སངས།</translation>
-    </message>
-    <message>
-        <source>Saturday</source>
-        <translation>གཟའ་སྤེན་པ།</translation>
-    </message>
-    <message>
-        <source>Sunday</source>
-        <translation>གཟའ་ཉི་མ།</translation>
-    </message>
-    <message>
-        <source>monday</source>
-        <translation>གཟའ་ཟླ་བ། </translation>
-    </message>
-    <message>
-        <source>tuesday</source>
-        <translation>གཟའ་མིག་དམར།</translation>
-    </message>
-    <message>
-        <source>wednesday</source>
-        <translation>གཟའ་ལྷག་པ།</translation>
-    </message>
-    <message>
-        <source>thursday</source>
-        <translation>གཟའ་ཕུར་བུ།</translation>
-    </message>
-    <message>
-        <source>friday</source>
-        <translation>གཟའ་པ་སངས།</translation>
-    </message>
-    <message>
-        <source>saturday</source>
-        <translation>གཟའ་སྤེན་པ།</translation>
-    </message>
-    <message>
-        <source>sunday</source>
-        <translation>གཟའ་ཉི་མ།</translation>
     </message>
 </context>
 <context>
@@ -439,7 +382,14 @@
     </message>
     <message>
         <source>Balance Performance</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PluginItemWidget</name>
+    <message>
+        <source>Disconnect</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -545,11 +495,11 @@
     </message>
     <message>
         <source>Capacity %1, charging protection active</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Charging protection active</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/plugins/dde-dock/translations/dde-dock_br.ts
+++ b/plugins/dde-dock/translations/dde-dock_br.ts
@@ -194,65 +194,6 @@
     </message>
 </context>
 <context>
-    <name>DatetimeWidget</name>
-    <message>
-        <source>Monday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Tuesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Wednesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Thursday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Friday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Saturday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sunday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>monday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>tuesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>wednesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>thursday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>friday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>saturday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>sunday</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>DeviceControlWidget</name>
     <message>
         <source>Other Devices</source>
@@ -445,6 +386,13 @@
     </message>
 </context>
 <context>
+    <name>PluginItemWidget</name>
+    <message>
+        <source>Disconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PowerApplet</name>
     <message>
         <source>Power</source>
@@ -543,6 +491,14 @@
     </message>
     <message>
         <source>Charging, %1 hr until full</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Capacity %1, charging protection active</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Charging protection active</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/plugins/dde-dock/translations/dde-dock_ca.ts
+++ b/plugins/dde-dock/translations/dde-dock_ca.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="ca">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ca">
 <context>
     <name>AirplaneModeItem</name>
     <message>
@@ -192,65 +194,6 @@
     </message>
 </context>
 <context>
-    <name>DatetimeWidget</name>
-    <message>
-        <source>Monday</source>
-        <translation>Dilluns</translation>
-    </message>
-    <message>
-        <source>Tuesday</source>
-        <translation>Dimarts</translation>
-    </message>
-    <message>
-        <source>Wednesday</source>
-        <translation>Dimecres</translation>
-    </message>
-    <message>
-        <source>Thursday</source>
-        <translation>Dijous</translation>
-    </message>
-    <message>
-        <source>Friday</source>
-        <translation>Divendres</translation>
-    </message>
-    <message>
-        <source>Saturday</source>
-        <translation>Dissabte</translation>
-    </message>
-    <message>
-        <source>Sunday</source>
-        <translation>Diumenge</translation>
-    </message>
-    <message>
-        <source>monday</source>
-        <translation>dilluns</translation>
-    </message>
-    <message>
-        <source>tuesday</source>
-        <translation>dimarts</translation>
-    </message>
-    <message>
-        <source>wednesday</source>
-        <translation>dimecres</translation>
-    </message>
-    <message>
-        <source>thursday</source>
-        <translation>dijous</translation>
-    </message>
-    <message>
-        <source>friday</source>
-        <translation>divendres</translation>
-    </message>
-    <message>
-        <source>saturday</source>
-        <translation>dissabte</translation>
-    </message>
-    <message>
-        <source>sunday</source>
-        <translation>diumenge</translation>
-    </message>
-</context>
-<context>
     <name>DeviceControlWidget</name>
     <message>
         <source>Other Devices</source>
@@ -440,6 +383,13 @@
     <message>
         <source>Balance Performance</source>
         <translation>Equilibratge del rendiment</translation>
+    </message>
+</context>
+<context>
+    <name>PluginItemWidget</name>
+    <message>
+        <source>Disconnect</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/plugins/dde-dock/translations/dde-dock_cgg.ts
+++ b/plugins/dde-dock/translations/dde-dock_cgg.ts
@@ -194,65 +194,6 @@
     </message>
 </context>
 <context>
-    <name>DatetimeWidget</name>
-    <message>
-        <source>Monday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Tuesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Wednesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Thursday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Friday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Saturday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sunday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>monday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>tuesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>wednesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>thursday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>friday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>saturday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>sunday</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>DeviceControlWidget</name>
     <message>
         <source>Other Devices</source>
@@ -445,6 +386,13 @@
     </message>
 </context>
 <context>
+    <name>PluginItemWidget</name>
+    <message>
+        <source>Disconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PowerApplet</name>
     <message>
         <source>Power</source>
@@ -543,6 +491,14 @@
     </message>
     <message>
         <source>Charging, %1 hr until full</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Capacity %1, charging protection active</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Charging protection active</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/plugins/dde-dock/translations/dde-dock_cs.ts
+++ b/plugins/dde-dock/translations/dde-dock_cs.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="cs">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="cs">
 <context>
     <name>AirplaneModeItem</name>
     <message>
@@ -52,7 +54,7 @@
     </message>
     <message>
         <source>Disable [Airplane Mode](#) first if you want to connect to a Bluetooth</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -189,65 +191,6 @@
     <message>
         <source>Open the calendar</source>
         <translation>Otevřít kalendář</translation>
-    </message>
-</context>
-<context>
-    <name>DatetimeWidget</name>
-    <message>
-        <source>Monday</source>
-        <translation>pondělí</translation>
-    </message>
-    <message>
-        <source>Tuesday</source>
-        <translation>úterý</translation>
-    </message>
-    <message>
-        <source>Wednesday</source>
-        <translation>středa</translation>
-    </message>
-    <message>
-        <source>Thursday</source>
-        <translation>čtvrtek</translation>
-    </message>
-    <message>
-        <source>Friday</source>
-        <translation>pátek</translation>
-    </message>
-    <message>
-        <source>Saturday</source>
-        <translation>sobota</translation>
-    </message>
-    <message>
-        <source>Sunday</source>
-        <translation>neděle</translation>
-    </message>
-    <message>
-        <source>monday</source>
-        <translation>pondělí</translation>
-    </message>
-    <message>
-        <source>tuesday</source>
-        <translation>úterý</translation>
-    </message>
-    <message>
-        <source>wednesday</source>
-        <translation>středa</translation>
-    </message>
-    <message>
-        <source>thursday</source>
-        <translation>čtvrtek</translation>
-    </message>
-    <message>
-        <source>friday</source>
-        <translation>pátek</translation>
-    </message>
-    <message>
-        <source>saturday</source>
-        <translation>sobota</translation>
-    </message>
-    <message>
-        <source>sunday</source>
-        <translation>neděle</translation>
     </message>
 </context>
 <context>
@@ -389,27 +332,27 @@
     <name>NotificationPlugin</name>
     <message>
         <source>No messages</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Notification settings</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Notifications</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Turn off DND mode</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Turn on DND mode</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Notification</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -439,7 +382,14 @@
     </message>
     <message>
         <source>Balance Performance</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PluginItemWidget</name>
+    <message>
+        <source>Disconnect</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -549,7 +499,7 @@
     </message>
     <message>
         <source>Charging protection active</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/plugins/dde-dock/translations/dde-dock_da.ts
+++ b/plugins/dde-dock/translations/dde-dock_da.ts
@@ -194,65 +194,6 @@
     </message>
 </context>
 <context>
-    <name>DatetimeWidget</name>
-    <message>
-        <source>Monday</source>
-        <translation>Mandag</translation>
-    </message>
-    <message>
-        <source>Tuesday</source>
-        <translation>Tirsdag</translation>
-    </message>
-    <message>
-        <source>Wednesday</source>
-        <translation>Onsdag</translation>
-    </message>
-    <message>
-        <source>Thursday</source>
-        <translation>Torsdag</translation>
-    </message>
-    <message>
-        <source>Friday</source>
-        <translation>Fredag</translation>
-    </message>
-    <message>
-        <source>Saturday</source>
-        <translation>Lørdag</translation>
-    </message>
-    <message>
-        <source>Sunday</source>
-        <translation>Søndag</translation>
-    </message>
-    <message>
-        <source>monday</source>
-        <translation>mandag</translation>
-    </message>
-    <message>
-        <source>tuesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>wednesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>thursday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>friday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>saturday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>sunday</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>DeviceControlWidget</name>
     <message>
         <source>Other Devices</source>
@@ -445,6 +386,13 @@
     </message>
 </context>
 <context>
+    <name>PluginItemWidget</name>
+    <message>
+        <source>Disconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PowerApplet</name>
     <message>
         <source>Power</source>
@@ -543,6 +491,14 @@
     </message>
     <message>
         <source>Charging, %1 hr until full</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Capacity %1, charging protection active</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Charging protection active</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/plugins/dde-dock/translations/dde-dock_de.ts
+++ b/plugins/dde-dock/translations/dde-dock_de.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="de">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="de">
 <context>
     <name>AirplaneModeItem</name>
     <message>
@@ -52,7 +54,7 @@
     </message>
     <message>
         <source>Disable [Airplane Mode](#) first if you want to connect to a Bluetooth</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -189,65 +191,6 @@
     <message>
         <source>Open the calendar</source>
         <translation>Kalender öffnen</translation>
-    </message>
-</context>
-<context>
-    <name>DatetimeWidget</name>
-    <message>
-        <source>Monday</source>
-        <translation>Montag</translation>
-    </message>
-    <message>
-        <source>Tuesday</source>
-        <translation>Dienstag</translation>
-    </message>
-    <message>
-        <source>Wednesday</source>
-        <translation>Mittwoch</translation>
-    </message>
-    <message>
-        <source>Thursday</source>
-        <translation>Donnerstag</translation>
-    </message>
-    <message>
-        <source>Friday</source>
-        <translation>Freitag</translation>
-    </message>
-    <message>
-        <source>Saturday</source>
-        <translation>Samstag</translation>
-    </message>
-    <message>
-        <source>Sunday</source>
-        <translation>Sonntag</translation>
-    </message>
-    <message>
-        <source>monday</source>
-        <translation>Montag</translation>
-    </message>
-    <message>
-        <source>tuesday</source>
-        <translation>Dienstag</translation>
-    </message>
-    <message>
-        <source>wednesday</source>
-        <translation>Mittwoch</translation>
-    </message>
-    <message>
-        <source>thursday</source>
-        <translation>Donnerstag</translation>
-    </message>
-    <message>
-        <source>friday</source>
-        <translation>Freitag</translation>
-    </message>
-    <message>
-        <source>saturday</source>
-        <translation>Samstag</translation>
-    </message>
-    <message>
-        <source>sunday</source>
-        <translation>Sonntag</translation>
     </message>
 </context>
 <context>
@@ -439,14 +382,21 @@
     </message>
     <message>
         <source>Balance Performance</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PluginItemWidget</name>
+    <message>
+        <source>Disconnect</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>PowerApplet</name>
     <message>
         <source>Power</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -545,11 +495,11 @@
     </message>
     <message>
         <source>Capacity %1, charging protection active</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Charging protection active</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -756,7 +706,7 @@
     </message>
     <message>
         <source>Output</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Sound settings</source>

--- a/plugins/dde-dock/translations/dde-dock_el.ts
+++ b/plugins/dde-dock/translations/dde-dock_el.ts
@@ -194,65 +194,6 @@
     </message>
 </context>
 <context>
-    <name>DatetimeWidget</name>
-    <message>
-        <source>Monday</source>
-        <translation>Δευτέρα</translation>
-    </message>
-    <message>
-        <source>Tuesday</source>
-        <translation>Τρίτη</translation>
-    </message>
-    <message>
-        <source>Wednesday</source>
-        <translation>Τετάρτη</translation>
-    </message>
-    <message>
-        <source>Thursday</source>
-        <translation>Πέμπτη</translation>
-    </message>
-    <message>
-        <source>Friday</source>
-        <translation>Παρασκευή</translation>
-    </message>
-    <message>
-        <source>Saturday</source>
-        <translation>Σάββατο</translation>
-    </message>
-    <message>
-        <source>Sunday</source>
-        <translation>Κυριακή</translation>
-    </message>
-    <message>
-        <source>monday</source>
-        <translation>Δευτέρα</translation>
-    </message>
-    <message>
-        <source>tuesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>wednesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>thursday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>friday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>saturday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>sunday</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>DeviceControlWidget</name>
     <message>
         <source>Other Devices</source>
@@ -445,6 +386,13 @@
     </message>
 </context>
 <context>
+    <name>PluginItemWidget</name>
+    <message>
+        <source>Disconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PowerApplet</name>
     <message>
         <source>Power</source>
@@ -543,6 +491,14 @@
     </message>
     <message>
         <source>Charging, %1 hr until full</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Capacity %1, charging protection active</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Charging protection active</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/plugins/dde-dock/translations/dde-dock_el_GR.ts
+++ b/plugins/dde-dock/translations/dde-dock_el_GR.ts
@@ -194,65 +194,6 @@
     </message>
 </context>
 <context>
-    <name>DatetimeWidget</name>
-    <message>
-        <source>Monday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Tuesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Wednesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Thursday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Friday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Saturday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sunday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>monday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>tuesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>wednesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>thursday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>friday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>saturday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>sunday</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>DeviceControlWidget</name>
     <message>
         <source>Other Devices</source>
@@ -445,6 +386,13 @@
     </message>
 </context>
 <context>
+    <name>PluginItemWidget</name>
+    <message>
+        <source>Disconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PowerApplet</name>
     <message>
         <source>Power</source>
@@ -543,6 +491,14 @@
     </message>
     <message>
         <source>Charging, %1 hr until full</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Capacity %1, charging protection active</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Charging protection active</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/plugins/dde-dock/translations/dde-dock_en_AU.ts
+++ b/plugins/dde-dock/translations/dde-dock_en_AU.ts
@@ -194,65 +194,6 @@
     </message>
 </context>
 <context>
-    <name>DatetimeWidget</name>
-    <message>
-        <source>Monday</source>
-        <translation>Monday</translation>
-    </message>
-    <message>
-        <source>Tuesday</source>
-        <translation>Tuesday</translation>
-    </message>
-    <message>
-        <source>Wednesday</source>
-        <translation>Wednesday</translation>
-    </message>
-    <message>
-        <source>Thursday</source>
-        <translation>Thursday</translation>
-    </message>
-    <message>
-        <source>Friday</source>
-        <translation>Friday</translation>
-    </message>
-    <message>
-        <source>Saturday</source>
-        <translation>Saturday</translation>
-    </message>
-    <message>
-        <source>Sunday</source>
-        <translation>Sunday</translation>
-    </message>
-    <message>
-        <source>monday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>tuesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>wednesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>thursday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>friday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>saturday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>sunday</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>DeviceControlWidget</name>
     <message>
         <source>Other Devices</source>
@@ -445,6 +386,13 @@
     </message>
 </context>
 <context>
+    <name>PluginItemWidget</name>
+    <message>
+        <source>Disconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PowerApplet</name>
     <message>
         <source>Power</source>
@@ -543,6 +491,14 @@
     </message>
     <message>
         <source>Charging, %1 hr until full</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Capacity %1, charging protection active</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Charging protection active</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/plugins/dde-dock/translations/dde-dock_en_GB.ts
+++ b/plugins/dde-dock/translations/dde-dock_en_GB.ts
@@ -194,65 +194,6 @@
     </message>
 </context>
 <context>
-    <name>DatetimeWidget</name>
-    <message>
-        <source>Monday</source>
-        <translation>Monday</translation>
-    </message>
-    <message>
-        <source>Tuesday</source>
-        <translation>Tuesday</translation>
-    </message>
-    <message>
-        <source>Wednesday</source>
-        <translation>Wednesday</translation>
-    </message>
-    <message>
-        <source>Thursday</source>
-        <translation>Thursday</translation>
-    </message>
-    <message>
-        <source>Friday</source>
-        <translation>Friday</translation>
-    </message>
-    <message>
-        <source>Saturday</source>
-        <translation>Saturday</translation>
-    </message>
-    <message>
-        <source>Sunday</source>
-        <translation>Sunday</translation>
-    </message>
-    <message>
-        <source>monday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>tuesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>wednesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>thursday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>friday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>saturday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>sunday</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>DeviceControlWidget</name>
     <message>
         <source>Other Devices</source>
@@ -445,6 +386,13 @@
     </message>
 </context>
 <context>
+    <name>PluginItemWidget</name>
+    <message>
+        <source>Disconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PowerApplet</name>
     <message>
         <source>Power</source>
@@ -543,6 +491,14 @@
     </message>
     <message>
         <source>Charging, %1 hr until full</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Capacity %1, charging protection active</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Charging protection active</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/plugins/dde-dock/translations/dde-dock_en_NO.ts
+++ b/plugins/dde-dock/translations/dde-dock_en_NO.ts
@@ -194,65 +194,6 @@
     </message>
 </context>
 <context>
-    <name>DatetimeWidget</name>
-    <message>
-        <source>Monday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Tuesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Wednesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Thursday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Friday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Saturday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sunday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>monday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>tuesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>wednesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>thursday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>friday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>saturday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>sunday</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>DeviceControlWidget</name>
     <message>
         <source>Other Devices</source>
@@ -445,6 +386,13 @@
     </message>
 </context>
 <context>
+    <name>PluginItemWidget</name>
+    <message>
+        <source>Disconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PowerApplet</name>
     <message>
         <source>Power</source>
@@ -543,6 +491,14 @@
     </message>
     <message>
         <source>Charging, %1 hr until full</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Capacity %1, charging protection active</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Charging protection active</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/plugins/dde-dock/translations/dde-dock_en_US.ts
+++ b/plugins/dde-dock/translations/dde-dock_en_US.ts
@@ -194,65 +194,6 @@
     </message>
 </context>
 <context>
-    <name>DatetimeWidget</name>
-    <message>
-        <source>Monday</source>
-        <translation>Monday</translation>
-    </message>
-    <message>
-        <source>Tuesday</source>
-        <translation>Tuesday</translation>
-    </message>
-    <message>
-        <source>Wednesday</source>
-        <translation>Wednesday</translation>
-    </message>
-    <message>
-        <source>Thursday</source>
-        <translation>Thursday</translation>
-    </message>
-    <message>
-        <source>Friday</source>
-        <translation>Friday</translation>
-    </message>
-    <message>
-        <source>Saturday</source>
-        <translation>Saturday</translation>
-    </message>
-    <message>
-        <source>Sunday</source>
-        <translation>Sunday</translation>
-    </message>
-    <message>
-        <source>monday</source>
-        <translation>monday</translation>
-    </message>
-    <message>
-        <source>tuesday</source>
-        <translation>tuesday</translation>
-    </message>
-    <message>
-        <source>wednesday</source>
-        <translation>wednesday</translation>
-    </message>
-    <message>
-        <source>thursday</source>
-        <translation>thursday</translation>
-    </message>
-    <message>
-        <source>friday</source>
-        <translation>friday</translation>
-    </message>
-    <message>
-        <source>saturday</source>
-        <translation>saturday</translation>
-    </message>
-    <message>
-        <source>sunday</source>
-        <translation>sunday</translation>
-    </message>
-</context>
-<context>
     <name>DeviceControlWidget</name>
     <message>
         <source>Other Devices</source>
@@ -445,6 +386,13 @@
     </message>
 </context>
 <context>
+    <name>PluginItemWidget</name>
+    <message>
+        <source>Disconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PowerApplet</name>
     <message>
         <source>Power</source>
@@ -543,6 +491,14 @@
     </message>
     <message>
         <source>Charging, %1 hr until full</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Capacity %1, charging protection active</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Charging protection active</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/plugins/dde-dock/translations/dde-dock_eo.ts
+++ b/plugins/dde-dock/translations/dde-dock_eo.ts
@@ -194,65 +194,6 @@
     </message>
 </context>
 <context>
-    <name>DatetimeWidget</name>
-    <message>
-        <source>Monday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Tuesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Wednesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Thursday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Friday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Saturday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sunday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>monday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>tuesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>wednesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>thursday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>friday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>saturday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>sunday</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>DeviceControlWidget</name>
     <message>
         <source>Other Devices</source>
@@ -445,6 +386,13 @@
     </message>
 </context>
 <context>
+    <name>PluginItemWidget</name>
+    <message>
+        <source>Disconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PowerApplet</name>
     <message>
         <source>Power</source>
@@ -543,6 +491,14 @@
     </message>
     <message>
         <source>Charging, %1 hr until full</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Capacity %1, charging protection active</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Charging protection active</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/plugins/dde-dock/translations/dde-dock_es.ts
+++ b/plugins/dde-dock/translations/dde-dock_es.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="es">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="es">
 <context>
     <name>AirplaneModeItem</name>
     <message>
@@ -192,65 +194,6 @@
     </message>
 </context>
 <context>
-    <name>DatetimeWidget</name>
-    <message>
-        <source>Monday</source>
-        <translation>Lunes</translation>
-    </message>
-    <message>
-        <source>Tuesday</source>
-        <translation>Martes</translation>
-    </message>
-    <message>
-        <source>Wednesday</source>
-        <translation>Miércoles</translation>
-    </message>
-    <message>
-        <source>Thursday</source>
-        <translation>Jueves</translation>
-    </message>
-    <message>
-        <source>Friday</source>
-        <translation>Viernes</translation>
-    </message>
-    <message>
-        <source>Saturday</source>
-        <translation>Sábado</translation>
-    </message>
-    <message>
-        <source>Sunday</source>
-        <translation>Domingo</translation>
-    </message>
-    <message>
-        <source>monday</source>
-        <translation>lunes</translation>
-    </message>
-    <message>
-        <source>tuesday</source>
-        <translation>martes</translation>
-    </message>
-    <message>
-        <source>wednesday</source>
-        <translation>miércoles</translation>
-    </message>
-    <message>
-        <source>thursday</source>
-        <translation>jueves</translation>
-    </message>
-    <message>
-        <source>friday</source>
-        <translation>viernes</translation>
-    </message>
-    <message>
-        <source>saturday</source>
-        <translation>sábado</translation>
-    </message>
-    <message>
-        <source>sunday</source>
-        <translation>domingo</translation>
-    </message>
-</context>
-<context>
     <name>DeviceControlWidget</name>
     <message>
         <source>Other Devices</source>
@@ -440,6 +383,13 @@
     <message>
         <source>Balance Performance</source>
         <translation>Rendimiento equilibrado</translation>
+    </message>
+</context>
+<context>
+    <name>PluginItemWidget</name>
+    <message>
+        <source>Disconnect</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/plugins/dde-dock/translations/dde-dock_et.ts
+++ b/plugins/dde-dock/translations/dde-dock_et.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="et">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="et">
 <context>
     <name>AirplaneModeItem</name>
     <message>
@@ -52,7 +54,7 @@
     </message>
     <message>
         <source>Disable [Airplane Mode](#) first if you want to connect to a Bluetooth</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -189,65 +191,6 @@
     <message>
         <source>Open the calendar</source>
         <translation>Ava kalender</translation>
-    </message>
-</context>
-<context>
-    <name>DatetimeWidget</name>
-    <message>
-        <source>Monday</source>
-        <translation>Esmaspäev</translation>
-    </message>
-    <message>
-        <source>Tuesday</source>
-        <translation>Teisipäev</translation>
-    </message>
-    <message>
-        <source>Wednesday</source>
-        <translation>Kolmapäev</translation>
-    </message>
-    <message>
-        <source>Thursday</source>
-        <translation>Neljapäev</translation>
-    </message>
-    <message>
-        <source>Friday</source>
-        <translation>Reede</translation>
-    </message>
-    <message>
-        <source>Saturday</source>
-        <translation>Laupäev</translation>
-    </message>
-    <message>
-        <source>Sunday</source>
-        <translation>Pühapäev</translation>
-    </message>
-    <message>
-        <source>monday</source>
-        <translation>Esmaspäev</translation>
-    </message>
-    <message>
-        <source>tuesday</source>
-        <translation>Teisipaev</translation>
-    </message>
-    <message>
-        <source>wednesday</source>
-        <translation>Kuupaev</translation>
-    </message>
-    <message>
-        <source>thursday</source>
-        <translation>Reede</translation>
-    </message>
-    <message>
-        <source>friday</source>
-        <translation>Laupäev</translation>
-    </message>
-    <message>
-        <source>saturday</source>
-        <translation>Pühapäev</translation>
-    </message>
-    <message>
-        <source>sunday</source>
-        <translation>Esmaspäev</translation>
     </message>
 </context>
 <context>
@@ -443,6 +386,13 @@
     </message>
 </context>
 <context>
+    <name>PluginItemWidget</name>
+    <message>
+        <source>Disconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PowerApplet</name>
     <message>
         <source>Power</source>
@@ -545,11 +495,11 @@
     </message>
     <message>
         <source>Capacity %1, charging protection active</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Charging protection active</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -641,27 +591,27 @@
     </message>
     <message>
         <source>Monday</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Esmaspäev</translation>
     </message>
     <message>
         <source>Tuesday</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Teisipäev</translation>
     </message>
     <message>
         <source>Wednesday</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Kolmapäev</translation>
     </message>
     <message>
         <source>Thursday</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Neljapäev</translation>
     </message>
     <message>
         <source>Friday</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Reede</translation>
     </message>
     <message>
         <source>Saturday</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Laupäev</translation>
     </message>
     <message>
         <source>Sunday</source>

--- a/plugins/dde-dock/translations/dde-dock_eu.ts
+++ b/plugins/dde-dock/translations/dde-dock_eu.ts
@@ -194,65 +194,6 @@
     </message>
 </context>
 <context>
-    <name>DatetimeWidget</name>
-    <message>
-        <source>Monday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Tuesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Wednesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Thursday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Friday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Saturday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sunday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>monday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>tuesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>wednesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>thursday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>friday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>saturday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>sunday</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>DeviceControlWidget</name>
     <message>
         <source>Other Devices</source>
@@ -445,6 +386,13 @@
     </message>
 </context>
 <context>
+    <name>PluginItemWidget</name>
+    <message>
+        <source>Disconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PowerApplet</name>
     <message>
         <source>Power</source>
@@ -543,6 +491,14 @@
     </message>
     <message>
         <source>Charging, %1 hr until full</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Capacity %1, charging protection active</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Charging protection active</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/plugins/dde-dock/translations/dde-dock_fa.ts
+++ b/plugins/dde-dock/translations/dde-dock_fa.ts
@@ -194,65 +194,6 @@
     </message>
 </context>
 <context>
-    <name>DatetimeWidget</name>
-    <message>
-        <source>Monday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Tuesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Wednesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Thursday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Friday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Saturday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sunday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>monday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>tuesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>wednesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>thursday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>friday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>saturday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>sunday</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>DeviceControlWidget</name>
     <message>
         <source>Other Devices</source>
@@ -445,6 +386,13 @@
     </message>
 </context>
 <context>
+    <name>PluginItemWidget</name>
+    <message>
+        <source>Disconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PowerApplet</name>
     <message>
         <source>Power</source>
@@ -543,6 +491,14 @@
     </message>
     <message>
         <source>Charging, %1 hr until full</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Capacity %1, charging protection active</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Charging protection active</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/plugins/dde-dock/translations/dde-dock_fi.ts
+++ b/plugins/dde-dock/translations/dde-dock_fi.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="fi">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="fi">
 <context>
     <name>AirplaneModeItem</name>
     <message>
@@ -192,65 +194,6 @@
     </message>
 </context>
 <context>
-    <name>DatetimeWidget</name>
-    <message>
-        <source>Monday</source>
-        <translation>Maanantai</translation>
-    </message>
-    <message>
-        <source>Tuesday</source>
-        <translation>Tiistai</translation>
-    </message>
-    <message>
-        <source>Wednesday</source>
-        <translation>Keskiviikko</translation>
-    </message>
-    <message>
-        <source>Thursday</source>
-        <translation>Torstai</translation>
-    </message>
-    <message>
-        <source>Friday</source>
-        <translation>Perjantai</translation>
-    </message>
-    <message>
-        <source>Saturday</source>
-        <translation>Lauantai</translation>
-    </message>
-    <message>
-        <source>Sunday</source>
-        <translation>Sunnuntai</translation>
-    </message>
-    <message>
-        <source>monday</source>
-        <translation>maanantai</translation>
-    </message>
-    <message>
-        <source>tuesday</source>
-        <translation>tiistai</translation>
-    </message>
-    <message>
-        <source>wednesday</source>
-        <translation>keskiviikko</translation>
-    </message>
-    <message>
-        <source>thursday</source>
-        <translation>torstai</translation>
-    </message>
-    <message>
-        <source>friday</source>
-        <translation>perjantai</translation>
-    </message>
-    <message>
-        <source>saturday</source>
-        <translation>lauantai</translation>
-    </message>
-    <message>
-        <source>sunday</source>
-        <translation>sunnuntai</translation>
-    </message>
-</context>
-<context>
     <name>DeviceControlWidget</name>
     <message>
         <source>Other Devices</source>
@@ -440,6 +383,13 @@
     <message>
         <source>Balance Performance</source>
         <translation>Tasapainoinen suoritusteho</translation>
+    </message>
+</context>
+<context>
+    <name>PluginItemWidget</name>
+    <message>
+        <source>Disconnect</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/plugins/dde-dock/translations/dde-dock_fil.ts
+++ b/plugins/dde-dock/translations/dde-dock_fil.ts
@@ -194,65 +194,6 @@
     </message>
 </context>
 <context>
-    <name>DatetimeWidget</name>
-    <message>
-        <source>Monday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Tuesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Wednesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Thursday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Friday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Saturday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sunday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>monday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>tuesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>wednesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>thursday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>friday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>saturday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>sunday</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>DeviceControlWidget</name>
     <message>
         <source>Other Devices</source>
@@ -445,6 +386,13 @@
     </message>
 </context>
 <context>
+    <name>PluginItemWidget</name>
+    <message>
+        <source>Disconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PowerApplet</name>
     <message>
         <source>Power</source>
@@ -543,6 +491,14 @@
     </message>
     <message>
         <source>Charging, %1 hr until full</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Capacity %1, charging protection active</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Charging protection active</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/plugins/dde-dock/translations/dde-dock_fr.ts
+++ b/plugins/dde-dock/translations/dde-dock_fr.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="fr">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="fr">
 <context>
     <name>AirplaneModeItem</name>
     <message>
@@ -189,65 +191,6 @@
     <message>
         <source>Open the calendar</source>
         <translation>Ouvrir le calendrier</translation>
-    </message>
-</context>
-<context>
-    <name>DatetimeWidget</name>
-    <message>
-        <source>Monday</source>
-        <translation>Lundi</translation>
-    </message>
-    <message>
-        <source>Tuesday</source>
-        <translation>Mardi</translation>
-    </message>
-    <message>
-        <source>Wednesday</source>
-        <translation>Mercredi</translation>
-    </message>
-    <message>
-        <source>Thursday</source>
-        <translation>Jeudi</translation>
-    </message>
-    <message>
-        <source>Friday</source>
-        <translation>Vendredi</translation>
-    </message>
-    <message>
-        <source>Saturday</source>
-        <translation>Samedi</translation>
-    </message>
-    <message>
-        <source>Sunday</source>
-        <translation>Dimanche</translation>
-    </message>
-    <message>
-        <source>monday</source>
-        <translation>lundi</translation>
-    </message>
-    <message>
-        <source>tuesday</source>
-        <translation>mardi</translation>
-    </message>
-    <message>
-        <source>wednesday</source>
-        <translation>mercredi</translation>
-    </message>
-    <message>
-        <source>thursday</source>
-        <translation>jeudi</translation>
-    </message>
-    <message>
-        <source>friday</source>
-        <translation>vendredi</translation>
-    </message>
-    <message>
-        <source>saturday</source>
-        <translation>samedi</translation>
-    </message>
-    <message>
-        <source>sunday</source>
-        <translation>dimanche</translation>
     </message>
 </context>
 <context>
@@ -443,6 +386,13 @@
     </message>
 </context>
 <context>
+    <name>PluginItemWidget</name>
+    <message>
+        <source>Disconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PowerApplet</name>
     <message>
         <source>Power</source>
@@ -509,7 +459,7 @@
     </message>
     <message>
         <source>%1 hr %2 min remaining</source>
-        <translation>%1 h %2 restant</translation>
+        <translation>%1&#xa0;h&#xa0;%2 restant</translation>
     </message>
     <message>
         <source>Not charging</source>
@@ -525,7 +475,7 @@
     </message>
     <message>
         <source>Charging, %1 hr %2 min until full</source>
-        <translation>En charge, %1 h %2 avant la charge complète</translation>
+        <translation>En charge, %1&#xa0;h&#xa0;%2 avant la charge complète</translation>
     </message>
     <message>
         <source>Capacity %1, %2 hr remaining</source>

--- a/plugins/dde-dock/translations/dde-dock_gl.ts
+++ b/plugins/dde-dock/translations/dde-dock_gl.ts
@@ -194,65 +194,6 @@
     </message>
 </context>
 <context>
-    <name>DatetimeWidget</name>
-    <message>
-        <source>Monday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Tuesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Wednesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Thursday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Friday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Saturday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sunday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>monday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>tuesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>wednesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>thursday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>friday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>saturday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>sunday</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>DeviceControlWidget</name>
     <message>
         <source>Other Devices</source>
@@ -445,6 +386,13 @@
     </message>
 </context>
 <context>
+    <name>PluginItemWidget</name>
+    <message>
+        <source>Disconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PowerApplet</name>
     <message>
         <source>Power</source>
@@ -543,6 +491,14 @@
     </message>
     <message>
         <source>Charging, %1 hr until full</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Capacity %1, charging protection active</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Charging protection active</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/plugins/dde-dock/translations/dde-dock_gl_ES.ts
+++ b/plugins/dde-dock/translations/dde-dock_gl_ES.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="gl_ES">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="gl_ES">
 <context>
     <name>AirplaneModeItem</name>
     <message>
@@ -48,11 +50,11 @@
     </message>
     <message>
         <source>Turned off</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Desactivado</translation>
     </message>
     <message>
         <source>Disable [Airplane Mode](#) first if you want to connect to a Bluetooth</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -189,65 +191,6 @@
     <message>
         <source>Open the calendar</source>
         <translation>Abrir o calendario</translation>
-    </message>
-</context>
-<context>
-    <name>DatetimeWidget</name>
-    <message>
-        <source>Monday</source>
-        <translation>Luns</translation>
-    </message>
-    <message>
-        <source>Tuesday</source>
-        <translation>Martes</translation>
-    </message>
-    <message>
-        <source>Wednesday</source>
-        <translation>Mércores</translation>
-    </message>
-    <message>
-        <source>Thursday</source>
-        <translation>Xoves</translation>
-    </message>
-    <message>
-        <source>Friday</source>
-        <translation>Venres</translation>
-    </message>
-    <message>
-        <source>Saturday</source>
-        <translation>Sábado</translation>
-    </message>
-    <message>
-        <source>Sunday</source>
-        <translation>Domingo</translation>
-    </message>
-    <message>
-        <source>monday</source>
-        <translation>luns</translation>
-    </message>
-    <message>
-        <source>tuesday</source>
-        <translation>martes</translation>
-    </message>
-    <message>
-        <source>wednesday</source>
-        <translation>miércoles</translation>
-    </message>
-    <message>
-        <source>thursday</source>
-        <translation>jueves</translation>
-    </message>
-    <message>
-        <source>friday</source>
-        <translation>viernes</translation>
-    </message>
-    <message>
-        <source>saturday</source>
-        <translation>sábado</translation>
-    </message>
-    <message>
-        <source>sunday</source>
-        <translation>domingo</translation>
     </message>
 </context>
 <context>
@@ -443,6 +386,13 @@
     </message>
 </context>
 <context>
+    <name>PluginItemWidget</name>
+    <message>
+        <source>Disconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PowerApplet</name>
     <message>
         <source>Power</source>
@@ -545,18 +495,18 @@
     </message>
     <message>
         <source>Capacity %1, charging protection active</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Charging protection active</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>PowerStatusWidget</name>
     <message>
         <source>Power settings</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Axustes de enerxía</translation>
     </message>
 </context>
 <context>
@@ -641,31 +591,31 @@
     </message>
     <message>
         <source>Monday</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Luns</translation>
     </message>
     <message>
         <source>Tuesday</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Martes</translation>
     </message>
     <message>
         <source>Wednesday</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Mércores</translation>
     </message>
     <message>
         <source>Thursday</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Xoves</translation>
     </message>
     <message>
         <source>Friday</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Venres</translation>
     </message>
     <message>
         <source>Saturday</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Sábado</translation>
     </message>
     <message>
         <source>Sunday</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Domingo</translation>
     </message>
     <message>
         <source>Jan</source>
@@ -721,7 +671,7 @@
     </message>
     <message>
         <source>monday</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">luns</translation>
     </message>
     <message>
         <source>tuesday</source>

--- a/plugins/dde-dock/translations/dde-dock_he.ts
+++ b/plugins/dde-dock/translations/dde-dock_he.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="he">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="he">
 <context>
     <name>AirplaneModeItem</name>
     <message>
@@ -52,7 +54,7 @@
     </message>
     <message>
         <source>Disable [Airplane Mode](#) first if you want to connect to a Bluetooth</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -189,65 +191,6 @@
     <message>
         <source>Open the calendar</source>
         <translation>פתח את שולחן התאריכים</translation>
-    </message>
-</context>
-<context>
-    <name>DatetimeWidget</name>
-    <message>
-        <source>Monday</source>
-        <translation>יום שני</translation>
-    </message>
-    <message>
-        <source>Tuesday</source>
-        <translation>יום שלישי</translation>
-    </message>
-    <message>
-        <source>Wednesday</source>
-        <translation>יום רביעי</translation>
-    </message>
-    <message>
-        <source>Thursday</source>
-        <translation>יום חמישי</translation>
-    </message>
-    <message>
-        <source>Friday</source>
-        <translation>יום שישי</translation>
-    </message>
-    <message>
-        <source>Saturday</source>
-        <translation>יום שבת</translation>
-    </message>
-    <message>
-        <source>Sunday</source>
-        <translation>יום ראשון</translation>
-    </message>
-    <message>
-        <source>monday</source>
-        <translation>יום שני</translation>
-    </message>
-    <message>
-        <source>tuesday</source>
-        <translation>יום שלישי</translation>
-    </message>
-    <message>
-        <source>wednesday</source>
-        <translation>יום רביעי</translation>
-    </message>
-    <message>
-        <source>thursday</source>
-        <translation>יום חמישי</translation>
-    </message>
-    <message>
-        <source>friday</source>
-        <translation>יום שישי</translation>
-    </message>
-    <message>
-        <source>saturday</source>
-        <translation>יום שבת</translation>
-    </message>
-    <message>
-        <source>sunday</source>
-        <translation>יום ראשון</translation>
     </message>
 </context>
 <context>
@@ -393,30 +336,30 @@
     </message>
     <message>
         <source>Notification settings</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Notifications</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Turn off DND mode</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Turn on DND mode</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Notification</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>OnboardPlugin</name>
     <message>
         <source>Onboard</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Settings</source>
@@ -427,69 +370,76 @@
     <name>PerformanceModeController</name>
     <message>
         <source>High Performance</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Balanced</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Power Saver</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Balance Performance</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PluginItemWidget</name>
+    <message>
+        <source>Disconnect</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>PowerApplet</name>
     <message>
         <source>Power</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>PowerPlugin</name>
     <message>
         <source>Power settings</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">הגדרות החשמל</translation>
     </message>
     <message>
         <source>Capacity %1, %2 min remaining</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Capacity %1, %2 hr %3 min remaining</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Charging %1, %2 min until full</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Charging %1, %2 hr %3 min until full</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Capacity %1</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Charging %1</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Capacity %1 ...</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Capacity %1, fully charged</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Capacity %1, not charging</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Battery</source>
@@ -497,19 +447,19 @@
     </message>
     <message>
         <source>Charging, calculating estimated charging time</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Calculating remaining usage time</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>%1 min remaining</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>%1 hr %2 min remaining</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Not charging</source>
@@ -545,11 +495,11 @@
     </message>
     <message>
         <source>Capacity %1, charging protection active</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Charging protection active</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -641,31 +591,31 @@
     </message>
     <message>
         <source>Monday</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">יום שני</translation>
     </message>
     <message>
         <source>Tuesday</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">יום שלישי</translation>
     </message>
     <message>
         <source>Wednesday</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">יום רביעי</translation>
     </message>
     <message>
         <source>Thursday</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">יום חמישי</translation>
     </message>
     <message>
         <source>Friday</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">יום שישי</translation>
     </message>
     <message>
         <source>Saturday</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">יום שבת</translation>
     </message>
     <message>
         <source>Sunday</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">יום ראשון</translation>
     </message>
     <message>
         <source>Jan</source>

--- a/plugins/dde-dock/translations/dde-dock_hi.ts
+++ b/plugins/dde-dock/translations/dde-dock_hi.ts
@@ -194,65 +194,6 @@
     </message>
 </context>
 <context>
-    <name>DatetimeWidget</name>
-    <message>
-        <source>Monday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Tuesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Wednesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Thursday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Friday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Saturday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sunday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>monday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>tuesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>wednesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>thursday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>friday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>saturday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>sunday</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>DeviceControlWidget</name>
     <message>
         <source>Other Devices</source>
@@ -445,6 +386,13 @@
     </message>
 </context>
 <context>
+    <name>PluginItemWidget</name>
+    <message>
+        <source>Disconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PowerApplet</name>
     <message>
         <source>Power</source>
@@ -543,6 +491,14 @@
     </message>
     <message>
         <source>Charging, %1 hr %2 min until full</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Capacity %1, charging protection active</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Charging protection active</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/plugins/dde-dock/translations/dde-dock_hi_IN.ts
+++ b/plugins/dde-dock/translations/dde-dock_hi_IN.ts
@@ -194,65 +194,6 @@
     </message>
 </context>
 <context>
-    <name>DatetimeWidget</name>
-    <message>
-        <source>Monday</source>
-        <translation>सोमवार</translation>
-    </message>
-    <message>
-        <source>Tuesday</source>
-        <translation>मंगलवार</translation>
-    </message>
-    <message>
-        <source>Wednesday</source>
-        <translation>बुधवार</translation>
-    </message>
-    <message>
-        <source>Thursday</source>
-        <translation>गुरुवार</translation>
-    </message>
-    <message>
-        <source>Friday</source>
-        <translation>शुक्रवार</translation>
-    </message>
-    <message>
-        <source>Saturday</source>
-        <translation>शनिवार</translation>
-    </message>
-    <message>
-        <source>Sunday</source>
-        <translation>रविवार</translation>
-    </message>
-    <message>
-        <source>monday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>tuesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>wednesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>thursday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>friday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>saturday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>sunday</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>DeviceControlWidget</name>
     <message>
         <source>Other Devices</source>
@@ -445,6 +386,13 @@
     </message>
 </context>
 <context>
+    <name>PluginItemWidget</name>
+    <message>
+        <source>Disconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PowerApplet</name>
     <message>
         <source>Power</source>
@@ -543,6 +491,14 @@
     </message>
     <message>
         <source>Charging, %1 hr until full</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Capacity %1, charging protection active</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Charging protection active</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/plugins/dde-dock/translations/dde-dock_hr.ts
+++ b/plugins/dde-dock/translations/dde-dock_hr.ts
@@ -194,65 +194,6 @@
     </message>
 </context>
 <context>
-    <name>DatetimeWidget</name>
-    <message>
-        <source>Monday</source>
-        <translation>Ponedjeljak</translation>
-    </message>
-    <message>
-        <source>Tuesday</source>
-        <translation>Utorak</translation>
-    </message>
-    <message>
-        <source>Wednesday</source>
-        <translation>Srijeda</translation>
-    </message>
-    <message>
-        <source>Thursday</source>
-        <translation>Četvrtak</translation>
-    </message>
-    <message>
-        <source>Friday</source>
-        <translation>Petak</translation>
-    </message>
-    <message>
-        <source>Saturday</source>
-        <translation>Subota</translation>
-    </message>
-    <message>
-        <source>Sunday</source>
-        <translation>Nedjelja</translation>
-    </message>
-    <message>
-        <source>monday</source>
-        <translation>ponedjeljak</translation>
-    </message>
-    <message>
-        <source>tuesday</source>
-        <translation>utorak</translation>
-    </message>
-    <message>
-        <source>wednesday</source>
-        <translation>srijeda</translation>
-    </message>
-    <message>
-        <source>thursday</source>
-        <translation>četvrtak</translation>
-    </message>
-    <message>
-        <source>friday</source>
-        <translation>petak</translation>
-    </message>
-    <message>
-        <source>saturday</source>
-        <translation>subota</translation>
-    </message>
-    <message>
-        <source>sunday</source>
-        <translation>nedjelja</translation>
-    </message>
-</context>
-<context>
     <name>DeviceControlWidget</name>
     <message>
         <source>Other Devices</source>
@@ -445,6 +386,13 @@
     </message>
 </context>
 <context>
+    <name>PluginItemWidget</name>
+    <message>
+        <source>Disconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PowerApplet</name>
     <message>
         <source>Power</source>
@@ -543,6 +491,14 @@
     </message>
     <message>
         <source>Charging, %1 hr until full</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Capacity %1, charging protection active</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Charging protection active</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/plugins/dde-dock/translations/dde-dock_hu.ts
+++ b/plugins/dde-dock/translations/dde-dock_hu.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="hu">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="hu">
 <context>
     <name>AirplaneModeItem</name>
     <message>
@@ -52,7 +54,7 @@
     </message>
     <message>
         <source>Disable [Airplane Mode](#) first if you want to connect to a Bluetooth</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -189,65 +191,6 @@
     <message>
         <source>Open the calendar</source>
         <translation>Naptár megnyitása</translation>
-    </message>
-</context>
-<context>
-    <name>DatetimeWidget</name>
-    <message>
-        <source>Monday</source>
-        <translation>Hétfő</translation>
-    </message>
-    <message>
-        <source>Tuesday</source>
-        <translation>Kedd</translation>
-    </message>
-    <message>
-        <source>Wednesday</source>
-        <translation>Szerda</translation>
-    </message>
-    <message>
-        <source>Thursday</source>
-        <translation>Csütörtök</translation>
-    </message>
-    <message>
-        <source>Friday</source>
-        <translation>Péntek</translation>
-    </message>
-    <message>
-        <source>Saturday</source>
-        <translation>Szombat</translation>
-    </message>
-    <message>
-        <source>Sunday</source>
-        <translation>Vasárnap</translation>
-    </message>
-    <message>
-        <source>monday</source>
-        <translation>Hétfő</translation>
-    </message>
-    <message>
-        <source>tuesday</source>
-        <translation>Kedd</translation>
-    </message>
-    <message>
-        <source>wednesday</source>
-        <translation>Szerda</translation>
-    </message>
-    <message>
-        <source>thursday</source>
-        <translation>Csütörtök</translation>
-    </message>
-    <message>
-        <source>friday</source>
-        <translation>Péntek</translation>
-    </message>
-    <message>
-        <source>saturday</source>
-        <translation>Szombat</translation>
-    </message>
-    <message>
-        <source>sunday</source>
-        <translation>Vasárnap</translation>
     </message>
 </context>
 <context>
@@ -443,6 +386,13 @@
     </message>
 </context>
 <context>
+    <name>PluginItemWidget</name>
+    <message>
+        <source>Disconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PowerApplet</name>
     <message>
         <source>Power</source>
@@ -549,7 +499,7 @@
     </message>
     <message>
         <source>Charging protection active</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/plugins/dde-dock/translations/dde-dock_hy.ts
+++ b/plugins/dde-dock/translations/dde-dock_hy.ts
@@ -194,65 +194,6 @@
     </message>
 </context>
 <context>
-    <name>DatetimeWidget</name>
-    <message>
-        <source>Monday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Tuesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Wednesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Thursday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Friday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Saturday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sunday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>monday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>tuesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>wednesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>thursday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>friday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>saturday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>sunday</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>DeviceControlWidget</name>
     <message>
         <source>Other Devices</source>
@@ -445,6 +386,13 @@
     </message>
 </context>
 <context>
+    <name>PluginItemWidget</name>
+    <message>
+        <source>Disconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PowerApplet</name>
     <message>
         <source>Power</source>
@@ -543,6 +491,14 @@
     </message>
     <message>
         <source>Charging, %1 hr until full</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Capacity %1, charging protection active</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Charging protection active</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/plugins/dde-dock/translations/dde-dock_id.ts
+++ b/plugins/dde-dock/translations/dde-dock_id.ts
@@ -194,65 +194,6 @@
     </message>
 </context>
 <context>
-    <name>DatetimeWidget</name>
-    <message>
-        <source>Monday</source>
-        <translation>Senin</translation>
-    </message>
-    <message>
-        <source>Tuesday</source>
-        <translation>Selasa</translation>
-    </message>
-    <message>
-        <source>Wednesday</source>
-        <translation>Rabu</translation>
-    </message>
-    <message>
-        <source>Thursday</source>
-        <translation>Kamis</translation>
-    </message>
-    <message>
-        <source>Friday</source>
-        <translation>Jum&apos;at</translation>
-    </message>
-    <message>
-        <source>Saturday</source>
-        <translation>Sabtu</translation>
-    </message>
-    <message>
-        <source>Sunday</source>
-        <translation>Minggu</translation>
-    </message>
-    <message>
-        <source>monday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>tuesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>wednesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>thursday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>friday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>saturday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>sunday</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>DeviceControlWidget</name>
     <message>
         <source>Other Devices</source>
@@ -445,6 +386,13 @@
     </message>
 </context>
 <context>
+    <name>PluginItemWidget</name>
+    <message>
+        <source>Disconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PowerApplet</name>
     <message>
         <source>Power</source>
@@ -543,6 +491,14 @@
     </message>
     <message>
         <source>Charging, %1 hr until full</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Capacity %1, charging protection active</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Charging protection active</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/plugins/dde-dock/translations/dde-dock_id_ID.ts
+++ b/plugins/dde-dock/translations/dde-dock_id_ID.ts
@@ -194,65 +194,6 @@
     </message>
 </context>
 <context>
-    <name>DatetimeWidget</name>
-    <message>
-        <source>Monday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Tuesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Wednesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Thursday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Friday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Saturday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sunday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>monday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>tuesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>wednesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>thursday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>friday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>saturday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>sunday</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>DeviceControlWidget</name>
     <message>
         <source>Other Devices</source>
@@ -445,6 +386,13 @@
     </message>
 </context>
 <context>
+    <name>PluginItemWidget</name>
+    <message>
+        <source>Disconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PowerApplet</name>
     <message>
         <source>Power</source>
@@ -543,6 +491,14 @@
     </message>
     <message>
         <source>Charging, %1 hr until full</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Capacity %1, charging protection active</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Charging protection active</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/plugins/dde-dock/translations/dde-dock_it.ts
+++ b/plugins/dde-dock/translations/dde-dock_it.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="it">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="it">
 <context>
     <name>AirplaneModeItem</name>
     <message>
@@ -37,7 +39,7 @@
     <name>BluetoothAdapterItem</name>
     <message>
         <source>My Devices</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -52,7 +54,7 @@
     </message>
     <message>
         <source>Disable [Airplane Mode](#) first if you want to connect to a Bluetooth</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -188,73 +190,14 @@
     </message>
     <message>
         <source>Open the calendar</source>
-        <translation type="unfinished"/>
-    </message>
-</context>
-<context>
-    <name>DatetimeWidget</name>
-    <message>
-        <source>Monday</source>
-        <translation>Lunedì</translation>
-    </message>
-    <message>
-        <source>Tuesday</source>
-        <translation>Martedì</translation>
-    </message>
-    <message>
-        <source>Wednesday</source>
-        <translation>Mercoledì</translation>
-    </message>
-    <message>
-        <source>Thursday</source>
-        <translation>Giovedì</translation>
-    </message>
-    <message>
-        <source>Friday</source>
-        <translation>Venerdì</translation>
-    </message>
-    <message>
-        <source>Saturday</source>
-        <translation>Sabato</translation>
-    </message>
-    <message>
-        <source>Sunday</source>
-        <translation>Domenica</translation>
-    </message>
-    <message>
-        <source>monday</source>
-        <translation>lunedì</translation>
-    </message>
-    <message>
-        <source>tuesday</source>
-        <translation>martedì</translation>
-    </message>
-    <message>
-        <source>wednesday</source>
-        <translation>mercoledì</translation>
-    </message>
-    <message>
-        <source>thursday</source>
-        <translation>giovedì</translation>
-    </message>
-    <message>
-        <source>friday</source>
-        <translation>venerdì</translation>
-    </message>
-    <message>
-        <source>saturday</source>
-        <translation>sabato</translation>
-    </message>
-    <message>
-        <source>sunday</source>
-        <translation>domenica</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>DeviceControlWidget</name>
     <message>
         <source>Other Devices</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -307,82 +250,82 @@
     </message>
     <message>
         <source>Display settings</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Impostazioni schermo</translation>
     </message>
     <message>
         <source>Eye comfort</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Theme</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>On</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Off</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Spento</translation>
     </message>
     <message>
         <source>Light</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Dark</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Auto</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Disable eye comfort</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Enable eye comfort</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Display Settings</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Theme: Light</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Theme: Dark</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Theme: Auto</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Visual effect</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>EyeComfortmodeApplet</name>
     <message>
         <source>Light</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Dark</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Auto</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Theme</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -439,14 +382,21 @@
     </message>
     <message>
         <source>Balance Performance</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PluginItemWidget</name>
+    <message>
+        <source>Disconnect</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>PowerApplet</name>
     <message>
         <source>Power</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -497,66 +447,66 @@
     </message>
     <message>
         <source>Charging, calculating estimated charging time</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Calculating remaining usage time</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>%1 min remaining</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>%1 hr %2 min remaining</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Not charging</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Fully charged</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Charging, %1 min until full</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Charging, %1 hr %2 min until full</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Capacity %1, %2 hr remaining</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>%1 hr remaining</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Charging %1, %2 hr until full</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Charging, %1 hr until full</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Capacity %1, charging protection active</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Charging protection active</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>PowerStatusWidget</name>
     <message>
         <source>Power settings</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Impostazioni Alimentazione</translation>
     </message>
 </context>
 <context>
@@ -567,7 +517,7 @@
     </message>
     <message>
         <source>Unknown</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -610,142 +560,142 @@
     </message>
     <message>
         <source>Shut Down</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Switch user</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>SidebarCalendarWidget</name>
     <message>
         <source>Today</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Lunar</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>y</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>m</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>d</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Monday</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Lunedì</translation>
     </message>
     <message>
         <source>Tuesday</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Martedì</translation>
     </message>
     <message>
         <source>Wednesday</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Mercoledì</translation>
     </message>
     <message>
         <source>Thursday</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Giovedì</translation>
     </message>
     <message>
         <source>Friday</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Venerdì</translation>
     </message>
     <message>
         <source>Saturday</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Sabato</translation>
     </message>
     <message>
         <source>Sunday</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Domenica</translation>
     </message>
     <message>
         <source>Jan</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Feb</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Mar</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Apr</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>May</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Jun</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Jul</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Aug</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Sept</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Oct</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Nov</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Dec</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Open the calendar</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>monday</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">lunedì</translation>
     </message>
     <message>
         <source>tuesday</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">martedì</translation>
     </message>
     <message>
         <source>wednesday</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">mercoledì</translation>
     </message>
     <message>
         <source>thursday</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">giovedì</translation>
     </message>
     <message>
         <source>friday</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">venerdì</translation>
     </message>
     <message>
         <source>saturday</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">sabato</translation>
     </message>
     <message>
         <source>sunday</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">domenica</translation>
     </message>
 </context>
 <context>

--- a/plugins/dde-dock/translations/dde-dock_ja.ts
+++ b/plugins/dde-dock/translations/dde-dock_ja.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="ja">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ja">
 <context>
     <name>AirplaneModeItem</name>
     <message>
@@ -189,65 +191,6 @@
     <message>
         <source>Open the calendar</source>
         <translation>カレンダーを開く</translation>
-    </message>
-</context>
-<context>
-    <name>DatetimeWidget</name>
-    <message>
-        <source>Monday</source>
-        <translation>月曜日</translation>
-    </message>
-    <message>
-        <source>Tuesday</source>
-        <translation>火曜日</translation>
-    </message>
-    <message>
-        <source>Wednesday</source>
-        <translation>水曜日</translation>
-    </message>
-    <message>
-        <source>Thursday</source>
-        <translation>木曜日</translation>
-    </message>
-    <message>
-        <source>Friday</source>
-        <translation>金曜日</translation>
-    </message>
-    <message>
-        <source>Saturday</source>
-        <translation>土曜日</translation>
-    </message>
-    <message>
-        <source>Sunday</source>
-        <translation>日曜日</translation>
-    </message>
-    <message>
-        <source>monday</source>
-        <translation>月曜日</translation>
-    </message>
-    <message>
-        <source>tuesday</source>
-        <translation>火曜日</translation>
-    </message>
-    <message>
-        <source>wednesday</source>
-        <translation>水曜日</translation>
-    </message>
-    <message>
-        <source>thursday</source>
-        <translation>木曜日</translation>
-    </message>
-    <message>
-        <source>friday</source>
-        <translation>金曜日</translation>
-    </message>
-    <message>
-        <source>saturday</source>
-        <translation>土曜日</translation>
-    </message>
-    <message>
-        <source>sunday</source>
-        <translation>日曜日</translation>
     </message>
 </context>
 <context>
@@ -443,6 +386,13 @@
     </message>
 </context>
 <context>
+    <name>PluginItemWidget</name>
+    <message>
+        <source>Disconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PowerApplet</name>
     <message>
         <source>Power</source>
@@ -457,19 +407,19 @@
     </message>
     <message>
         <source>Capacity %1, %2 min remaining</source>
-        <translation>バッテリー残量 %1　残り %2 分</translation>
+        <translation>バッテリー残量 %1&#x3000;残り %2 分</translation>
     </message>
     <message>
         <source>Capacity %1, %2 hr %3 min remaining</source>
-        <translation>バッテリー残量 %1　残り %2 時間 %3 分</translation>
+        <translation>バッテリー残量 %1&#x3000;残り %2 時間 %3 分</translation>
     </message>
     <message>
         <source>Charging %1, %2 min until full</source>
-        <translation>充電中 %1　完了まで %2 分</translation>
+        <translation>充電中 %1&#x3000;完了まで %2 分</translation>
     </message>
     <message>
         <source>Charging %1, %2 hr %3 min until full</source>
-        <translation>充電中 %1　完了まで %2 時間 %3 分</translation>
+        <translation>充電中 %1&#x3000;完了まで %2 時間 %3 分</translation>
     </message>
     <message>
         <source>Capacity %1</source>
@@ -485,11 +435,11 @@
     </message>
     <message>
         <source>Capacity %1, fully charged</source>
-        <translation>バッテリー残量 %1　充電完了</translation>
+        <translation>バッテリー残量 %1&#x3000;充電完了</translation>
     </message>
     <message>
         <source>Capacity %1, not charging</source>
-        <translation>バッテリー残量 %1　充電していません</translation>
+        <translation>バッテリー残量 %1&#x3000;充電していません</translation>
     </message>
     <message>
         <source>Battery</source>
@@ -497,7 +447,7 @@
     </message>
     <message>
         <source>Charging, calculating estimated charging time</source>
-        <translation>充電中　完了までの時間を計算しています</translation>
+        <translation>充電中&#x3000;完了までの時間を計算しています</translation>
     </message>
     <message>
         <source>Calculating remaining usage time</source>
@@ -521,15 +471,15 @@
     </message>
     <message>
         <source>Charging, %1 min until full</source>
-        <translation>充電中　完了まで%1分</translation>
+        <translation>充電中&#x3000;完了まで%1分</translation>
     </message>
     <message>
         <source>Charging, %1 hr %2 min until full</source>
-        <translation>充電中　完了まで%1時間%2分</translation>
+        <translation>充電中&#x3000;完了まで%1時間%2分</translation>
     </message>
     <message>
         <source>Capacity %1, %2 hr remaining</source>
-        <translation>バッテリー残量 %1　残り %2時間</translation>
+        <translation>バッテリー残量 %1&#x3000;残り %2時間</translation>
     </message>
     <message>
         <source>%1 hr remaining</source>
@@ -537,19 +487,19 @@
     </message>
     <message>
         <source>Charging %1, %2 hr until full</source>
-        <translation>充電中 %1　完了まで %2時間</translation>
+        <translation>充電中 %1&#x3000;完了まで %2時間</translation>
     </message>
     <message>
         <source>Charging, %1 hr until full</source>
-        <translation>充電中　完了まで%1時間</translation>
+        <translation>充電中&#x3000;完了まで%1時間</translation>
     </message>
     <message>
         <source>Capacity %1, charging protection active</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Charging protection active</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -625,19 +575,19 @@
     </message>
     <message>
         <source>Lunar</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>y</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>m</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>d</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Monday</source>

--- a/plugins/dde-dock/translations/dde-dock_ka.ts
+++ b/plugins/dde-dock/translations/dde-dock_ka.ts
@@ -194,65 +194,6 @@
     </message>
 </context>
 <context>
-    <name>DatetimeWidget</name>
-    <message>
-        <source>Monday</source>
-        <translation>ორშაბათი</translation>
-    </message>
-    <message>
-        <source>Tuesday</source>
-        <translation>სამშაბათი</translation>
-    </message>
-    <message>
-        <source>Wednesday</source>
-        <translation>ოთხშაბათი</translation>
-    </message>
-    <message>
-        <source>Thursday</source>
-        <translation>ხუთშაბათი</translation>
-    </message>
-    <message>
-        <source>Friday</source>
-        <translation>პარასკევი</translation>
-    </message>
-    <message>
-        <source>Saturday</source>
-        <translation>შაბათი</translation>
-    </message>
-    <message>
-        <source>Sunday</source>
-        <translation>კვირა</translation>
-    </message>
-    <message>
-        <source>monday</source>
-        <translation>ორშაბათი</translation>
-    </message>
-    <message>
-        <source>tuesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>wednesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>thursday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>friday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>saturday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>sunday</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>DeviceControlWidget</name>
     <message>
         <source>Other Devices</source>
@@ -445,6 +386,13 @@
     </message>
 </context>
 <context>
+    <name>PluginItemWidget</name>
+    <message>
+        <source>Disconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PowerApplet</name>
     <message>
         <source>Power</source>
@@ -543,6 +491,14 @@
     </message>
     <message>
         <source>Charging, %1 hr until full</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Capacity %1, charging protection active</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Charging protection active</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/plugins/dde-dock/translations/dde-dock_kk.ts
+++ b/plugins/dde-dock/translations/dde-dock_kk.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="kk">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="kk">
 <context>
     <name>AirplaneModeItem</name>
     <message>
@@ -52,7 +54,7 @@
     </message>
     <message>
         <source>Disable [Airplane Mode](#) first if you want to connect to a Bluetooth</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -189,65 +191,6 @@
     <message>
         <source>Open the calendar</source>
         <translation>Календарды басыңыз</translation>
-    </message>
-</context>
-<context>
-    <name>DatetimeWidget</name>
-    <message>
-        <source>Monday</source>
-        <translation>Пятіркі</translation>
-    </message>
-    <message>
-        <source>Tuesday</source>
-        <translation>Сырткі</translation>
-    </message>
-    <message>
-        <source>Wednesday</source>
-        <translation>Себті</translation>
-    </message>
-    <message>
-        <source>Thursday</source>
-        <translation>Жұма</translation>
-    </message>
-    <message>
-        <source>Friday</source>
-        <translation>Денес</translation>
-    </message>
-    <message>
-        <source>Saturday</source>
-        <translation>Күні</translation>
-    </message>
-    <message>
-        <source>Sunday</source>
-        <translation>Жеке күні</translation>
-    </message>
-    <message>
-        <source>monday</source>
-        <translation>пятіркі</translation>
-    </message>
-    <message>
-        <source>tuesday</source>
-        <translation>сырткі</translation>
-    </message>
-    <message>
-        <source>wednesday</source>
-        <translation>себті</translation>
-    </message>
-    <message>
-        <source>thursday</source>
-        <translation>жұма</translation>
-    </message>
-    <message>
-        <source>friday</source>
-        <translation>денес</translation>
-    </message>
-    <message>
-        <source>saturday</source>
-        <translation>күні</translation>
-    </message>
-    <message>
-        <source>sunday</source>
-        <translation>жұлдыз</translation>
     </message>
 </context>
 <context>
@@ -443,6 +386,13 @@
     </message>
 </context>
 <context>
+    <name>PluginItemWidget</name>
+    <message>
+        <source>Disconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PowerApplet</name>
     <message>
         <source>Power</source>
@@ -545,11 +495,11 @@
     </message>
     <message>
         <source>Capacity %1, charging protection active</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Charging protection active</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/plugins/dde-dock/translations/dde-dock_km_KH.ts
+++ b/plugins/dde-dock/translations/dde-dock_km_KH.ts
@@ -194,65 +194,6 @@
     </message>
 </context>
 <context>
-    <name>DatetimeWidget</name>
-    <message>
-        <source>Monday</source>
-        <translation>ថ្ងៃចន្ទ</translation>
-    </message>
-    <message>
-        <source>Tuesday</source>
-        <translation>ថ្ងៃអង្គារ</translation>
-    </message>
-    <message>
-        <source>Wednesday</source>
-        <translation>ថ្ងៃពុធ</translation>
-    </message>
-    <message>
-        <source>Thursday</source>
-        <translation>ថ្ងៃព្រហស្បតិ៍</translation>
-    </message>
-    <message>
-        <source>Friday</source>
-        <translation>ថ្ងៃសុក្រ</translation>
-    </message>
-    <message>
-        <source>Saturday</source>
-        <translation>ថ្ងៃសៅរ៍</translation>
-    </message>
-    <message>
-        <source>Sunday</source>
-        <translation>ថ្ងៃអាទិត្យ</translation>
-    </message>
-    <message>
-        <source>monday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>tuesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>wednesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>thursday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>friday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>saturday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>sunday</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>DeviceControlWidget</name>
     <message>
         <source>Other Devices</source>
@@ -445,6 +386,13 @@
     </message>
 </context>
 <context>
+    <name>PluginItemWidget</name>
+    <message>
+        <source>Disconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PowerApplet</name>
     <message>
         <source>Power</source>
@@ -543,6 +491,14 @@
     </message>
     <message>
         <source>Charging, %1 hr until full</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Capacity %1, charging protection active</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Charging protection active</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/plugins/dde-dock/translations/dde-dock_kn_IN.ts
+++ b/plugins/dde-dock/translations/dde-dock_kn_IN.ts
@@ -194,65 +194,6 @@
     </message>
 </context>
 <context>
-    <name>DatetimeWidget</name>
-    <message>
-        <source>Monday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Tuesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Wednesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Thursday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Friday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Saturday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sunday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>monday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>tuesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>wednesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>thursday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>friday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>saturday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>sunday</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>DeviceControlWidget</name>
     <message>
         <source>Other Devices</source>
@@ -445,6 +386,13 @@
     </message>
 </context>
 <context>
+    <name>PluginItemWidget</name>
+    <message>
+        <source>Disconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PowerApplet</name>
     <message>
         <source>Power</source>
@@ -543,6 +491,14 @@
     </message>
     <message>
         <source>Charging, %1 hr until full</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Capacity %1, charging protection active</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Charging protection active</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/plugins/dde-dock/translations/dde-dock_ko.ts
+++ b/plugins/dde-dock/translations/dde-dock_ko.ts
@@ -194,65 +194,6 @@
     </message>
 </context>
 <context>
-    <name>DatetimeWidget</name>
-    <message>
-        <source>Monday</source>
-        <translation>월요일</translation>
-    </message>
-    <message>
-        <source>Tuesday</source>
-        <translation>화요일</translation>
-    </message>
-    <message>
-        <source>Wednesday</source>
-        <translation>수요일</translation>
-    </message>
-    <message>
-        <source>Thursday</source>
-        <translation>목요일</translation>
-    </message>
-    <message>
-        <source>Friday</source>
-        <translation>금요일</translation>
-    </message>
-    <message>
-        <source>Saturday</source>
-        <translation>토요일</translation>
-    </message>
-    <message>
-        <source>Sunday</source>
-        <translation>일요일</translation>
-    </message>
-    <message>
-        <source>monday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>tuesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>wednesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>thursday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>friday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>saturday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>sunday</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>DeviceControlWidget</name>
     <message>
         <source>Other Devices</source>
@@ -445,6 +386,13 @@
     </message>
 </context>
 <context>
+    <name>PluginItemWidget</name>
+    <message>
+        <source>Disconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PowerApplet</name>
     <message>
         <source>Power</source>
@@ -543,6 +491,14 @@
     </message>
     <message>
         <source>Charging, %1 hr until full</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Capacity %1, charging protection active</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Charging protection active</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/plugins/dde-dock/translations/dde-dock_ku.ts
+++ b/plugins/dde-dock/translations/dde-dock_ku.ts
@@ -194,65 +194,6 @@
     </message>
 </context>
 <context>
-    <name>DatetimeWidget</name>
-    <message>
-        <source>Monday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Tuesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Wednesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Thursday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Friday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Saturday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sunday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>monday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>tuesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>wednesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>thursday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>friday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>saturday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>sunday</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>DeviceControlWidget</name>
     <message>
         <source>Other Devices</source>
@@ -445,6 +386,13 @@
     </message>
 </context>
 <context>
+    <name>PluginItemWidget</name>
+    <message>
+        <source>Disconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PowerApplet</name>
     <message>
         <source>Power</source>
@@ -543,6 +491,14 @@
     </message>
     <message>
         <source>Charging, %1 hr until full</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Capacity %1, charging protection active</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Charging protection active</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/plugins/dde-dock/translations/dde-dock_ku_IQ.ts
+++ b/plugins/dde-dock/translations/dde-dock_ku_IQ.ts
@@ -194,65 +194,6 @@
     </message>
 </context>
 <context>
-    <name>DatetimeWidget</name>
-    <message>
-        <source>Monday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Tuesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Wednesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Thursday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Friday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Saturday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sunday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>monday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>tuesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>wednesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>thursday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>friday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>saturday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>sunday</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>DeviceControlWidget</name>
     <message>
         <source>Other Devices</source>
@@ -445,6 +386,13 @@
     </message>
 </context>
 <context>
+    <name>PluginItemWidget</name>
+    <message>
+        <source>Disconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PowerApplet</name>
     <message>
         <source>Power</source>
@@ -543,6 +491,14 @@
     </message>
     <message>
         <source>Charging, %1 hr until full</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Capacity %1, charging protection active</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Charging protection active</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/plugins/dde-dock/translations/dde-dock_ky.ts
+++ b/plugins/dde-dock/translations/dde-dock_ky.ts
@@ -194,65 +194,6 @@
     </message>
 </context>
 <context>
-    <name>DatetimeWidget</name>
-    <message>
-        <source>Monday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Tuesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Wednesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Thursday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Friday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Saturday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sunday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>monday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>tuesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>wednesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>thursday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>friday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>saturday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>sunday</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>DeviceControlWidget</name>
     <message>
         <source>Other Devices</source>
@@ -445,6 +386,13 @@
     </message>
 </context>
 <context>
+    <name>PluginItemWidget</name>
+    <message>
+        <source>Disconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PowerApplet</name>
     <message>
         <source>Power</source>
@@ -543,6 +491,14 @@
     </message>
     <message>
         <source>Charging, %1 hr until full</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Capacity %1, charging protection active</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Charging protection active</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/plugins/dde-dock/translations/dde-dock_la.ts
+++ b/plugins/dde-dock/translations/dde-dock_la.ts
@@ -194,65 +194,6 @@
     </message>
 </context>
 <context>
-    <name>DatetimeWidget</name>
-    <message>
-        <source>Monday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Tuesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Wednesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Thursday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Friday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Saturday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sunday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>monday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>tuesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>wednesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>thursday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>friday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>saturday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>sunday</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>DeviceControlWidget</name>
     <message>
         <source>Other Devices</source>
@@ -445,6 +386,13 @@
     </message>
 </context>
 <context>
+    <name>PluginItemWidget</name>
+    <message>
+        <source>Disconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PowerApplet</name>
     <message>
         <source>Power</source>
@@ -543,6 +491,14 @@
     </message>
     <message>
         <source>Charging, %1 hr until full</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Capacity %1, charging protection active</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Charging protection active</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/plugins/dde-dock/translations/dde-dock_lo.ts
+++ b/plugins/dde-dock/translations/dde-dock_lo.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="lo">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="lo">
 <context>
     <name>AirplaneModeItem</name>
     <message>
@@ -189,65 +191,6 @@
     <message>
         <source>Open the calendar</source>
         <translation>ເປີດປະຕິທິນ</translation>
-    </message>
-</context>
-<context>
-    <name>DatetimeWidget</name>
-    <message>
-        <source>Monday</source>
-        <translation>ອາທິດ</translation>
-    </message>
-    <message>
-        <source>Tuesday</source>
-        <translation>ພັນຫັດ</translation>
-    </message>
-    <message>
-        <source>Wednesday</source>
-        <translation>ພັງສາ</translation>
-    </message>
-    <message>
-        <source>Thursday</source>
-        <translation>ສຸກ</translation>
-    </message>
-    <message>
-        <source>Friday</source>
-        <translation>ເສັ້ນ</translation>
-    </message>
-    <message>
-        <source>Saturday</source>
-        <translation>ເສາມ</translation>
-    </message>
-    <message>
-        <source>Sunday</source>
-        <translation>ອາທິດ</translation>
-    </message>
-    <message>
-        <source>monday</source>
-        <translation>ອາທິດ</translation>
-    </message>
-    <message>
-        <source>tuesday</source>
-        <translation>ພັນຫັດ</translation>
-    </message>
-    <message>
-        <source>wednesday</source>
-        <translation>ພັງສາ</translation>
-    </message>
-    <message>
-        <source>thursday</source>
-        <translation>ສຸກ</translation>
-    </message>
-    <message>
-        <source>friday</source>
-        <translation>ເສັ້ນ</translation>
-    </message>
-    <message>
-        <source>saturday</source>
-        <translation>ສາາວານມືການ</translation>
-    </message>
-    <message>
-        <source>sunday</source>
-        <translation>ສາາວານອາທິດ</translation>
     </message>
 </context>
 <context>
@@ -443,6 +386,13 @@
     </message>
 </context>
 <context>
+    <name>PluginItemWidget</name>
+    <message>
+        <source>Disconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PowerApplet</name>
     <message>
         <source>Power</source>
@@ -545,11 +495,11 @@
     </message>
     <message>
         <source>Capacity %1, charging protection active</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Charging protection active</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/plugins/dde-dock/translations/dde-dock_lt.ts
+++ b/plugins/dde-dock/translations/dde-dock_lt.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="lt">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="lt">
 <context>
     <name>AirplaneModeItem</name>
     <message>
@@ -52,7 +54,7 @@
     </message>
     <message>
         <source>Disable [Airplane Mode](#) first if you want to connect to a Bluetooth</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -189,65 +191,6 @@
     <message>
         <source>Open the calendar</source>
         <translation>Atverti kalendorių</translation>
-    </message>
-</context>
-<context>
-    <name>DatetimeWidget</name>
-    <message>
-        <source>Monday</source>
-        <translation>Pirmadienis</translation>
-    </message>
-    <message>
-        <source>Tuesday</source>
-        <translation>Antradienis</translation>
-    </message>
-    <message>
-        <source>Wednesday</source>
-        <translation>Trečiadienis</translation>
-    </message>
-    <message>
-        <source>Thursday</source>
-        <translation>Ketvirtadienis</translation>
-    </message>
-    <message>
-        <source>Friday</source>
-        <translation>Penktadienis</translation>
-    </message>
-    <message>
-        <source>Saturday</source>
-        <translation>Šeštadienis</translation>
-    </message>
-    <message>
-        <source>Sunday</source>
-        <translation>Sekmadienis</translation>
-    </message>
-    <message>
-        <source>monday</source>
-        <translation>pirmadienis</translation>
-    </message>
-    <message>
-        <source>tuesday</source>
-        <translation>antradienis</translation>
-    </message>
-    <message>
-        <source>wednesday</source>
-        <translation>trečiadienis</translation>
-    </message>
-    <message>
-        <source>thursday</source>
-        <translation>ketvirtadienis</translation>
-    </message>
-    <message>
-        <source>friday</source>
-        <translation>penktadienis</translation>
-    </message>
-    <message>
-        <source>saturday</source>
-        <translation>šeštadienis</translation>
-    </message>
-    <message>
-        <source>sunday</source>
-        <translation>sekmadienis</translation>
     </message>
 </context>
 <context>
@@ -443,6 +386,13 @@
     </message>
 </context>
 <context>
+    <name>PluginItemWidget</name>
+    <message>
+        <source>Disconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PowerApplet</name>
     <message>
         <source>Power</source>
@@ -545,11 +495,11 @@
     </message>
     <message>
         <source>Capacity %1, charging protection active</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Charging protection active</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/plugins/dde-dock/translations/dde-dock_lv.ts
+++ b/plugins/dde-dock/translations/dde-dock_lv.ts
@@ -194,65 +194,6 @@
     </message>
 </context>
 <context>
-    <name>DatetimeWidget</name>
-    <message>
-        <source>Monday</source>
-        <translation>Pirmdiena</translation>
-    </message>
-    <message>
-        <source>Tuesday</source>
-        <translation>Otrdiena</translation>
-    </message>
-    <message>
-        <source>Wednesday</source>
-        <translation>Trešdiena</translation>
-    </message>
-    <message>
-        <source>Thursday</source>
-        <translation>Ceturtdiena</translation>
-    </message>
-    <message>
-        <source>Friday</source>
-        <translation>Piektdiena</translation>
-    </message>
-    <message>
-        <source>Saturday</source>
-        <translation>Sestdiena</translation>
-    </message>
-    <message>
-        <source>Sunday</source>
-        <translation>Svētdiena</translation>
-    </message>
-    <message>
-        <source>monday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>tuesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>wednesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>thursday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>friday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>saturday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>sunday</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>DeviceControlWidget</name>
     <message>
         <source>Other Devices</source>
@@ -445,6 +386,13 @@
     </message>
 </context>
 <context>
+    <name>PluginItemWidget</name>
+    <message>
+        <source>Disconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PowerApplet</name>
     <message>
         <source>Power</source>
@@ -543,6 +491,14 @@
     </message>
     <message>
         <source>Charging, %1 hr until full</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Capacity %1, charging protection active</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Charging protection active</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/plugins/dde-dock/translations/dde-dock_ml.ts
+++ b/plugins/dde-dock/translations/dde-dock_ml.ts
@@ -194,65 +194,6 @@
     </message>
 </context>
 <context>
-    <name>DatetimeWidget</name>
-    <message>
-        <source>Monday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Tuesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Wednesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Thursday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Friday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Saturday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sunday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>monday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>tuesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>wednesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>thursday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>friday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>saturday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>sunday</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>DeviceControlWidget</name>
     <message>
         <source>Other Devices</source>
@@ -445,6 +386,13 @@
     </message>
 </context>
 <context>
+    <name>PluginItemWidget</name>
+    <message>
+        <source>Disconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PowerApplet</name>
     <message>
         <source>Power</source>
@@ -543,6 +491,14 @@
     </message>
     <message>
         <source>Charging, %1 hr until full</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Capacity %1, charging protection active</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Charging protection active</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/plugins/dde-dock/translations/dde-dock_mn.ts
+++ b/plugins/dde-dock/translations/dde-dock_mn.ts
@@ -194,65 +194,6 @@
     </message>
 </context>
 <context>
-    <name>DatetimeWidget</name>
-    <message>
-        <source>Monday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Tuesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Wednesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Thursday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Friday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Saturday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sunday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>monday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>tuesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>wednesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>thursday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>friday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>saturday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>sunday</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>DeviceControlWidget</name>
     <message>
         <source>Other Devices</source>
@@ -445,6 +386,13 @@
     </message>
 </context>
 <context>
+    <name>PluginItemWidget</name>
+    <message>
+        <source>Disconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PowerApplet</name>
     <message>
         <source>Power</source>
@@ -543,6 +491,14 @@
     </message>
     <message>
         <source>Charging, %1 hr until full</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Capacity %1, charging protection active</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Charging protection active</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/plugins/dde-dock/translations/dde-dock_mr.ts
+++ b/plugins/dde-dock/translations/dde-dock_mr.ts
@@ -194,65 +194,6 @@
     </message>
 </context>
 <context>
-    <name>DatetimeWidget</name>
-    <message>
-        <source>Monday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Tuesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Wednesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Thursday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Friday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Saturday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sunday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>monday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>tuesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>wednesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>thursday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>friday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>saturday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>sunday</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>DeviceControlWidget</name>
     <message>
         <source>Other Devices</source>
@@ -445,6 +386,13 @@
     </message>
 </context>
 <context>
+    <name>PluginItemWidget</name>
+    <message>
+        <source>Disconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PowerApplet</name>
     <message>
         <source>Power</source>
@@ -543,6 +491,14 @@
     </message>
     <message>
         <source>Charging, %1 hr until full</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Capacity %1, charging protection active</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Charging protection active</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/plugins/dde-dock/translations/dde-dock_ms.ts
+++ b/plugins/dde-dock/translations/dde-dock_ms.ts
@@ -194,65 +194,6 @@
     </message>
 </context>
 <context>
-    <name>DatetimeWidget</name>
-    <message>
-        <source>Monday</source>
-        <translation>Isnin</translation>
-    </message>
-    <message>
-        <source>Tuesday</source>
-        <translation>Selasa</translation>
-    </message>
-    <message>
-        <source>Wednesday</source>
-        <translation>Rabu</translation>
-    </message>
-    <message>
-        <source>Thursday</source>
-        <translation>Khamis</translation>
-    </message>
-    <message>
-        <source>Friday</source>
-        <translation>Jumaat</translation>
-    </message>
-    <message>
-        <source>Saturday</source>
-        <translation>Sabtu</translation>
-    </message>
-    <message>
-        <source>Sunday</source>
-        <translation>Ahad</translation>
-    </message>
-    <message>
-        <source>monday</source>
-        <translation>isnin</translation>
-    </message>
-    <message>
-        <source>tuesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>wednesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>thursday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>friday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>saturday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>sunday</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>DeviceControlWidget</name>
     <message>
         <source>Other Devices</source>
@@ -445,6 +386,13 @@
     </message>
 </context>
 <context>
+    <name>PluginItemWidget</name>
+    <message>
+        <source>Disconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PowerApplet</name>
     <message>
         <source>Power</source>
@@ -543,6 +491,14 @@
     </message>
     <message>
         <source>Charging, %1 hr until full</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Capacity %1, charging protection active</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Charging protection active</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/plugins/dde-dock/translations/dde-dock_nb.ts
+++ b/plugins/dde-dock/translations/dde-dock_nb.ts
@@ -194,65 +194,6 @@
     </message>
 </context>
 <context>
-    <name>DatetimeWidget</name>
-    <message>
-        <source>Monday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Tuesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Wednesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Thursday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Friday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Saturday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sunday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>monday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>tuesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>wednesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>thursday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>friday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>saturday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>sunday</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>DeviceControlWidget</name>
     <message>
         <source>Other Devices</source>
@@ -445,6 +386,13 @@
     </message>
 </context>
 <context>
+    <name>PluginItemWidget</name>
+    <message>
+        <source>Disconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PowerApplet</name>
     <message>
         <source>Power</source>
@@ -543,6 +491,14 @@
     </message>
     <message>
         <source>Charging, %1 hr until full</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Capacity %1, charging protection active</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Charging protection active</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/plugins/dde-dock/translations/dde-dock_ne.ts
+++ b/plugins/dde-dock/translations/dde-dock_ne.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="ne">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ne">
 <context>
     <name>AirplaneModeItem</name>
     <message>
@@ -52,7 +54,7 @@
     </message>
     <message>
         <source>Disable [Airplane Mode](#) first if you want to connect to a Bluetooth</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -189,65 +191,6 @@
     <message>
         <source>Open the calendar</source>
         <translation>कैलेंडर खोल्नुहोस्</translation>
-    </message>
-</context>
-<context>
-    <name>DatetimeWidget</name>
-    <message>
-        <source>Monday</source>
-        <translation>सोमबार</translation>
-    </message>
-    <message>
-        <source>Tuesday</source>
-        <translation>मंगलबार</translation>
-    </message>
-    <message>
-        <source>Wednesday</source>
-        <translation>बुधबार</translation>
-    </message>
-    <message>
-        <source>Thursday</source>
-        <translation>बिहिबार</translation>
-    </message>
-    <message>
-        <source>Friday</source>
-        <translation>शुक्रबार</translation>
-    </message>
-    <message>
-        <source>Saturday</source>
-        <translation>शनिबार</translation>
-    </message>
-    <message>
-        <source>Sunday</source>
-        <translation>आइतबार</translation>
-    </message>
-    <message>
-        <source>monday</source>
-        <translation>मङ्दावस</translation>
-    </message>
-    <message>
-        <source>tuesday</source>
-        <translation>बुधवास</translation>
-    </message>
-    <message>
-        <source>wednesday</source>
-        <translation>बीविषावस</translation>
-    </message>
-    <message>
-        <source>thursday</source>
-        <translation>गुरुवास</translation>
-    </message>
-    <message>
-        <source>friday</source>
-        <translation>शुक्रवास</translation>
-    </message>
-    <message>
-        <source>saturday</source>
-        <translation>शनिवास</translation>
-    </message>
-    <message>
-        <source>sunday</source>
-        <translation>रविवास</translation>
     </message>
 </context>
 <context>
@@ -443,6 +386,13 @@
     </message>
 </context>
 <context>
+    <name>PluginItemWidget</name>
+    <message>
+        <source>Disconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PowerApplet</name>
     <message>
         <source>Power</source>
@@ -545,18 +495,18 @@
     </message>
     <message>
         <source>Capacity %1, charging protection active</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Charging protection active</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>PowerStatusWidget</name>
     <message>
         <source>Power settings</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">पावर सेटिङहरू</translation>
     </message>
 </context>
 <context>
@@ -641,31 +591,31 @@
     </message>
     <message>
         <source>Monday</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">सोमबार</translation>
     </message>
     <message>
         <source>Tuesday</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">मंगलबार</translation>
     </message>
     <message>
         <source>Wednesday</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">बुधबार</translation>
     </message>
     <message>
         <source>Thursday</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">बिहिबार</translation>
     </message>
     <message>
         <source>Friday</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">शुक्रबार</translation>
     </message>
     <message>
         <source>Saturday</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">शनिबार</translation>
     </message>
     <message>
         <source>Sunday</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">आइतबार</translation>
     </message>
     <message>
         <source>Jan</source>

--- a/plugins/dde-dock/translations/dde-dock_nl.ts
+++ b/plugins/dde-dock/translations/dde-dock_nl.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="nl">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="nl">
 <context>
     <name>AirplaneModeItem</name>
     <message>
@@ -192,65 +194,6 @@
     </message>
 </context>
 <context>
-    <name>DatetimeWidget</name>
-    <message>
-        <source>Monday</source>
-        <translation>Maandag</translation>
-    </message>
-    <message>
-        <source>Tuesday</source>
-        <translation>Dinsdag</translation>
-    </message>
-    <message>
-        <source>Wednesday</source>
-        <translation>Woensdag</translation>
-    </message>
-    <message>
-        <source>Thursday</source>
-        <translation>Donderdag</translation>
-    </message>
-    <message>
-        <source>Friday</source>
-        <translation>Vrijdag</translation>
-    </message>
-    <message>
-        <source>Saturday</source>
-        <translation>Zaterdag</translation>
-    </message>
-    <message>
-        <source>Sunday</source>
-        <translation>Zondag</translation>
-    </message>
-    <message>
-        <source>monday</source>
-        <translation>maandag</translation>
-    </message>
-    <message>
-        <source>tuesday</source>
-        <translation>dinsdag</translation>
-    </message>
-    <message>
-        <source>wednesday</source>
-        <translation>woensdag</translation>
-    </message>
-    <message>
-        <source>thursday</source>
-        <translation>donderdag</translation>
-    </message>
-    <message>
-        <source>friday</source>
-        <translation>vrijdag</translation>
-    </message>
-    <message>
-        <source>saturday</source>
-        <translation>zaterdag</translation>
-    </message>
-    <message>
-        <source>sunday</source>
-        <translation>zondag</translation>
-    </message>
-</context>
-<context>
     <name>DeviceControlWidget</name>
     <message>
         <source>Other Devices</source>
@@ -440,6 +383,13 @@
     <message>
         <source>Balance Performance</source>
         <translation>Gebalanceerde prestaties</translation>
+    </message>
+</context>
+<context>
+    <name>PluginItemWidget</name>
+    <message>
+        <source>Disconnect</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/plugins/dde-dock/translations/dde-dock_pa.ts
+++ b/plugins/dde-dock/translations/dde-dock_pa.ts
@@ -194,65 +194,6 @@
     </message>
 </context>
 <context>
-    <name>DatetimeWidget</name>
-    <message>
-        <source>Monday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Tuesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Wednesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Thursday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Friday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Saturday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sunday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>monday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>tuesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>wednesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>thursday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>friday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>saturday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>sunday</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>DeviceControlWidget</name>
     <message>
         <source>Other Devices</source>
@@ -445,6 +386,13 @@
     </message>
 </context>
 <context>
+    <name>PluginItemWidget</name>
+    <message>
+        <source>Disconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PowerApplet</name>
     <message>
         <source>Power</source>
@@ -543,6 +491,14 @@
     </message>
     <message>
         <source>Charging, %1 hr until full</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Capacity %1, charging protection active</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Charging protection active</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/plugins/dde-dock/translations/dde-dock_pl.ts
+++ b/plugins/dde-dock/translations/dde-dock_pl.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="pl">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="pl">
 <context>
     <name>AirplaneModeItem</name>
     <message>
@@ -192,65 +194,6 @@
     </message>
 </context>
 <context>
-    <name>DatetimeWidget</name>
-    <message>
-        <source>Monday</source>
-        <translation>Poniedziałek</translation>
-    </message>
-    <message>
-        <source>Tuesday</source>
-        <translation>Wtorek</translation>
-    </message>
-    <message>
-        <source>Wednesday</source>
-        <translation>Środa</translation>
-    </message>
-    <message>
-        <source>Thursday</source>
-        <translation>Czwartek</translation>
-    </message>
-    <message>
-        <source>Friday</source>
-        <translation>Piątek</translation>
-    </message>
-    <message>
-        <source>Saturday</source>
-        <translation>Sobota</translation>
-    </message>
-    <message>
-        <source>Sunday</source>
-        <translation>Niedziela</translation>
-    </message>
-    <message>
-        <source>monday</source>
-        <translation>poniedziałek</translation>
-    </message>
-    <message>
-        <source>tuesday</source>
-        <translation>wtorek</translation>
-    </message>
-    <message>
-        <source>wednesday</source>
-        <translation>środa</translation>
-    </message>
-    <message>
-        <source>thursday</source>
-        <translation>czwartek</translation>
-    </message>
-    <message>
-        <source>friday</source>
-        <translation>piątek</translation>
-    </message>
-    <message>
-        <source>saturday</source>
-        <translation>sobota</translation>
-    </message>
-    <message>
-        <source>sunday</source>
-        <translation>niedziela</translation>
-    </message>
-</context>
-<context>
     <name>DeviceControlWidget</name>
     <message>
         <source>Other Devices</source>
@@ -440,6 +383,13 @@
     <message>
         <source>Balance Performance</source>
         <translation>Wydajność zbalansowana</translation>
+    </message>
+</context>
+<context>
+    <name>PluginItemWidget</name>
+    <message>
+        <source>Disconnect</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/plugins/dde-dock/translations/dde-dock_ps.ts
+++ b/plugins/dde-dock/translations/dde-dock_ps.ts
@@ -194,65 +194,6 @@
     </message>
 </context>
 <context>
-    <name>DatetimeWidget</name>
-    <message>
-        <source>Monday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Tuesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Wednesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Thursday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Friday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Saturday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sunday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>monday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>tuesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>wednesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>thursday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>friday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>saturday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>sunday</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>DeviceControlWidget</name>
     <message>
         <source>Other Devices</source>
@@ -445,6 +386,13 @@
     </message>
 </context>
 <context>
+    <name>PluginItemWidget</name>
+    <message>
+        <source>Disconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PowerApplet</name>
     <message>
         <source>Power</source>
@@ -543,6 +491,14 @@
     </message>
     <message>
         <source>Charging, %1 hr until full</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Capacity %1, charging protection active</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Charging protection active</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/plugins/dde-dock/translations/dde-dock_pt.ts
+++ b/plugins/dde-dock/translations/dde-dock_pt.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="pt">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="pt">
 <context>
     <name>AirplaneModeItem</name>
     <message>
@@ -52,7 +54,7 @@
     </message>
     <message>
         <source>Disable [Airplane Mode](#) first if you want to connect to a Bluetooth</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -189,65 +191,6 @@
     <message>
         <source>Open the calendar</source>
         <translation>Abrir o Calendário</translation>
-    </message>
-</context>
-<context>
-    <name>DatetimeWidget</name>
-    <message>
-        <source>Monday</source>
-        <translation>Segunda</translation>
-    </message>
-    <message>
-        <source>Tuesday</source>
-        <translation>Terça</translation>
-    </message>
-    <message>
-        <source>Wednesday</source>
-        <translation>Quarta</translation>
-    </message>
-    <message>
-        <source>Thursday</source>
-        <translation>Quinta</translation>
-    </message>
-    <message>
-        <source>Friday</source>
-        <translation>Sexta</translation>
-    </message>
-    <message>
-        <source>Saturday</source>
-        <translation>Sábado</translation>
-    </message>
-    <message>
-        <source>Sunday</source>
-        <translation>Domingo</translation>
-    </message>
-    <message>
-        <source>monday</source>
-        <translation>segunda</translation>
-    </message>
-    <message>
-        <source>tuesday</source>
-        <translation>terça</translation>
-    </message>
-    <message>
-        <source>wednesday</source>
-        <translation>quarta</translation>
-    </message>
-    <message>
-        <source>thursday</source>
-        <translation>quinta</translation>
-    </message>
-    <message>
-        <source>friday</source>
-        <translation>sexta</translation>
-    </message>
-    <message>
-        <source>saturday</source>
-        <translation>sábado</translation>
-    </message>
-    <message>
-        <source>sunday</source>
-        <translation>domingo</translation>
     </message>
 </context>
 <context>
@@ -439,7 +382,14 @@
     </message>
     <message>
         <source>Balance Performance</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PluginItemWidget</name>
+    <message>
+        <source>Disconnect</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -545,11 +495,11 @@
     </message>
     <message>
         <source>Capacity %1, charging protection active</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Charging protection active</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/plugins/dde-dock/translations/dde-dock_pt_BR.ts
+++ b/plugins/dde-dock/translations/dde-dock_pt_BR.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="pt_BR">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="pt_BR">
 <context>
     <name>AirplaneModeItem</name>
     <message>
@@ -192,65 +194,6 @@
     </message>
 </context>
 <context>
-    <name>DatetimeWidget</name>
-    <message>
-        <source>Monday</source>
-        <translation>Segunda-feira</translation>
-    </message>
-    <message>
-        <source>Tuesday</source>
-        <translation>Terça-feira</translation>
-    </message>
-    <message>
-        <source>Wednesday</source>
-        <translation>Quarta-feira</translation>
-    </message>
-    <message>
-        <source>Thursday</source>
-        <translation>Quinta-feira</translation>
-    </message>
-    <message>
-        <source>Friday</source>
-        <translation>Sexta-feira</translation>
-    </message>
-    <message>
-        <source>Saturday</source>
-        <translation>Sábado</translation>
-    </message>
-    <message>
-        <source>Sunday</source>
-        <translation>Domingo</translation>
-    </message>
-    <message>
-        <source>monday</source>
-        <translation>segunda-feira</translation>
-    </message>
-    <message>
-        <source>tuesday</source>
-        <translation>terça-feira</translation>
-    </message>
-    <message>
-        <source>wednesday</source>
-        <translation>quarta-feira</translation>
-    </message>
-    <message>
-        <source>thursday</source>
-        <translation>quinta-feira</translation>
-    </message>
-    <message>
-        <source>friday</source>
-        <translation>sexta-feira</translation>
-    </message>
-    <message>
-        <source>saturday</source>
-        <translation>sábado</translation>
-    </message>
-    <message>
-        <source>sunday</source>
-        <translation>domingo</translation>
-    </message>
-</context>
-<context>
     <name>DeviceControlWidget</name>
     <message>
         <source>Other Devices</source>
@@ -440,6 +383,13 @@
     <message>
         <source>Balance Performance</source>
         <translation>Desempenho Equilibrado</translation>
+    </message>
+</context>
+<context>
+    <name>PluginItemWidget</name>
+    <message>
+        <source>Disconnect</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/plugins/dde-dock/translations/dde-dock_ro.ts
+++ b/plugins/dde-dock/translations/dde-dock_ro.ts
@@ -194,65 +194,6 @@
     </message>
 </context>
 <context>
-    <name>DatetimeWidget</name>
-    <message>
-        <source>Monday</source>
-        <translation>Luni</translation>
-    </message>
-    <message>
-        <source>Tuesday</source>
-        <translation>Marţi</translation>
-    </message>
-    <message>
-        <source>Wednesday</source>
-        <translation>Miercuri</translation>
-    </message>
-    <message>
-        <source>Thursday</source>
-        <translation>Joi</translation>
-    </message>
-    <message>
-        <source>Friday</source>
-        <translation>Vineri</translation>
-    </message>
-    <message>
-        <source>Saturday</source>
-        <translation>Sâmbătă</translation>
-    </message>
-    <message>
-        <source>Sunday</source>
-        <translation>Duminică</translation>
-    </message>
-    <message>
-        <source>monday</source>
-        <translation>luni</translation>
-    </message>
-    <message>
-        <source>tuesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>wednesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>thursday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>friday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>saturday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>sunday</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>DeviceControlWidget</name>
     <message>
         <source>Other Devices</source>
@@ -445,6 +386,13 @@
     </message>
 </context>
 <context>
+    <name>PluginItemWidget</name>
+    <message>
+        <source>Disconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PowerApplet</name>
     <message>
         <source>Power</source>
@@ -543,6 +491,14 @@
     </message>
     <message>
         <source>Charging, %1 hr until full</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Capacity %1, charging protection active</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Charging protection active</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/plugins/dde-dock/translations/dde-dock_ru.ts
+++ b/plugins/dde-dock/translations/dde-dock_ru.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="ru">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ru">
 <context>
     <name>AirplaneModeItem</name>
     <message>
@@ -189,65 +191,6 @@
     <message>
         <source>Open the calendar</source>
         <translation>Открыть календарь</translation>
-    </message>
-</context>
-<context>
-    <name>DatetimeWidget</name>
-    <message>
-        <source>Monday</source>
-        <translation>Понедельник</translation>
-    </message>
-    <message>
-        <source>Tuesday</source>
-        <translation>Вторник</translation>
-    </message>
-    <message>
-        <source>Wednesday</source>
-        <translation>Среда</translation>
-    </message>
-    <message>
-        <source>Thursday</source>
-        <translation>Четверг</translation>
-    </message>
-    <message>
-        <source>Friday</source>
-        <translation>Пятница</translation>
-    </message>
-    <message>
-        <source>Saturday</source>
-        <translation>Суббота</translation>
-    </message>
-    <message>
-        <source>Sunday</source>
-        <translation>Воскресенье</translation>
-    </message>
-    <message>
-        <source>monday</source>
-        <translation>понедельник</translation>
-    </message>
-    <message>
-        <source>tuesday</source>
-        <translation>вторник</translation>
-    </message>
-    <message>
-        <source>wednesday</source>
-        <translation>среда</translation>
-    </message>
-    <message>
-        <source>thursday</source>
-        <translation>четверг</translation>
-    </message>
-    <message>
-        <source>friday</source>
-        <translation>пятница</translation>
-    </message>
-    <message>
-        <source>saturday</source>
-        <translation>суббота</translation>
-    </message>
-    <message>
-        <source>sunday</source>
-        <translation>воскресенье</translation>
     </message>
 </context>
 <context>
@@ -443,6 +386,13 @@
     </message>
 </context>
 <context>
+    <name>PluginItemWidget</name>
+    <message>
+        <source>Disconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PowerApplet</name>
     <message>
         <source>Power</source>
@@ -549,7 +499,7 @@
     </message>
     <message>
         <source>Charging protection active</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/plugins/dde-dock/translations/dde-dock_ru_UA.ts
+++ b/plugins/dde-dock/translations/dde-dock_ru_UA.ts
@@ -194,65 +194,6 @@
     </message>
 </context>
 <context>
-    <name>DatetimeWidget</name>
-    <message>
-        <source>Monday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Tuesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Wednesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Thursday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Friday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Saturday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sunday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>monday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>tuesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>wednesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>thursday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>friday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>saturday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>sunday</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>DeviceControlWidget</name>
     <message>
         <source>Other Devices</source>
@@ -445,6 +386,13 @@
     </message>
 </context>
 <context>
+    <name>PluginItemWidget</name>
+    <message>
+        <source>Disconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PowerApplet</name>
     <message>
         <source>Power</source>
@@ -543,6 +491,14 @@
     </message>
     <message>
         <source>Charging, %1 hr until full</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Capacity %1, charging protection active</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Charging protection active</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/plugins/dde-dock/translations/dde-dock_sc.ts
+++ b/plugins/dde-dock/translations/dde-dock_sc.ts
@@ -194,65 +194,6 @@
     </message>
 </context>
 <context>
-    <name>DatetimeWidget</name>
-    <message>
-        <source>Monday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Tuesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Wednesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Thursday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Friday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Saturday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sunday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>monday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>tuesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>wednesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>thursday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>friday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>saturday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>sunday</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>DeviceControlWidget</name>
     <message>
         <source>Other Devices</source>
@@ -445,6 +386,13 @@
     </message>
 </context>
 <context>
+    <name>PluginItemWidget</name>
+    <message>
+        <source>Disconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PowerApplet</name>
     <message>
         <source>Power</source>
@@ -543,6 +491,14 @@
     </message>
     <message>
         <source>Charging, %1 hr until full</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Capacity %1, charging protection active</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Charging protection active</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/plugins/dde-dock/translations/dde-dock_si.ts
+++ b/plugins/dde-dock/translations/dde-dock_si.ts
@@ -194,65 +194,6 @@
     </message>
 </context>
 <context>
-    <name>DatetimeWidget</name>
-    <message>
-        <source>Monday</source>
-        <translation>සඳුදා</translation>
-    </message>
-    <message>
-        <source>Tuesday</source>
-        <translation>අඟහරුවාදා</translation>
-    </message>
-    <message>
-        <source>Wednesday</source>
-        <translation>බදාදා</translation>
-    </message>
-    <message>
-        <source>Thursday</source>
-        <translation>බ්‍රහස්පතින්දා</translation>
-    </message>
-    <message>
-        <source>Friday</source>
-        <translation>සිකුරාදා</translation>
-    </message>
-    <message>
-        <source>Saturday</source>
-        <translation>සෙනසුරාදා</translation>
-    </message>
-    <message>
-        <source>Sunday</source>
-        <translation>ඉරිදා</translation>
-    </message>
-    <message>
-        <source>monday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>tuesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>wednesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>thursday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>friday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>saturday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>sunday</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>DeviceControlWidget</name>
     <message>
         <source>Other Devices</source>
@@ -445,6 +386,13 @@
     </message>
 </context>
 <context>
+    <name>PluginItemWidget</name>
+    <message>
+        <source>Disconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PowerApplet</name>
     <message>
         <source>Power</source>
@@ -543,6 +491,14 @@
     </message>
     <message>
         <source>Charging, %1 hr until full</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Capacity %1, charging protection active</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Charging protection active</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/plugins/dde-dock/translations/dde-dock_sk.ts
+++ b/plugins/dde-dock/translations/dde-dock_sk.ts
@@ -194,65 +194,6 @@
     </message>
 </context>
 <context>
-    <name>DatetimeWidget</name>
-    <message>
-        <source>Monday</source>
-        <translation>Pondelok</translation>
-    </message>
-    <message>
-        <source>Tuesday</source>
-        <translation>Utorok</translation>
-    </message>
-    <message>
-        <source>Wednesday</source>
-        <translation>Streda</translation>
-    </message>
-    <message>
-        <source>Thursday</source>
-        <translation>Štvrtok</translation>
-    </message>
-    <message>
-        <source>Friday</source>
-        <translation>Piatok</translation>
-    </message>
-    <message>
-        <source>Saturday</source>
-        <translation>Sobota</translation>
-    </message>
-    <message>
-        <source>Sunday</source>
-        <translation>Nedeľa</translation>
-    </message>
-    <message>
-        <source>monday</source>
-        <translation>pondelok</translation>
-    </message>
-    <message>
-        <source>tuesday</source>
-        <translation>Utorok</translation>
-    </message>
-    <message>
-        <source>wednesday</source>
-        <translation>streda</translation>
-    </message>
-    <message>
-        <source>thursday</source>
-        <translation>štvrtok</translation>
-    </message>
-    <message>
-        <source>friday</source>
-        <translation>piatok</translation>
-    </message>
-    <message>
-        <source>saturday</source>
-        <translation>sobota</translation>
-    </message>
-    <message>
-        <source>sunday</source>
-        <translation>nedeľa</translation>
-    </message>
-</context>
-<context>
     <name>DeviceControlWidget</name>
     <message>
         <source>Other Devices</source>
@@ -445,6 +386,13 @@
     </message>
 </context>
 <context>
+    <name>PluginItemWidget</name>
+    <message>
+        <source>Disconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PowerApplet</name>
     <message>
         <source>Power</source>
@@ -543,6 +491,14 @@
     </message>
     <message>
         <source>Charging, %1 hr until full</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Capacity %1, charging protection active</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Charging protection active</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/plugins/dde-dock/translations/dde-dock_sl.ts
+++ b/plugins/dde-dock/translations/dde-dock_sl.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="sl">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="sl">
 <context>
     <name>AirplaneModeItem</name>
     <message>
@@ -52,7 +54,7 @@
     </message>
     <message>
         <source>Disable [Airplane Mode](#) first if you want to connect to a Bluetooth</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -189,65 +191,6 @@
     <message>
         <source>Open the calendar</source>
         <translation>Odpri kalendar</translation>
-    </message>
-</context>
-<context>
-    <name>DatetimeWidget</name>
-    <message>
-        <source>Monday</source>
-        <translation>Ponedeljek</translation>
-    </message>
-    <message>
-        <source>Tuesday</source>
-        <translation>Torek</translation>
-    </message>
-    <message>
-        <source>Wednesday</source>
-        <translation>Sreda</translation>
-    </message>
-    <message>
-        <source>Thursday</source>
-        <translation>Četrtek</translation>
-    </message>
-    <message>
-        <source>Friday</source>
-        <translation>Petek</translation>
-    </message>
-    <message>
-        <source>Saturday</source>
-        <translation>Sobota</translation>
-    </message>
-    <message>
-        <source>Sunday</source>
-        <translation>Nedelja</translation>
-    </message>
-    <message>
-        <source>monday</source>
-        <translation>ponedeljek</translation>
-    </message>
-    <message>
-        <source>tuesday</source>
-        <translation>ponedeljek</translation>
-    </message>
-    <message>
-        <source>wednesday</source>
-        <translation>toreg</translation>
-    </message>
-    <message>
-        <source>thursday</source>
-        <translation>sreda</translation>
-    </message>
-    <message>
-        <source>friday</source>
-        <translation>četrtek</translation>
-    </message>
-    <message>
-        <source>saturday</source>
-        <translation>petek</translation>
-    </message>
-    <message>
-        <source>sunday</source>
-        <translation>sobota</translation>
     </message>
 </context>
 <context>
@@ -443,6 +386,13 @@
     </message>
 </context>
 <context>
+    <name>PluginItemWidget</name>
+    <message>
+        <source>Disconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PowerApplet</name>
     <message>
         <source>Power</source>
@@ -549,14 +499,14 @@
     </message>
     <message>
         <source>Charging protection active</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>PowerStatusWidget</name>
     <message>
         <source>Power settings</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Nastavitve energijske porabe</translation>
     </message>
 </context>
 <context>

--- a/plugins/dde-dock/translations/dde-dock_sq.ts
+++ b/plugins/dde-dock/translations/dde-dock_sq.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="sq">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="sq">
 <context>
     <name>AirplaneModeItem</name>
     <message>
@@ -192,65 +194,6 @@
     </message>
 </context>
 <context>
-    <name>DatetimeWidget</name>
-    <message>
-        <source>Monday</source>
-        <translation>E hënë</translation>
-    </message>
-    <message>
-        <source>Tuesday</source>
-        <translation>E martë</translation>
-    </message>
-    <message>
-        <source>Wednesday</source>
-        <translation>E mërkurë</translation>
-    </message>
-    <message>
-        <source>Thursday</source>
-        <translation>E enjte</translation>
-    </message>
-    <message>
-        <source>Friday</source>
-        <translation>E premte</translation>
-    </message>
-    <message>
-        <source>Saturday</source>
-        <translation>E shtunë</translation>
-    </message>
-    <message>
-        <source>Sunday</source>
-        <translation>E diel</translation>
-    </message>
-    <message>
-        <source>monday</source>
-        <translation>e hënë</translation>
-    </message>
-    <message>
-        <source>tuesday</source>
-        <translation>e martë</translation>
-    </message>
-    <message>
-        <source>wednesday</source>
-        <translation>e mërkurë</translation>
-    </message>
-    <message>
-        <source>thursday</source>
-        <translation>e enjte</translation>
-    </message>
-    <message>
-        <source>friday</source>
-        <translation>e premte</translation>
-    </message>
-    <message>
-        <source>saturday</source>
-        <translation>e shtunë</translation>
-    </message>
-    <message>
-        <source>sunday</source>
-        <translation>e diel</translation>
-    </message>
-</context>
-<context>
     <name>DeviceControlWidget</name>
     <message>
         <source>Other Devices</source>
@@ -416,7 +359,7 @@
     <name>OnboardPlugin</name>
     <message>
         <source>Onboard</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Settings</source>
@@ -427,7 +370,7 @@
     <name>PerformanceModeController</name>
     <message>
         <source>High Performance</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Balanced</source>
@@ -439,7 +382,14 @@
     </message>
     <message>
         <source>Balance Performance</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PluginItemWidget</name>
+    <message>
+        <source>Disconnect</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -756,7 +706,7 @@
     </message>
     <message>
         <source>Output</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Sound settings</source>

--- a/plugins/dde-dock/translations/dde-dock_sr.ts
+++ b/plugins/dde-dock/translations/dde-dock_sr.ts
@@ -194,65 +194,6 @@
     </message>
 </context>
 <context>
-    <name>DatetimeWidget</name>
-    <message>
-        <source>Monday</source>
-        <translation>Понедељак</translation>
-    </message>
-    <message>
-        <source>Tuesday</source>
-        <translation>Уторак</translation>
-    </message>
-    <message>
-        <source>Wednesday</source>
-        <translation>Среда</translation>
-    </message>
-    <message>
-        <source>Thursday</source>
-        <translation>Четвртак</translation>
-    </message>
-    <message>
-        <source>Friday</source>
-        <translation>Петак</translation>
-    </message>
-    <message>
-        <source>Saturday</source>
-        <translation>Субота</translation>
-    </message>
-    <message>
-        <source>Sunday</source>
-        <translation>Недеља</translation>
-    </message>
-    <message>
-        <source>monday</source>
-        <translation>понедељак</translation>
-    </message>
-    <message>
-        <source>tuesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>wednesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>thursday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>friday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>saturday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>sunday</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>DeviceControlWidget</name>
     <message>
         <source>Other Devices</source>
@@ -445,6 +386,13 @@
     </message>
 </context>
 <context>
+    <name>PluginItemWidget</name>
+    <message>
+        <source>Disconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PowerApplet</name>
     <message>
         <source>Power</source>
@@ -543,6 +491,14 @@
     </message>
     <message>
         <source>Charging, %1 hr until full</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Capacity %1, charging protection active</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Charging protection active</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/plugins/dde-dock/translations/dde-dock_sv.ts
+++ b/plugins/dde-dock/translations/dde-dock_sv.ts
@@ -194,65 +194,6 @@
     </message>
 </context>
 <context>
-    <name>DatetimeWidget</name>
-    <message>
-        <source>Monday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Tuesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Wednesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Thursday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Friday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Saturday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sunday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>monday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>tuesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>wednesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>thursday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>friday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>saturday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>sunday</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>DeviceControlWidget</name>
     <message>
         <source>Other Devices</source>
@@ -445,6 +386,13 @@
     </message>
 </context>
 <context>
+    <name>PluginItemWidget</name>
+    <message>
+        <source>Disconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PowerApplet</name>
     <message>
         <source>Power</source>
@@ -543,6 +491,14 @@
     </message>
     <message>
         <source>Charging, %1 hr until full</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Capacity %1, charging protection active</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Charging protection active</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/plugins/dde-dock/translations/dde-dock_sv_SE.ts
+++ b/plugins/dde-dock/translations/dde-dock_sv_SE.ts
@@ -194,65 +194,6 @@
     </message>
 </context>
 <context>
-    <name>DatetimeWidget</name>
-    <message>
-        <source>Monday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Tuesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Wednesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Thursday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Friday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Saturday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sunday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>monday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>tuesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>wednesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>thursday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>friday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>saturday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>sunday</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>DeviceControlWidget</name>
     <message>
         <source>Other Devices</source>
@@ -445,6 +386,13 @@
     </message>
 </context>
 <context>
+    <name>PluginItemWidget</name>
+    <message>
+        <source>Disconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PowerApplet</name>
     <message>
         <source>Power</source>
@@ -543,6 +491,14 @@
     </message>
     <message>
         <source>Charging, %1 hr until full</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Capacity %1, charging protection active</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Charging protection active</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/plugins/dde-dock/translations/dde-dock_sw.ts
+++ b/plugins/dde-dock/translations/dde-dock_sw.ts
@@ -194,65 +194,6 @@
     </message>
 </context>
 <context>
-    <name>DatetimeWidget</name>
-    <message>
-        <source>Monday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Tuesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Wednesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Thursday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Friday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Saturday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sunday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>monday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>tuesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>wednesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>thursday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>friday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>saturday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>sunday</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>DeviceControlWidget</name>
     <message>
         <source>Other Devices</source>
@@ -445,6 +386,13 @@
     </message>
 </context>
 <context>
+    <name>PluginItemWidget</name>
+    <message>
+        <source>Disconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PowerApplet</name>
     <message>
         <source>Power</source>
@@ -543,6 +491,14 @@
     </message>
     <message>
         <source>Charging, %1 hr until full</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Capacity %1, charging protection active</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Charging protection active</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/plugins/dde-dock/translations/dde-dock_ta.ts
+++ b/plugins/dde-dock/translations/dde-dock_ta.ts
@@ -194,65 +194,6 @@
     </message>
 </context>
 <context>
-    <name>DatetimeWidget</name>
-    <message>
-        <source>Monday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Tuesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Wednesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Thursday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Friday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Saturday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sunday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>monday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>tuesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>wednesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>thursday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>friday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>saturday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>sunday</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>DeviceControlWidget</name>
     <message>
         <source>Other Devices</source>
@@ -445,6 +386,13 @@
     </message>
 </context>
 <context>
+    <name>PluginItemWidget</name>
+    <message>
+        <source>Disconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PowerApplet</name>
     <message>
         <source>Power</source>
@@ -543,6 +491,14 @@
     </message>
     <message>
         <source>Charging, %1 hr until full</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Capacity %1, charging protection active</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Charging protection active</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/plugins/dde-dock/translations/dde-dock_te.ts
+++ b/plugins/dde-dock/translations/dde-dock_te.ts
@@ -194,65 +194,6 @@
     </message>
 </context>
 <context>
-    <name>DatetimeWidget</name>
-    <message>
-        <source>Monday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Tuesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Wednesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Thursday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Friday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Saturday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sunday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>monday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>tuesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>wednesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>thursday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>friday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>saturday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>sunday</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>DeviceControlWidget</name>
     <message>
         <source>Other Devices</source>
@@ -445,6 +386,13 @@
     </message>
 </context>
 <context>
+    <name>PluginItemWidget</name>
+    <message>
+        <source>Disconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PowerApplet</name>
     <message>
         <source>Power</source>
@@ -543,6 +491,14 @@
     </message>
     <message>
         <source>Charging, %1 hr until full</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Capacity %1, charging protection active</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Charging protection active</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/plugins/dde-dock/translations/dde-dock_th.ts
+++ b/plugins/dde-dock/translations/dde-dock_th.ts
@@ -194,65 +194,6 @@
     </message>
 </context>
 <context>
-    <name>DatetimeWidget</name>
-    <message>
-        <source>Monday</source>
-        <translation>วันจันทร์</translation>
-    </message>
-    <message>
-        <source>Tuesday</source>
-        <translation>วันอังคาร</translation>
-    </message>
-    <message>
-        <source>Wednesday</source>
-        <translation>วันพุธ</translation>
-    </message>
-    <message>
-        <source>Thursday</source>
-        <translation>วันพฤหัสบดี</translation>
-    </message>
-    <message>
-        <source>Friday</source>
-        <translation>วันศุกร์</translation>
-    </message>
-    <message>
-        <source>Saturday</source>
-        <translation>วันศุกร์</translation>
-    </message>
-    <message>
-        <source>Sunday</source>
-        <translation>วันอาทิตย์</translation>
-    </message>
-    <message>
-        <source>monday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>tuesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>wednesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>thursday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>friday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>saturday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>sunday</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>DeviceControlWidget</name>
     <message>
         <source>Other Devices</source>
@@ -445,6 +386,13 @@
     </message>
 </context>
 <context>
+    <name>PluginItemWidget</name>
+    <message>
+        <source>Disconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PowerApplet</name>
     <message>
         <source>Power</source>
@@ -543,6 +491,14 @@
     </message>
     <message>
         <source>Charging, %1 hr until full</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Capacity %1, charging protection active</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Charging protection active</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/plugins/dde-dock/translations/dde-dock_tr.ts
+++ b/plugins/dde-dock/translations/dde-dock_tr.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="tr">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="tr">
 <context>
     <name>AirplaneModeItem</name>
     <message>
@@ -189,65 +191,6 @@
     <message>
         <source>Open the calendar</source>
         <translation>Takvimi aç</translation>
-    </message>
-</context>
-<context>
-    <name>DatetimeWidget</name>
-    <message>
-        <source>Monday</source>
-        <translation>Pazartesi</translation>
-    </message>
-    <message>
-        <source>Tuesday</source>
-        <translation>Salı</translation>
-    </message>
-    <message>
-        <source>Wednesday</source>
-        <translation>Çarşamba</translation>
-    </message>
-    <message>
-        <source>Thursday</source>
-        <translation>Perşembe</translation>
-    </message>
-    <message>
-        <source>Friday</source>
-        <translation>Cuma</translation>
-    </message>
-    <message>
-        <source>Saturday</source>
-        <translation>Cumartesi</translation>
-    </message>
-    <message>
-        <source>Sunday</source>
-        <translation>Pazar</translation>
-    </message>
-    <message>
-        <source>monday</source>
-        <translation>pazartesi</translation>
-    </message>
-    <message>
-        <source>tuesday</source>
-        <translation>Salı</translation>
-    </message>
-    <message>
-        <source>wednesday</source>
-        <translation>Çarşamba</translation>
-    </message>
-    <message>
-        <source>thursday</source>
-        <translation>Perşembe</translation>
-    </message>
-    <message>
-        <source>friday</source>
-        <translation>Cuma</translation>
-    </message>
-    <message>
-        <source>saturday</source>
-        <translation>Cumartesi</translation>
-    </message>
-    <message>
-        <source>sunday</source>
-        <translation>pazar</translation>
     </message>
 </context>
 <context>
@@ -443,6 +386,13 @@
     </message>
 </context>
 <context>
+    <name>PluginItemWidget</name>
+    <message>
+        <source>Disconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PowerApplet</name>
     <message>
         <source>Power</source>
@@ -549,7 +499,7 @@
     </message>
     <message>
         <source>Charging protection active</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/plugins/dde-dock/translations/dde-dock_ug.ts
+++ b/plugins/dde-dock/translations/dde-dock_ug.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="ug">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ug">
 <context>
     <name>AirplaneModeItem</name>
     <message>
@@ -52,7 +54,7 @@
     </message>
     <message>
         <source>Disable [Airplane Mode](#) first if you want to connect to a Bluetooth</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -189,65 +191,6 @@
     <message>
         <source>Open the calendar</source>
         <translation>كالېندارنى ئېچىش</translation>
-    </message>
-</context>
-<context>
-    <name>DatetimeWidget</name>
-    <message>
-        <source>Monday</source>
-        <translation>دۈشەنبە</translation>
-    </message>
-    <message>
-        <source>Tuesday</source>
-        <translation>سەيشەنبە</translation>
-    </message>
-    <message>
-        <source>Wednesday</source>
-        <translation>چارشەنبە</translation>
-    </message>
-    <message>
-        <source>Thursday</source>
-        <translation>پەيشەنبە</translation>
-    </message>
-    <message>
-        <source>Friday</source>
-        <translation>جۈمە</translation>
-    </message>
-    <message>
-        <source>Saturday</source>
-        <translation>شەنبە</translation>
-    </message>
-    <message>
-        <source>Sunday</source>
-        <translation>يەكشەنبە</translation>
-    </message>
-    <message>
-        <source>monday</source>
-        <translation>دۈشەنبە</translation>
-    </message>
-    <message>
-        <source>tuesday</source>
-        <translation>سەيشەنبە</translation>
-    </message>
-    <message>
-        <source>wednesday</source>
-        <translation>چارشەنبە</translation>
-    </message>
-    <message>
-        <source>thursday</source>
-        <translation>پەيشەنبە</translation>
-    </message>
-    <message>
-        <source>friday</source>
-        <translation>جۈمە</translation>
-    </message>
-    <message>
-        <source>saturday</source>
-        <translation>شەنبە</translation>
-    </message>
-    <message>
-        <source>sunday</source>
-        <translation>يەكشەنبە</translation>
     </message>
 </context>
 <context>
@@ -439,7 +382,14 @@
     </message>
     <message>
         <source>Balance Performance</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PluginItemWidget</name>
+    <message>
+        <source>Disconnect</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -545,11 +495,11 @@
     </message>
     <message>
         <source>Capacity %1, charging protection active</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Charging protection active</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/plugins/dde-dock/translations/dde-dock_uk.ts
+++ b/plugins/dde-dock/translations/dde-dock_uk.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="uk">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="uk">
 <context>
     <name>AirplaneModeItem</name>
     <message>
@@ -192,65 +194,6 @@
     </message>
 </context>
 <context>
-    <name>DatetimeWidget</name>
-    <message>
-        <source>Monday</source>
-        <translation>Понеділок</translation>
-    </message>
-    <message>
-        <source>Tuesday</source>
-        <translation>Вівторок</translation>
-    </message>
-    <message>
-        <source>Wednesday</source>
-        <translation>Середа</translation>
-    </message>
-    <message>
-        <source>Thursday</source>
-        <translation>Четвер</translation>
-    </message>
-    <message>
-        <source>Friday</source>
-        <translation>П&apos;ятниця</translation>
-    </message>
-    <message>
-        <source>Saturday</source>
-        <translation>Субота</translation>
-    </message>
-    <message>
-        <source>Sunday</source>
-        <translation>Неділя</translation>
-    </message>
-    <message>
-        <source>monday</source>
-        <translation>Понеділок</translation>
-    </message>
-    <message>
-        <source>tuesday</source>
-        <translation>вівторок</translation>
-    </message>
-    <message>
-        <source>wednesday</source>
-        <translation>середа</translation>
-    </message>
-    <message>
-        <source>thursday</source>
-        <translation>четвер</translation>
-    </message>
-    <message>
-        <source>friday</source>
-        <translation>п&apos;ятниця</translation>
-    </message>
-    <message>
-        <source>saturday</source>
-        <translation>субота</translation>
-    </message>
-    <message>
-        <source>sunday</source>
-        <translation>неділя</translation>
-    </message>
-</context>
-<context>
     <name>DeviceControlWidget</name>
     <message>
         <source>Other Devices</source>
@@ -440,6 +383,13 @@
     <message>
         <source>Balance Performance</source>
         <translation>Збалансована швидкодія</translation>
+    </message>
+</context>
+<context>
+    <name>PluginItemWidget</name>
+    <message>
+        <source>Disconnect</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/plugins/dde-dock/translations/dde-dock_ur.ts
+++ b/plugins/dde-dock/translations/dde-dock_ur.ts
@@ -194,65 +194,6 @@
     </message>
 </context>
 <context>
-    <name>DatetimeWidget</name>
-    <message>
-        <source>Monday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Tuesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Wednesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Thursday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Friday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Saturday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sunday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>monday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>tuesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>wednesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>thursday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>friday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>saturday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>sunday</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>DeviceControlWidget</name>
     <message>
         <source>Other Devices</source>
@@ -445,6 +386,13 @@
     </message>
 </context>
 <context>
+    <name>PluginItemWidget</name>
+    <message>
+        <source>Disconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PowerApplet</name>
     <message>
         <source>Power</source>
@@ -543,6 +491,14 @@
     </message>
     <message>
         <source>Charging, %1 hr until full</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Capacity %1, charging protection active</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Charging protection active</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/plugins/dde-dock/translations/dde-dock_uz.ts
+++ b/plugins/dde-dock/translations/dde-dock_uz.ts
@@ -194,65 +194,6 @@
     </message>
 </context>
 <context>
-    <name>DatetimeWidget</name>
-    <message>
-        <source>Monday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Tuesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Wednesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Thursday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Friday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Saturday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sunday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>monday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>tuesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>wednesday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>thursday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>friday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>saturday</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>sunday</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>DeviceControlWidget</name>
     <message>
         <source>Other Devices</source>
@@ -445,6 +386,13 @@
     </message>
 </context>
 <context>
+    <name>PluginItemWidget</name>
+    <message>
+        <source>Disconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PowerApplet</name>
     <message>
         <source>Power</source>
@@ -543,6 +491,14 @@
     </message>
     <message>
         <source>Charging, %1 hr until full</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Capacity %1, charging protection active</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Charging protection active</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/plugins/dde-dock/translations/dde-dock_vi.ts
+++ b/plugins/dde-dock/translations/dde-dock_vi.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="vi">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="vi">
 <context>
     <name>AirplaneModeItem</name>
     <message>
@@ -48,11 +50,11 @@
     </message>
     <message>
         <source>Turned off</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Đã tắt</translation>
     </message>
     <message>
         <source>Disable [Airplane Mode](#) first if you want to connect to a Bluetooth</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -189,65 +191,6 @@
     <message>
         <source>Open the calendar</source>
         <translation>Mở lịch</translation>
-    </message>
-</context>
-<context>
-    <name>DatetimeWidget</name>
-    <message>
-        <source>Monday</source>
-        <translation>Thứ hai</translation>
-    </message>
-    <message>
-        <source>Tuesday</source>
-        <translation>Thứ ba</translation>
-    </message>
-    <message>
-        <source>Wednesday</source>
-        <translation>Thứ tư</translation>
-    </message>
-    <message>
-        <source>Thursday</source>
-        <translation>Thứ năm</translation>
-    </message>
-    <message>
-        <source>Friday</source>
-        <translation>Thứ sáu</translation>
-    </message>
-    <message>
-        <source>Saturday</source>
-        <translation>Thứ bảy</translation>
-    </message>
-    <message>
-        <source>Sunday</source>
-        <translation>Chủ nhật</translation>
-    </message>
-    <message>
-        <source>monday</source>
-        <translation>thứ hai</translation>
-    </message>
-    <message>
-        <source>tuesday</source>
-        <translation>thứ hai</translation>
-    </message>
-    <message>
-        <source>wednesday</source>
-        <translation>thứ ba</translation>
-    </message>
-    <message>
-        <source>thursday</source>
-        <translation>thứ tư</translation>
-    </message>
-    <message>
-        <source>friday</source>
-        <translation>thứ năm</translation>
-    </message>
-    <message>
-        <source>saturday</source>
-        <translation>thứ sáu</translation>
-    </message>
-    <message>
-        <source>sunday</source>
-        <translation>chủ nhật</translation>
     </message>
 </context>
 <context>
@@ -443,6 +386,13 @@
     </message>
 </context>
 <context>
+    <name>PluginItemWidget</name>
+    <message>
+        <source>Disconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PowerApplet</name>
     <message>
         <source>Power</source>
@@ -545,18 +495,18 @@
     </message>
     <message>
         <source>Capacity %1, charging protection active</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Charging protection active</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>PowerStatusWidget</name>
     <message>
         <source>Power settings</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Thiết lập năng lượng</translation>
     </message>
 </context>
 <context>
@@ -641,31 +591,31 @@
     </message>
     <message>
         <source>Monday</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Thứ hai</translation>
     </message>
     <message>
         <source>Tuesday</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Thứ ba</translation>
     </message>
     <message>
         <source>Wednesday</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Thứ tư</translation>
     </message>
     <message>
         <source>Thursday</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Thứ năm</translation>
     </message>
     <message>
         <source>Friday</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Thứ sáu</translation>
     </message>
     <message>
         <source>Saturday</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Thứ bảy</translation>
     </message>
     <message>
         <source>Sunday</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Chủ nhật</translation>
     </message>
     <message>
         <source>Jan</source>

--- a/plugins/dde-dock/translations/dde-dock_zh_CN.ts
+++ b/plugins/dde-dock/translations/dde-dock_zh_CN.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="zh_CN">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="zh_CN">
 <context>
     <name>AirplaneModeItem</name>
     <message>
@@ -192,65 +194,6 @@
     </message>
 </context>
 <context>
-    <name>DatetimeWidget</name>
-    <message>
-        <source>Monday</source>
-        <translation>星期一</translation>
-    </message>
-    <message>
-        <source>Tuesday</source>
-        <translation>星期二</translation>
-    </message>
-    <message>
-        <source>Wednesday</source>
-        <translation>星期三</translation>
-    </message>
-    <message>
-        <source>Thursday</source>
-        <translation>星期四</translation>
-    </message>
-    <message>
-        <source>Friday</source>
-        <translation>星期五</translation>
-    </message>
-    <message>
-        <source>Saturday</source>
-        <translation>星期六</translation>
-    </message>
-    <message>
-        <source>Sunday</source>
-        <translation>星期日</translation>
-    </message>
-    <message>
-        <source>monday</source>
-        <translation>周一</translation>
-    </message>
-    <message>
-        <source>tuesday</source>
-        <translation>周二</translation>
-    </message>
-    <message>
-        <source>wednesday</source>
-        <translation>周三</translation>
-    </message>
-    <message>
-        <source>thursday</source>
-        <translation>周四</translation>
-    </message>
-    <message>
-        <source>friday</source>
-        <translation>周五</translation>
-    </message>
-    <message>
-        <source>saturday</source>
-        <translation>周六</translation>
-    </message>
-    <message>
-        <source>sunday</source>
-        <translation>周日</translation>
-    </message>
-</context>
-<context>
     <name>DeviceControlWidget</name>
     <message>
         <source>Other Devices</source>
@@ -440,6 +383,13 @@
     <message>
         <source>Balance Performance</source>
         <translation>性能模式</translation>
+    </message>
+</context>
+<context>
+    <name>PluginItemWidget</name>
+    <message>
+        <source>Disconnect</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/plugins/dde-dock/translations/dde-dock_zh_HK.ts
+++ b/plugins/dde-dock/translations/dde-dock_zh_HK.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="zh_HK">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="zh_HK">
 <context>
     <name>AirplaneModeItem</name>
     <message>
@@ -192,65 +194,6 @@
     </message>
 </context>
 <context>
-    <name>DatetimeWidget</name>
-    <message>
-        <source>Monday</source>
-        <translation>星期一</translation>
-    </message>
-    <message>
-        <source>Tuesday</source>
-        <translation>星期二</translation>
-    </message>
-    <message>
-        <source>Wednesday</source>
-        <translation>星期三</translation>
-    </message>
-    <message>
-        <source>Thursday</source>
-        <translation>星期四</translation>
-    </message>
-    <message>
-        <source>Friday</source>
-        <translation>星期五</translation>
-    </message>
-    <message>
-        <source>Saturday</source>
-        <translation>星期六</translation>
-    </message>
-    <message>
-        <source>Sunday</source>
-        <translation>星期日</translation>
-    </message>
-    <message>
-        <source>monday</source>
-        <translation>週一</translation>
-    </message>
-    <message>
-        <source>tuesday</source>
-        <translation>週二</translation>
-    </message>
-    <message>
-        <source>wednesday</source>
-        <translation>週三</translation>
-    </message>
-    <message>
-        <source>thursday</source>
-        <translation>週四</translation>
-    </message>
-    <message>
-        <source>friday</source>
-        <translation>週五</translation>
-    </message>
-    <message>
-        <source>saturday</source>
-        <translation>週六</translation>
-    </message>
-    <message>
-        <source>sunday</source>
-        <translation>週日</translation>
-    </message>
-</context>
-<context>
     <name>DeviceControlWidget</name>
     <message>
         <source>Other Devices</source>
@@ -440,6 +383,13 @@
     <message>
         <source>Balance Performance</source>
         <translation>性能模式</translation>
+    </message>
+</context>
+<context>
+    <name>PluginItemWidget</name>
+    <message>
+        <source>Disconnect</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/plugins/dde-dock/translations/dde-dock_zh_TW.ts
+++ b/plugins/dde-dock/translations/dde-dock_zh_TW.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="zh_TW">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="zh_TW">
 <context>
     <name>AirplaneModeItem</name>
     <message>
@@ -192,65 +194,6 @@
     </message>
 </context>
 <context>
-    <name>DatetimeWidget</name>
-    <message>
-        <source>Monday</source>
-        <translation>星期一</translation>
-    </message>
-    <message>
-        <source>Tuesday</source>
-        <translation>星期二</translation>
-    </message>
-    <message>
-        <source>Wednesday</source>
-        <translation>星期三</translation>
-    </message>
-    <message>
-        <source>Thursday</source>
-        <translation>星期四</translation>
-    </message>
-    <message>
-        <source>Friday</source>
-        <translation>星期五</translation>
-    </message>
-    <message>
-        <source>Saturday</source>
-        <translation>星期六</translation>
-    </message>
-    <message>
-        <source>Sunday</source>
-        <translation>星期日</translation>
-    </message>
-    <message>
-        <source>monday</source>
-        <translation>週一</translation>
-    </message>
-    <message>
-        <source>tuesday</source>
-        <translation>週二</translation>
-    </message>
-    <message>
-        <source>wednesday</source>
-        <translation>週三</translation>
-    </message>
-    <message>
-        <source>thursday</source>
-        <translation>週四</translation>
-    </message>
-    <message>
-        <source>friday</source>
-        <translation>週五</translation>
-    </message>
-    <message>
-        <source>saturday</source>
-        <translation>週六</translation>
-    </message>
-    <message>
-        <source>sunday</source>
-        <translation>週日</translation>
-    </message>
-</context>
-<context>
     <name>DeviceControlWidget</name>
     <message>
         <source>Other Devices</source>
@@ -440,6 +383,13 @@
     <message>
         <source>Balance Performance</source>
         <translation>效能模式</translation>
+    </message>
+</context>
+<context>
+    <name>PluginItemWidget</name>
+    <message>
+        <source>Disconnect</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>


### PR DESCRIPTION
1. Add CommonTextButton widget with rounded background and hover/press states
2. Show "Disconnect" text button on hover for connected plugin items
3. Hide connect icon on hover and restore it on leave
4. Route disconnect click signal to the new button instead of the icon
5. Update translations for the "Disconnect" string

Log: Connected plugin items now show a "Disconnect" button on hover.
Influence: Users can clearly see how to disconnect a dock plugin.

feat(dock-plugin): 插件项悬停时显示断开连接按钮

1. 新增 CommonTextButton 控件，支持圆角背景和悬停/按下状态
2. 连接的插件项在鼠标悬停时显示"断开连接"文字按钮
3. 悬停时隐藏连接图标，离开后恢复显示
4. 将断开点击信号连接到新按钮而非图标
5. 更新各语言翻译，添加"断开连接"字符串

Log: 连接的插件项在悬停时显示"断开连接"按钮。
PMS: STORY-41277
Influence: 用户能清晰知道如何断开插件连接。