### PR TITLE
fix: ensure popup geometry is applied before setting plugin position

### DIFF
--- a/src/tray-wayland-integration/pluginsurface.cpp
+++ b/src/tray-wayland-integration/pluginsurface.cpp
@@ -226,6 +226,7 @@ void PluginPopupSurface::plugin_popup_geometry(int32_t x, int32_t y, int32_t wid
     if (rect.height() <= 0)
         rect.setHeight(m_window->height());
 
+    setGeometryFromApplyConfigure(rect.topLeft(), rect.size());
     m_popup->setPluginPos(QPoint(x, y));
     if (plugin) {
         Q_EMIT plugin->eventGeometry(rect);


### PR DESCRIPTION
1. Added call to setGeometryFromApplyConfigure in plugin_popup_geometry
2. Popup geometry was being set after plugin position, causing layout
issues
3. This ensures the popup surface has its geometry correctly updated
before positioning
4. Prevents visual glitches and incorrect positioning in tray popups

Log: Fixed popup geometry application order for tray popups

Influence:
1. Test tray popup positioning in different screen configurations
2. Verify popup geometry matches expected dimensions after resize
3. Test with multiple monitors and different scale factors
4. Verify no visual glitches when opening/closing tray popups
5. Test popup behavior with different tray icon implementations

fix: 在设置插件位置前确保应用弹出窗口几何

1. 在 plugin_popup_geometry 中添加 setGeometryFromApplyConfigure 调用
2. 弹出窗口几何信息在设置插件位置后才设置，导致布局问题
3. 这确保弹出窗口表面在定位前正确更新其几何信息
4. 防止托盘弹出窗口出现视觉故障和错误定位

Log: 修复托盘弹出窗口的几何应用顺序

Influence:
1. 测试不同屏幕配置下的托盘弹出窗口定位
2. 验证调整大小后弹出窗口几何信息符合预期尺寸
3. 在多个显示器和不同缩放比例下测试
4. 验证打开/关闭托盘弹出窗口时无视觉故障
5. 使用不同的托盘图标实现测试弹出窗口行为

PMS: BUG-370143

## Summary by Sourcery

Bug Fixes:
- Update popup geometry before setting plugin position so tray popups use correct size and placement.