### PR TITLE
Revert "fix(sound): avoid muted slider double feedback"

### DIFF
--- a/plugins/dde-dock/sound/soundapplet.cpp
+++ b/plugins/dde-dock/sound/soundapplet.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2011 - 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2011 - 2022 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -183,7 +183,7 @@ void SoundApplet::onVolumeChanged(int volume)
 
 void SoundApplet::volumeSliderValueChanged()
 {
-    SoundController::ref().SetVolume(m_volumeSlider->value() * 0.01, !SoundModel::ref().isMute());
+    SoundController::ref().SetVolume(m_volumeSlider->value() * 0.01, true);
 }
 
 void SoundApplet::updatePorts()

--- a/plugins/dde-dock/sound/soundquickpanel.cpp
+++ b/plugins/dde-dock/sound/soundquickpanel.cpp
@@ -1,5 +1,5 @@
 // Copyright (C) 2022 ~ 2022 Deepin Technology Co., Ltd.
-// SPDX-FileCopyrightText: 2018 - 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2018 - 2023 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -78,7 +78,7 @@ void SoundQuickPanel::initConnection()
     });
 
     connect(m_sliderContainer, &SliderContainer::sliderValueChanged, this, [this](int value) {
-        SoundController::ref().SetVolume(value * 0.01, !SoundModel::ref().isMute());
+        SoundController::ref().SetVolume(value * 0.01, true);
     });
     connect(&SoundModel::ref(), &SoundModel::activePortChanged, this, &SoundQuickPanel::refreshWidget);
     connect(&SoundModel::ref(), &SoundModel::cardsInfoChanged, this, &SoundQuickPanel::refreshWidget);


### PR DESCRIPTION
This reverts commit 27f28c67786aea5c420d018cd1efcb61cbac867d. Fixed in this commit: https://github.com/linuxdeepin/dde-daemon/commit/36cd616507002b19eea8799cfe18d463e1f75bf8

Log: revert

## Summary by Sourcery

Revert the previous change that conditioned volume updates on the mute state for the sound dock applet and quick panel.

Enhancements:
- Restore unconditional volume updates from dock and quick panel sliders regardless of mute state.
- Adjust SPDX copyright year ranges in sound applet and quick panel sources to the previous values.