### PR TITLE
fix: 修复 SNI 懒加载托盘图标右键菜单无法显示的问题

### DIFF
--- a/plugins/application-tray/sniprotocolhandler.cpp
+++ b/plugins/application-tray/sniprotocolhandler.cpp
@@ -346,6 +346,8 @@ bool SniTrayProtocolHandler::eventFilter(QObject *watched, QEvent *event)
                 }
 
                 auto menu = menuImporter()->menu();
+                // SNI 懒加载应用（如 Snipaste）只有收到 AboutToShow 才填充菜单，因此主动调用 updateMenu() 触发一次 DBus AboutToShow
+                menuImporter()->updateMenu(menu);
                 menu->setFixedSize(menu->sizeHint());
                 menu->winId();
 


### PR DESCRIPTION
部分 SNI 应用（如 Snipaste）的 DBusMenu 菜单采用懒加载：只有收到 AboutToShow 调用后才填充菜单内容。此前右击托盘图标时从未触发 DBus AboutToShow，右键菜单始终无法显示内容。
    
修复：右击分支在显示菜单前主动调用 updateMenu(menu) 触发一次 DBus AboutToShow，拉取懒加载菜单内容。
    
本修复需配合 dde-shell 的对应修复（监听菜单 surface 尺寸变化并重新请求几何更新），使内容异步到达时弹窗能重新布局与绘制。


AI辅助声明：本修复方案由deepseek-v4-flash协助生成，并已在本地完成实际测试验证。

Snipaste下载地址：https://zh.snipaste.com/download.html
测试使用的Snipaste版本：https://download.snipaste.com/archives/Snipaste-2.11.3-x86_64.AppImage

## Summary by Sourcery

Bug Fixes:
- 修复 SNI 懒加载应用的托盘右键菜单无法显示内容的问题。