### PR TITLE
chore: update pkg-config include path for tray loader

### DIFF
--- a/dde-tray-loader.pc.in
+++ b/dde-tray-loader.pc.in
@@ -1,7 +1,7 @@
 prefix=@CMAKE_INSTALL_PREFIX@
 exec_prefix=${prefix}
 libdir=@CMAKE_INSTALL_FULL_LIBDIR@
-includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@/dde-tray-loader
+includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@/dde-dock
 
 Name: dde-tray-loader
 Description: tray plugin dev header for deepin


### PR DESCRIPTION
1. Change the includedir variable in dde-tray-loader.pc.in
from `@CMAKE_INSTALL_FULL_INCLUDEDIR@/dde-tray-loader` to
`@CMAKE_INSTALL_FULL_INCLUDEDIR@/dde-dock`
2. This corrects the actual installation directory where the tray plugin
development headers are placed
3. Ensures pkg-config consumers can successfully locate and include the
correct header files

Influence:
1. Verify that `pkg-config --cflags dde-tray-loader` returns the updated
include path pointing to `dde-dock`
2. Test building a sample program that uses the tray plugin headers via
pkg-config
3. Ensure that consumer packages depending on this pc file can compile
without header resolution errors

chore: 更新托盘加载器的 pkg-config 包含路径

1. 将 dde-tray-loader.pc.in 中的 includedir 变量
从 `@CMAKE_INSTALL_FULL_INCLUDEDIR@/dde-tray-loader` 改为
`@CMAKE_INSTALL_FULL_INCLUDEDIR@/dde-dock`
2. 修正了托盘插件开发头文件实际安装目录的配置
3. 确保使用 pkg-config 的消费者能够正确定位并引用正确的头文件

Influence:
1. 验证 `pkg-config --cflags dde-tray-loader` 返回的包含路径指向 `dde-
dock`
2. 测试通过 pkg-config 使用托盘插件头文件构建示例程序的过程
3. 确保依赖此 pc 文件的消费者包能够正常编译，无头文件解析错误

## Summary by Sourcery

Bug Fixes:
- Correct the tray loader pkg-config include path so consumers can locate the installed development headers.