### PR TITLE
fix(bluetooth): add audio-headset/audio-headphones icon mappings

### DIFF
--- a/plugins/dde-dock/bluetooth/componments/device.cpp
+++ b/plugins/dde-dock/bluetooth/componments/device.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2016 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2016 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -19,6 +19,8 @@ QMap<QString, QString> Device::deviceType2Icon = {
     {"input-gaming", "other"},
     {"input-tablet", "touchpad"},
     {"audio-card", "pheadset"},
+    {"audio-headset", "pheadset"},
+    {"audio-headphones", "pheadset"},
     {"network-wireless", "lan"},
     {"camera-video", "vidicon"},
     {"printer", "print"},


### PR DESCRIPTION
## 根因分析

PMS 275675：连接蓝牙音箱时，控制中心与任务栏蓝牙列表的设备图标不一致。

任务栏（dde-tray-loader）的 `deviceType2Icon` 缺少 `audio-headset` 和 `audio-headphones` 条目。当 BlueZ 返回这些值时，`QMap::operator[]` 返回空字符串，`bluetoothadapteritem.cpp` 回退到 `bluetooth_other`，而控制中心显示 `bluetooth_pheadset`，导致不一致。

## 修复方案

在 `plugins/dde-dock/bluetooth/componments/device.cpp` 的 `deviceType2Icon` 中补充 `audio-headset` 和 `audio-headphones` 条目，映射到 `pheadset`（与 `audio-card` 一致），使任务栏与控制中心图标对齐。

## 改动

1 个文件，2 行新增。低风险，`bluetooth_pheadset_16px.svg` 资源已存在。

## Summary by Sourcery

Bug Fixes:
- Add icon mappings for `audio-headset` and `audio-headphones` Bluetooth device types so they display the correct headset icon instead of the generic Bluetooth icon in the taskbar.