### PR TITLE
fix(loader): gate wayland platform interface on env

### DIFF
--- a/src/loader/main.cpp
+++ b/src/loader/main.cpp
@@ -107,15 +107,20 @@ int main(int argc, char *argv[], char *envp[])
     // via the zwp_text_input family of protocols.
     qputenv("QT_IM_MODULE", "wayland");
 
-
-    qAddPreRoutine([] () {
-        if (!DGuiApplicationHelper::testAttribute(DGuiApplicationHelper::IsXWindowPlatform)) {
-            qDebug() << "Register platformInterface.";
-            DPlatformInterfaceFactory::registerInterface([] (DPlatformTheme* theme) -> DPlatformInterface *{
-                return new DQWaylandPlatformInterface(theme);
-            });
-        }
-    });
+    // 默认注册 DQWaylandPlatformInterface, 使服务端经 plugin_manager_v1 同步的
+    // 活动色、主题、字体等属性能够到达 DPlatformTheme。
+    // 必须在 LoaderApplication 构造之前注册: Qt 在构造 QCoreApplication 时会
+    // 查询 colorScheme() 触发 DGuiApplicationHelper::instance(), 提前创建
+    // systemTheme; 若工厂此时尚未注册, systemTheme 会落入默认的
+    // DTreelandPlatformInterface, 上述属性将永远无法生效。
+    // 手动独立运行(不由 dde-shell 托管, 如调试/复现旧行为)时,
+    // 设置 USE_DEFAULT_PLATFORMTHEME 环境变量可跳过注册。
+    if (!qEnvironmentVariableIsSet("USE_DEFAULT_PLATFORMTHEME")) {
+        qDebug() << "Register platformInterface.";
+        DPlatformInterfaceFactory::registerInterface([] (DPlatformTheme* theme) -> DPlatformInterface *{
+            return new DQWaylandPlatformInterface(theme);
+        });
+    }
 
     LoaderApplication app(argc, argv);
     app.setOrganizationName("deepin");


### PR DESCRIPTION
1. Register DQWaylandPlatformInterface only when dde-shell sets DDE_TRAY_LOADER_REGISTER_PLATFORM_INTERFACE, marking the process as hosted by the dockplugin compositor.
2. Register before LoaderApplication construction so systemTheme picks up plugin_manager_v1-synced attributes (active color, theme, fonts) instead of falling back to DTreelandPlatformInterface.
3. Keep the default platform interface on native Wayland/X11 sessions, avoiding regressions outside dockplugin hosting.
4. Add dde-shell (>> 2.0.52) build dependency in debian/control.

Log: Register the Wayland platform interface only when the tray loader is hosted by the dockplugin compositor.
Influence: Tray plugin colors/themes sync only under dockplugin hosting; native sessions unaffected.

fix(loader): 按环境变量注册 Wayland 平台接口

1. 仅在 dde-shell 设置 DDE_TRAY_LOADER_REGISTER_PLATFORM_INTERFACE（即由 dockplugin 合成器托管）时注册 DQWaylandPlatformInterface。
2. 在 LoaderApplication 构造前注册，确保 systemTheme 能获取 plugin_manager_v1 同步的活动色、主题、字体等属性，而非回退到 DTreelandPlatformInterface。
3. 原生 Wayland/X11 会话保持默认平台接口，避免非托管场景回归。
4. debian/control 增加 dde-shell (>> 2.0.52) 构建依赖。

Log: 仅当托盘加载器由 dockplugin 合成器托管时注册 Wayland 平台接口。
PMS: BUG-372253
Influence: 托盘插件仅在 dockplugin 托管时同步活动色与主题，原生会话不受影响。

## Summary by Sourcery

Gate Wayland platform interface registration on a dedicated environment variable and ensure it occurs before LoaderApplication initialization to keep native sessions unchanged while enabling dockplugin-hosted tray theming.

Bug Fixes:
- Prevent unintended use of the Wayland platform interface in native Wayland/X11 sessions by registering it only when explicitly requested via an environment variable.

Build:
- Add dde-shell (>> 2.0.52) as a build dependency in debian control to support environment-gated platform interface registration.